### PR TITLE
feature: Checkout con Stripe y Historial de Pedidos (#74)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@clerk/backend": "^3.2.13",
     "@hono/zod-validator": "^0.7.6",
+    "dotenv": "^17.4.2",
     "hono": "^4.2.0",
     "mongoose": "^8.3.0",
     "stripe": "^22.0.2",

--- a/backend/src/controllers/checkout.controller.ts
+++ b/backend/src/controllers/checkout.controller.ts
@@ -10,22 +10,38 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
 });
 
 export const checkoutSessionController = async (c: Context) => {
-  const userId = c.get('userId'); // Extracted from Clerk Auth Middleware
-  
-  if (!userId) {
-    return c.json({ error: 'User authenticated but ID missing in context' }, 401);
-  }
-
-  const body = await c.req.json();
-  const cartItems = body.items as { productId: string, quantity: number }[];
-  
-  const productIds = cartItems.map(item => new Types.ObjectId(item.productId));
   
   try {
+    const userId = c.get('userId');
+    
+    if (!userId) {
+      return c.json({ error: 'User authenticated but ID missing in context' }, 401);
+    }
+
+    const body = await c.req.json();
+    
+    const cartItems = body.items as { productId: string, quantity: number }[];
+   
+    if (!cartItems || !Array.isArray(cartItems) || cartItems.length === 0) {
+      return c.json({ error: 'Cart cannot be empty' }, 400);
+    }
+   
+    for (const item of cartItems) {
+      if (!item.productId || typeof item.productId !== 'string') {
+        return c.json({ error: 'Invalid productId: expected string' }, 400);
+      }
+      if (!item.quantity || typeof item.quantity !== 'number' || item.quantity < 1) {
+        return c.json({ error: 'Invalid quantity: must be a positive number' }, 400);
+      }
+    }
+   
+   
+    const productIds = cartItems.map(item => new Types.ObjectId(item.productId));
+    
     const dbProducts = await Product.find({ _id: { $in: productIds } });
     
     if (dbProducts.length !== cartItems.length) {
-      return c.json({ error: 'One or more products were not found in database or there are invalid ObjectIds' }, 400);
+      return c.json({ error: 'One or more products not found in database' }, 400);
     }
     
     let totalAmount = 0;
@@ -53,21 +69,18 @@ export const checkoutSessionController = async (c: Context) => {
             name: dbProduct.name,
             images: dbProduct.image_urls?.length ? [dbProduct.image_urls[0]] : [],
           },
-          unit_amount: Math.round(dbProduct.price * 100), // Stripe expects cents
+          unit_amount: Math.round(dbProduct.price * 100),
         },
         quantity: item.quantity,
       });
     }
 
-    // Clerk ID mapping to DB User ObjectID
     let localUser = await import('../models/User').then(m => m.User.findOne({ clerk_id: userId }));
     
-    // Si no encontramos al User por clerk_id, crearemos uno temporalmente para no frenar el checkout.
-    // Lo ideal es que se registre via Webhook desde la creación en Clerk, pero en entornos de prueba...
     if (!localUser) {
       localUser = await import('../models/User').then(m => m.User.create({
         clerk_id: userId,
-        email: `${userId}@clerk-auth.local`, // Fallback email
+        email: `${userId}@clerk-auth.local`,
         role: 'user'
       }));
     }
@@ -77,21 +90,22 @@ export const checkoutSessionController = async (c: Context) => {
       line_items,
       mode: 'payment',
       success_url: `${process.env.FRONTEND_URL || 'http://localhost:5173'}/success?session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${process.env.FRONTEND_URL || 'http://localhost:5173'}/cart`,
+      cancel_url: `${process.env.FRONTEND_URL || 'http://localhost:5173'}/home`,
       metadata: {
         clerkUserId: userId
       }
     });
     
-    // Save pending Order locally
+   
+    
     const newOrder = await Order.create({
-      user_id: localUser._id,
+      userId: userId,
       total_amount: totalAmount,
       status: 'pending',
       stripe_session_id: session.id
     });
 
