### PR TITLE
Show user email instead of clerk_id in admin dashboard

### DIFF
--- a/frontend/src/components/StatsCards.tsx
+++ b/frontend/src/components/StatsCards.tsx
@@ -151,7 +151,7 @@ const RecentOrdersList: React.FC<{ orders: Order[] | undefined; trigger: boolean
         {recent.map((o, i) => (
           <div key={o._id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', paddingBottom: '0.625rem', borderBottom: i < recent.length - 1 ? '1px solid var(--line)' : 'none' }}>
             <div>
-              <p style={{ fontSize: '0.75rem', fontWeight: 500, color: 'var(--ink)', fontFamily: 'var(--font-sans)' }}>{o.userId?.slice(0, 10)}...</p>
+              <p style={{ fontSize: '0.75rem', fontWeight: 500, color: 'var(--ink)', fontFamily: 'var(--font-sans)' }}>{o.userDoc?.email ?? o.userId?.slice(0, 10)}...</p>
               <p style={{ fontSize: '0.55rem', color: 'var(--gray)', fontFamily: 'var(--font-sans)' }}>{new Date(o.createdAt).toLocaleDateString('es-ES', { day: '2-digit', month: 'short' })}</p>
             </div>
             <p style={{ fontSize: '0.8rem', fontWeight: 400, color: 'var(--ink)', fontFamily: 'var(--font-display)' }}>${o.total_amount?.toFixed(2)}</p>

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -10,6 +10,7 @@ export interface OrderItem {
 export interface Order {
   _id: string;
   userId: string;
+  userDoc?: { email?: string };
   total_amount: number;
   status: 'pending' | 'paid' | 'shipped' | 'failed';
   stripe_session_id?: string;


### PR DESCRIPTION
## Summary

- Updated the "Últimas Órdenes" section in the admin dashboard to display the user's email address instead of the clerk_id
- Added `userDoc` field to the Order type to capture the populated email from the backend
- Updated the RecentOrdersList component to display `userDoc.email` with a fallback to the truncated `userId` for backward compatibility

The backend was already populating `userDoc` with email in the `getAllOrders` controller — the frontend just wasn't using it.