### PR TITLE
feat: CRUD de productos con Zod y Hono (Issue 69)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -59,6 +59,22 @@ Se inicializó el proyecto frontend con React y Vite, integrando el SDK de Clerk
 
 ---
 
+## ✅ [Issue 69] Zod Validaciones y Hono CRUD Mongo (/api/products)
+**Sprint:** 1 | **Estado:** Completado 
+
+### 📂 Archivos Creados/Modificados
+- *[backend/package.json]*: Nuevas dependencias instaladas (`zod`, `@hono/zod-validator`).
+- *[backend/src/validators/product.validator.ts]*: Esquemas de validación de Zod para la creación y actualización de productos.
+- *[backend/src/controllers/product.controller.ts]*: Controladores para ejecutar operaciones CRUD en la BD a través del modelo Mongoose.
+- *[backend/src/routes/product.routes.ts]*: Enrutador de productos implementando middleware de validación `zValidator` de Hono.
+- *[backend/src/index.ts]*: Ruta base `/api/products` registrada en el backend.
+
+### 💡 Contexto Importante
+- Se instalaron las librerías `zod` y `@hono/zod-validator`.
+- Los datos de entrada POST y PUT son procesados por el middleware intermedio que detiene la ejecución y envía status 400 automáticamente si no cumplen las condiciones definidas.
+
+---
+
 ## ⏳ Template para futuros issues (Copiar y pegar)
 <!--
 ## [Issue X] Nombre del Issue

