### PR TITLE
feat: completar HU-20 y ajustar entorno de pruebas

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   mongodb:
     image: mongo:6-jammy
@@ -39,7 +37,7 @@ services:
       - "5173:5173"
     volumes:
       - ./frontend/src:/app/src
-      - ./frontend/.env.local:/app/.env.local
+      - ./frontend/.env:/app/.env
     environment:
       - VITE_API_URL=http://localhost:3000/api
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,8 +2,8 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-COPY package.json ./
-RUN npm install
+COPY package.json package-lock.json ./
+RUN npm ci
 
 COPY . .
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@clerk/clerk-react": "^5.61.5",
         "@hookform/resolvers": "^5.2.2",
-        "@stripe/react-stripe-js": "^5.4.0",
-        "@stripe/stripe-js": "^8.5.3",
+        "@stripe/react-stripe-js": "^6.2.0",
+        "@stripe/stripe-js": "^9.3.1",
         "@tanstack/react-query": "^5.99.2",
         "axios": "^1.15.2",
         "react": "^19.2.5",
@@ -948,23 +948,23 @@
       "license": "MIT"
     },
     "node_modules/@stripe/react-stripe-js": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-5.6.1.tgz",
-      "integrity": "sha512-5xBrjkGmFvKvpMod6VvpOaFaa67eRbmieKeFTePZyOr/sUXzm7A3YY91l330pS0usUst5PxTZDUZHWfOc0v1GA==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-6.7.0.tgz",
+      "integrity": "sha512-KSWTQHcDlAOlxcOz+uq0pTA/k9G4+IBF/X8mtSFkkBX+nb74buMTIFcCUCHWNhjuPqfD+yJm7NWDan1EaxSyzQ==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "@stripe/stripe-js": ">=8.0.0 <9.0.0",
+        "@stripe/stripe-js": ">=9.5.0 <10.0.0",
         "react": ">=16.8.0 <20.0.0",
         "react-dom": ">=16.8.0 <20.0.0"
       }
     },
     "node_modules/@stripe/stripe-js": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-8.11.0.tgz",
-      "integrity": "sha512-3fVF4z3efsgwgyj64nFK+6F4/vMw0mUXD2TBbOfftJtKVNx4JNv3CSfe1fY4DCtCk0JFp8/YPNcRkzgV0HJ8cg==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.9.0.tgz",
+      "integrity": "sha512-Vwqe6Q5cU4i82tPyAv2BpaW/fQSNdOSO4/J8EeDLPp5/oIZiMmdB+Hgh863zFH+rtoxpuWGvD1L7QPh8k1Rdvw==",
       "license": "MIT",
       "engines": {
         "node": ">=12.16"

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -271,6 +271,15 @@ export default function AdminDashboard() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['technicians'] }),
   });
 
+  const deactivateTechnicianMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const token = await getToken();
+      if (!token) throw new Error('No token');
+      return technicianService.deleteTechnician(id, token);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['technicians'] }),
+  });
+
   const handleSectionChange = (section: string) => {
     setActiveSection(section as SectionType);
     setOrdersPage(1);
@@ -492,15 +501,16 @@ export default function AdminDashboard() {
                       <th>Email</th>
                       <th>Teléfono</th>
                       <th>Estado</th>
+                      <th>Acciones</th>
                     </tr>
                   </thead>
                   <tbody>
                     {techniciansLoading
-                      ? Array.from({ length: 4 }).map((_, i) => <SkeletonTableRow key={i} cols={4} />)
+                      ? Array.from({ length: 4 }).map((_, i) => <SkeletonTableRow key={i} cols={5} />)
                       : pagedTechnicians.length === 0
                         ? (
                           <tr>
-                            <td colSpan={4} style={{ padding: '3rem', textAlign: 'center', color: 'var(--ink3)', fontSize: '0.9rem' }}>
+                            <td colSpan={5} style={{ padding: '3rem', textAlign: 'center', color: 'var(--ink3)', fontSize: '0.9rem' }}>
                               No hay técnicos registrados.
                             </td>
                           </tr>
@@ -514,6 +524,32 @@ export default function AdminDashboard() {
                               <Badge variant={tech.active ? 'success' : 'neutral'}>
                                 {tech.active ? 'Activo' : 'Inactivo'}
                               </Badge>
+                            </td>
+                            <td className="actions">
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  const confirmed = window.confirm(`¿Desactivar a ${tech.name}?`);
+                                  if (!confirmed) return;
+                                  deactivateTechnicianMutation.mutate(tech._id);
+                                }}
+                                disabled={deactivateTechnicianMutation.isPending}
+                                style={{
+                                  padding: '7px 12px',
+                                  border: '1px solid var(--line)',
+                                  borderRadius: 'var(--radius-ui)',
+                                  background: 'var(--white)',
+                                  color: 'var(--ink)',
+                                  fontSize: '0.78rem',
+                                  fontWeight: 500,
+                                  fontFamily: 'var(--font-sans)',
+                                  cursor: deactivateTechnicianMutation.isPending ? 'not-allowed' : 'pointer',
+                                  opacity: deactivateTechnicianMutation.isPending ? 0.6 : 1,
+                                }}
+                                title={`Desactivar a ${tech.name}`}
+                              >
+                                {deactivateTechnicianMutation.isPending ? 'Desactivando…' : 'Desactivar'}
+                              </button>
                             </td>
                           </tr>
                         ))


### PR DESCRIPTION
## Resumen
Completa HU-20 en el dashboard de tecnicos y deja listo el entorno local para validar el frontend con Docker.

## Cambios
- agrega la accion de desactivar tecnicos en el dashboard
- sincroniza el frontend con npm ci
- ajusta Docker Compose para usar frontend/.env

## Validacion
- build de frontend completado
- docker compose up -d --build completado
- prueba funcional del flujo de tecnicos en la UI

## Issue relacionado
Refs #129