-    // Save Order items
+
     for (const validItem of validItems) {
       await OrderItem.create({
         order_id: newOrder._id,
@@ -104,7 +118,7 @@ export const checkoutSessionController = async (c: Context) => {
     return c.json({ session_url: session.url }, 200);
 
   } catch (error) {
-    console.error('Checkout error:', error);
+    console.error('[Checkout] Error:', error);
     return c.json({ error: 'Internal server error processing checkout' }, 500);
   }
 };

--- a/backend/src/controllers/order.controller.ts
+++ b/backend/src/controllers/order.controller.ts
@@ -1,0 +1,19 @@
+import { Context } from 'hono';
+import { Order } from '../models/Order';
+
+export const getMyOrders = async (c: Context) => {
+  try {
+    const userId = c.get('userId');
+
+    if (!userId) {
+      return c.json({ error: 'Unauthorized: User ID not found' }, 401);
+    }
+
+    const orders = await Order.find({ userId }).populate('items.product').exec();
+
+    return c.json(orders);
+  } catch (error) {
+    console.error('Error fetching orders:', error);
+    return c.json({ error: 'Failed to fetch orders' }, 500);
+  }
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { connectDB } from './db/connection';
@@ -5,6 +6,9 @@ import healthRoutes from './routes/health.routes';
 import productRoutes from './routes/product.routes';
 import checkoutRoutes from './routes/checkout.routes';
 import webhookRoutes from './routes/webhook.routes';
+import orderRoutes from './routes/order.routes';
+
+console.log('[DEBUG] CLERK_SECRET_KEY:', process.env.CLERK_SECRET_KEY);
 
 const app = new Hono();
 
@@ -19,6 +23,7 @@ app.route('/api/health', healthRoutes);
 app.route('/api/products', productRoutes);
 app.route('/api/checkout', checkoutRoutes);
 app.route('/api/webhooks', webhookRoutes);
+app.route('/api/orders', orderRoutes);
 
 export default {
   port: process.env.PORT || 3000,

--- a/backend/src/middlewares/auth.middleware.ts
+++ b/backend/src/middlewares/auth.middleware.ts
@@ -2,6 +2,8 @@ import { verifyToken } from '@clerk/backend';
 import { Context, Next } from 'hono';
 
 export const clerkAuthMiddleware = async (c: Context, next: Next) => {
+  console.log('[Auth] CLERK_SECRET_KEY loaded:', process.env.CLERK_SECRET_KEY ? 'YES' : 'NO');
+  
   const authHeader = c.req.header('Authorization');
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -9,12 +11,17 @@ export const clerkAuthMiddleware = async (c: Context, next: Next) => {
   }
 
   const token = authHeader.split(' ')[1];
-
+  
+  console.log('[Auth] Token received:', token ? token.substring(0, 20) + '...' : 'NO TOKEN');
+  
   try {
+    console.log('[Auth] Verifying token with secret:', process.env.CLERK_SECRET_KEY?.substring(0, 10) + '...');
     const payload = await verifyToken(token, {
       secretKey: process.env.CLERK_SECRET_KEY,
     });
-
+    
+    console.log('[Auth] Token verified, userId:', payload.sub);
+    
     if (!payload.sub) {
       return c.json({ error: 'Unauthorized: Invalid token payload' }, 401);
     }
@@ -22,7 +29,7 @@ export const clerkAuthMiddleware = async (c: Context, next: Next) => {
     c.set('userId', payload.sub);
     await next();
   } catch (error) {
-    console.error('Clerk Auth Error:', error);
+    console.error('[Auth] Clerk Auth Error:', error);
     return c.json({ error: 'Unauthorized: Token verification failed' }, 401);
   }
 };

--- a/backend/src/models/Order.ts
+++ b/backend/src/models/Order.ts
@@ -1,10 +1,15 @@
 import { Schema, model } from 'mongoose';
 
 const orderSchema = new Schema({
-  user_id: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  userId: { type: String, required: true },
   total_amount: { type: Number, required: true },
   status: { type: String, enum: ['pending', 'paid', 'shipped'], default: 'pending' },
   stripe_session_id: { type: String },
+  items: [{
+    product: { type: Schema.Types.ObjectId, ref: 'Product' },
+    quantity: { type: Number, required: true },
+    price: { type: Number, required: true }
+  }]
 }, { timestamps: true });
 
 export const Order = model('Order', orderSchema);

--- a/backend/src/routes/checkout.routes.ts
+++ b/backend/src/routes/checkout.routes.ts
@@ -1,6 +1,5 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { checkoutSchema } from '../validators/checkout.validator';
 import { checkoutSessionController } from '../controllers/checkout.controller';
 import { clerkAuthMiddleware } from '../middlewares/auth.middleware';
 
@@ -10,11 +9,6 @@ const checkoutRoutes = new Hono();
 checkoutRoutes.post(
   '/',
   clerkAuthMiddleware,
-  zValidator('json', checkoutSchema, (result, c) => {
-    if (!result.success) {
-      return c.json({ error: result.error.issues }, 400);
-    }
-  }),
   checkoutSessionController
 );
 

--- a/backend/src/routes/order.routes.ts
+++ b/backend/src/routes/order.routes.ts
@@ -1,0 +1,9 @@
+import { Hono } from 'hono';
+import { getMyOrders } from '../controllers/order.controller';
+import { clerkAuthMiddleware } from '../middlewares/auth.middleware';
+
+const orderRouter = new Hono();
+
+orderRouter.get('/mine', clerkAuthMiddleware, getMyOrders);
+
+export default orderRouter;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,10 @@
 import { Routes, Route } from 'react-router-dom';
+import { SignedIn } from '@clerk/clerk-react';
 import Header from './components/Header';
 import Home from './pages/Home';
 import Login from './pages/Login';
 import Landing from './pages/Landing';
+import Orders from './pages/Orders';
 
 function App() {
   return (
@@ -13,6 +15,14 @@ function App() {
           <Route path="/" element={<Landing />} />
           <Route path="/home" element={<Home />} />
           <Route path="/login" element={<Login />} />
+          <Route 
+            path="/orders" 
+            element={
+              <SignedIn>
+                <Orders />
+              </SignedIn>
+            } 
+          />
         </Routes>
       </main>
     </div>

--- a/frontend/src/components/CartDrawer.tsx
+++ b/frontend/src/components/CartDrawer.tsx
@@ -21,16 +21,26 @@ export function CartDrawer() {
       const token = await getToken();
       if (!token) throw new Error("No hay token de autenticación");
       
-      // Asumiendo que el Store mapea .id pero aqui se llama ._id
       const payload = items.map(i => ({ 
-        id: i._id || i.id, 
+        productId: i._id || i.id, 
         quantity: i.quantity 
       }));
+      
+      console.log('[CartDrawer] Items in cart (full):', JSON.stringify(items, null, 2));
+      console.log('[CartDrawer] Payload to checkout:', payload);
 
       const { session_url } = await checkoutService.createSession(payload as any, token);
       window.location.href = session_url;
     } catch (error: any) {
-      alert(error.message || "Fallo preventivo al iniciar checkout.");
+      console.error('[Checkout Error]:', error);
+      
+      // Si el error indica productos no encontrados, limpiar el carrito
+      if (error.message?.includes('not found') || error.message?.includes('Invalid')) {
+        localStorage.removeItem('safetech-cart-storage');
+        window.location.reload();
+      } else {
+        alert(error.message || "Fallo preventivo al iniciar checkout.");
+      }
     } finally {
       setIsCheckingOut(false);
     }

--- a/frontend/src/hooks/useOrders.ts
+++ b/frontend/src/hooks/useOrders.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@clerk/clerk-react';
+import { ordersService } from '../services/orders.service';
+
+export const useOrders = () => {
+  const { getToken } = useAuth();
+
+  return useQuery({
+    queryKey: ['my-orders'],
+    queryFn: async () => {
+      const token = await getToken();
+      if (!token) {
+        throw new Error('Not authenticated');
+      }
+      return ordersService.getMyOrders(token);
+    },
+  });
+};

--- a/frontend/src/pages/Orders.tsx
+++ b/frontend/src/pages/Orders.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { useOrders } from '../hooks/useOrders';
+import { Link } from 'react-router-dom';
+
+const Orders: React.FC = () => {
+  const { data: orders, isLoading, isError } = useOrders();
+
+  if (isLoading) {
+    return <div className="text-center py-10">Loading orders...</div>;
+  }
+
+  if (isError) {
+    return <div className="text-center py-10 text-red-500">Error fetching orders</div>;
+  }
+
+  if (!orders || orders.length === 0) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold mb-6">My Orders</h1>
+        <div className="bg-gray-50 border border-gray-200 text-center py-12 rounded-lg">
+          <p className="text-gray-500 text-lg">You have no orders yet</p>
+          <Link to="/" className="text-indigo-600 hover:text-indigo-800 font-medium mt-4 inline-block">
+            Start Shopping
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-6">My Orders</h1>
+      <div className="space-y-6">
+        {orders.map((order) => {
+          const totalItems = order.items.reduce((sum, item) => sum + item.quantity, 0);
+          
+          return (
+            <div key={order._id} className="bg-white border rounded-lg shadow-sm overflow-hidden">
+              <div className="bg-gray-50 px-6 py-4 border-b flex flex-wrap justify-between items-center gap-4">
+                <div>
+                  <p className="text-sm text-gray-500">Order Placed</p>
+                  <p className="font-medium">{new Date(order.createdAt || Date.now()).toLocaleDateString()}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-gray-500">Total Amount</p>
+                  <p className="font-medium">${order.total_amount.toFixed(2)}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-gray-500">Items</p>
+                  <p className="font-medium">{totalItems}</p>
+                </div>
+                <div>
+                  <p className="text-sm text-gray-500">Status</p>
+                  <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium capitalize
+                    ${order.status === 'paid' ? 'bg-green-100 text-green-800' : 
+                      order.status === 'shipped' ? 'bg-blue-100 text-blue-800' : 
+                      'bg-yellow-100 text-yellow-800'}`}>
+                    {order.status}
+                  </span>
+                </div>
+                <div>
+                  <Link 
+                    to={`/warranties?orderId=${order._id}`}
+                    className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700"
+                  >
+                    Solicitar Garantía
+                  </Link>
+                </div>
+              </div>
+              
+              <div className="px-6 py-4">
+                <h4 className="text-md font-medium mb-3">Items in your order</h4>
+                <ul className="divide-y divide-gray-200">
+                  {order.items.map((item, index) => (
+                    <li key={index} className="py-3 flex items-center">
+                      {item.product?.image_urls?.[0] && (
+                        <img 
+                          src={item.product.image_urls[0]} 
+                          alt={item.product.name} 
+                          className="h-16 w-16 object-cover rounded mr-4"
+                        />
+                      )}
+                      <div className="flex-1">
+                        <p className="font-medium">{item.product?.name || 'Unknown Product'}</p>
+                        <p className="text-sm text-gray-500">Qty: {item.quantity} | Price: ${item.price.toFixed(2)}</p>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default Orders;

--- a/frontend/src/services/checkout.service.ts
+++ b/frontend/src/services/checkout.service.ts
@@ -3,13 +3,10 @@ import type { CartItem } from '../types/cart';
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000';
 
 export const checkoutService = {
-  createSession: async (items: CartItem[], token: string) => {
-    const payload = {
-      items: items.map(i => ({
-        productId: i.id,
-        quantity: i.quantity
-      }))
-    };
+  createSession: async (items: any[], token: string) => {
+    // El CartDrawer ya envía productId directamente
+    const payload = { items };
+    
 
     const response = await fetch(`${BACKEND_URL}/api/checkout`, {
       method: 'POST',
@@ -22,7 +19,19 @@ export const checkoutService = {
 
     if (!response.ok) {
       const errorData = await response.json();
-      throw new Error(errorData.error || 'Failed to create checkout session');
+      console.error('[Checkout Error Full]:', errorData);
+      console.error('[Checkout Error Stringified]:', JSON.stringify(errorData));
+      
+      let errorMsg = 'Checkout failed';
+      if (typeof errorData.error === 'string') {
+        errorMsg = errorData.error;
+      } else if (Array.isArray(errorData.error)) {
+        errorMsg = errorData.error.join(', ');
+      } else if (errorData.error) {
+        errorMsg = JSON.stringify(errorData.error);
+      }
+      
+      throw new Error(errorMsg);
     }
 
     return response.json();

--- a/frontend/src/services/orders.service.ts
+++ b/frontend/src/services/orders.service.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+import type { Order } from '../types/order';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
+
+export const ordersService = {
+  getMyOrders: async (token: string): Promise<Order[]> => {
+    const response = await axios.get(`${API_URL}/orders/mine`, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+    return response.data;
+  }
+};

--- a/frontend/src/services/products.service.ts
+++ b/frontend/src/services/products.service.ts
@@ -1,23 +1,21 @@
 import type { Product } from '../types/product';
-import { mockProducts } from '../data/mockProducts';
 
 const API_URL = 'http://localhost:3000/api';
 
 export const getProducts = async (): Promise<Product[]> => {
-  // Temporalmente usando mockProducts para el diseño del carrito
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve(mockProducts);
-    }, 500); // 500ms de latencia simulada
-  });
-
-  /* 
-  // Fetch real backend:
   const response = await fetch(`${API_URL}/products`);
   if (!response.ok) {
     throw new Error('Network response was not ok');
   }
   const result = await response.json();
   return result.data || [];
+
+  /* 
+  // Temporalmente usando mockProducts para el diseño del carrito
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(mockProducts);
+    }, 500); // 500ms de latencia simulada
+  });
   */
 };

--- a/frontend/src/store/cart.store.ts
+++ b/frontend/src/store/cart.store.ts
@@ -46,7 +46,7 @@ export const useCartStore = create<CartState>()(
         })
       })),
       
-      clearCart: () => set({ items: [] })
+      clearCart: () => set({ items: [], isDrawerOpen: false })
     }),
     {
       name: 'safetech-cart-storage', // name of the item in the storage (must be unique)

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -1,0 +1,19 @@
+import type { Product } from './product';
+
+export interface OrderItem {
+  _id: string;
+  product: Product;
+  quantity: number;
+  price: number;
+}
+
+export interface Order {
+  _id: string;
+  userId: string;
+  total_amount: number;
+  status: 'pending' | 'paid' | 'shipped';
+  stripe_session_id?: string;
+  items: OrderItem[];
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## Summary
- Implementar checkout con Stripe Checkout Sessions y persistencia de ordenes en MongoDB
- Implementar historial de pedidos del usuario autenticado via JWT de Clerk

## Cambios realizados
### Backend
- POST /api/checkout: Crea sesion de Stripe, valida inventario y guarda orden pendiente
- GET /api/orders/mine: Devuelve pedidos del usuario autenticado
- Middleware clerkAuthMiddleware para verificacion de JWT
- Carga de variables de entorno con dotenv

### Frontend
- CartDrawer: Flujo completo de checkout hacia Stripe
- /orders: Pagina de historial protegida con SignedIn
- Fix de cancel_url de Stripe hacia /home

## Criterios de Aceptacion
- [x] Checkout crea sesion de Stripe y guarda orden en DB
- [x] Historial muestra solo pedidos del usuario autenticado
- [x] Ruta /orders protegida
- [x] Cancel en Stripe redirige al home

## Related HU issues
#115, #117, #118