--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -5,8 +5,10 @@
     "": {
       "name": "backend",
       "dependencies": {
+        "@hono/zod-validator": "^0.7.6",
         "hono": "^4.2.0",
         "mongoose": "^8.3.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -17,6 +19,8 @@
     },
   },
   "packages": {
+    "@hono/zod-validator": ["@hono/zod-validator@0.7.6", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="],
+
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.8", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-kpjr2jy2w71w0oqAMI8oibBmiF9lXxWkEQs5gMkW4hVE48bsqINGLxnCSYW62ck/NHXJQpQEfA9WlJ1sY0eqBg=="],
 
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
@@ -66,5 +70,7 @@
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
     "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,8 +7,10 @@
     "dev": "bun run --watch src/index.ts"
   },
   "dependencies": {
+    "@hono/zod-validator": "^0.7.6",
     "hono": "^4.2.0",
-    "mongoose": "^8.3.0"
+    "mongoose": "^8.3.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/bun": "latest"

--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -1,0 +1,74 @@
+import { Context } from 'hono';
+import { Product } from '../models/Product';
+
+export const getProducts = async (c: Context) => {
+  try {
+    const products = await Product.find();
+    return c.json({ success: true, data: products });
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};
+
+export const getProductById = async (c: Context) => {
+  try {
+    const id = c.req.param('id');
+    const product = await Product.findById(id);
+    
+    if (!product) {
+      return c.json({ success: false, message: 'Producto no encontrado' }, 404);
+    }
+    
+    return c.json({ success: true, data: product });
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};
+
+export const createProduct = async (c: Context) => {
+  try {
+    // Validated by zod-validator middleware
+    const data = c.req.valid('json' as any);
+    
+    const newProduct = await Product.create(data);
+    return c.json({ success: true, data: newProduct }, 201);
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};
+
+export const updateProduct = async (c: Context) => {
+  try {
+    const id = c.req.param('id');
+    // Validated by zod-validator middleware
+    const data = c.req.valid('json' as any);
+    
+    const updatedProduct = await Product.findByIdAndUpdate(id, data, {
+      new: true,
+      runValidators: true,
+    });
+    
+    if (!updatedProduct) {
+      return c.json({ success: false, message: 'Producto no encontrado' }, 404);
+    }
+    
+    return c.json({ success: true, data: updatedProduct });
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};
+
+export const deleteProduct = async (c: Context) => {
+  try {
+    const id = c.req.param('id');
+    const deletedProduct = await Product.findByIdAndDelete(id);
+    
+    if (!deletedProduct) {
+      return c.json({ success: false, message: 'Producto no encontrado' }, 404);
+    }
+    
+    return c.json({ success: true, message: 'Producto eliminado correctamente' });
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { connectDB } from './db/connection';
 import healthRoutes from './routes/health.routes';
+import productRoutes from './routes/product.routes';
 
 const app = new Hono();
 
@@ -9,6 +10,7 @@ connectDB();
 
 // Register routes
 app.route('/api/health', healthRoutes);
+app.route('/api/products', productRoutes);
 
 export default {
   port: process.env.PORT || 3000,

--- a/backend/src/routes/product.routes.ts
+++ b/backend/src/routes/product.routes.ts
@@ -1,0 +1,48 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import {
+  createProduct,
+  deleteProduct,
+  getProductById,
+  getProducts,
+  updateProduct,
+} from '../controllers/product.controller';
+import {
+  createProductSchema,
+  updateProductSchema,
+} from '../validators/product.validator';
+
+const productRoutes = new Hono();
+
+// Obtener todos los productos
+productRoutes.get('/', getProducts);
+
+// Obtener un producto por ID
+productRoutes.get('/:id', getProductById);
+
+// Crear un producto con validación de Zod
+productRoutes.post(
+  '/',
+  zValidator('json', createProductSchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  createProduct
+);
+
+// Actualizar un producto con validación parcial
+productRoutes.put(
+  '/:id',
+  zValidator('json', updateProductSchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  updateProduct
+);
+
+// Eliminar un producto
+productRoutes.delete('/:id', deleteProduct);
+
+export default productRoutes;

--- a/backend/src/validators/product.validator.ts
+++ b/backend/src/validators/product.validator.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const createProductSchema = z.object({
+  name: z.string().min(1, 'El nombre es requerido'),
+  description: z.string().optional(),
+  price: z.number().min(0, 'El precio debe ser un valor positivo'),
+  stock: z.number().int().min(0, 'El stock debe ser 0 o un entero positivo').default(0),
+  condition: z.enum(['A', 'B', 'C'], {
+    errorMap: () => ({ message: 'La condición debe ser A, B o C' }),
+  }),
+  image_urls: z.array(z.string().url('Debe ser una URL válida')).optional(),
+});
+
+export const updateProductSchema = createProductSchema.partial();


### PR DESCRIPTION
## Descripción
Este PR implementa el Issue #69 correspondiente al Sprint 1: Creación del CRUD para Productos en el backend integrando Mongoose y añadiendo la capa de validación usando Zod junto a Hono.

Closes #69

## 🛠️ Cambios introducidos
- **Dependencias**: Se instalaron `zod` y `@hono/zod-validator` para manejar la validación de manera nativa en Hono.
- **Validadores**: Se agregaron los esquemas de validación Zod (`createProductSchema` y `updateProductSchema`) en `src/validators/product.validator.ts` asegurando tipos y reglas como precio positivo y campos requeridos.
- **Controladores**: Se implementaron las funciones CRUD base (`getProducts`, `getProductById`, `createProduct`, `updateProduct`, `deleteProduct`) interactuando con el modelo de Mongoose en `src/controllers/product.controller.ts`.
- **Rutas**: Se creó el enrutador en `src/routes/product.routes.ts`, aplicando el middleware `zValidator` para interceptar datos erróneos de tipo POST/PUT emitiendo un estado HTTP `400` antes de tocar el controlador.
- **Documentación**: Se actualizó `PROGRESS.md` reflejando este issue completado.

## ✅ Pruebas realizadas
- [x] POST `/api/products` (Crear producto válido)
- [x] POST `/api/products` (Probada falla por datos inválidos - Zod lo intercepta correctamente)
- [x] GET `/api/products` (Lista todos)
- [x] GET `/api/products/:id` (Trae uno)
- [x] PUT `/api/products/:id` (Actualiza de manera parcial)
- [x] DELETE `/api/products/:id` (Elimina registro de BD)

## Related HU issues
#111