### PR TITLE
HU-26: crear productos desde un agente IA (create_product)

### DIFF
--- a/backend/src/routes/product.routes.ts
+++ b/backend/src/routes/product.routes.ts
@@ -11,6 +11,7 @@ import {
   createProductSchema,
   updateProductSchema,
 } from '../validators/product.validator';
+import { adminAuthMiddleware } from '../middlewares/auth.middleware';
 
 const productRoutes = new Hono();
 
@@ -20,9 +21,10 @@ productRoutes.get('/', getProducts);
 // Obtener un producto por ID
 productRoutes.get('/:id', getProductById);
 
-// Crear un producto con validación de Zod
+// Crear un producto con validación de Zod (solo admin)
 productRoutes.post(
   '/',
+  adminAuthMiddleware,
   zValidator('json', createProductSchema, (result, c) => {
     if (!result.success) {
       return c.json({ success: false, errors: result.error.errors }, 400);
@@ -31,9 +33,10 @@ productRoutes.post(
   createProduct
 );
 
-// Actualizar un producto con validación parcial
+// Actualizar un producto con validación parcial (solo admin)
 productRoutes.put(
   '/:id',
+  adminAuthMiddleware,
   zValidator('json', updateProductSchema, (result, c) => {
     if (!result.success) {
       return c.json({ success: false, errors: result.error.errors }, 400);
@@ -42,7 +45,7 @@ productRoutes.put(
   updateProduct
 );
 
-// Eliminar un producto
-productRoutes.delete('/:id', deleteProduct);
+// Eliminar un producto (solo admin)
+productRoutes.delete('/:id', adminAuthMiddleware, deleteProduct);
 
 export default productRoutes;

--- a/e2e/product-admin-auth.spec.ts
+++ b/e2e/product-admin-auth.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test';
+import { resetE2EState } from './helpers';
+
+const API_URL = 'http://127.0.0.1:3001/api';
+
+const validProductBody = {
+  name: 'Producto E2E Auth',
+  description: 'Producto de prueba para HU-25',
+  price: 100,
+  stock: 5,
+  condition: 'A',
+  category: 'celular',
+};
+
+test.beforeEach(async ({ request }) => {
+  await resetE2EState(request);
+});
+
+test('rechaza crear un producto sin token', async ({ request }) => {
+  const response = await request.post(`${API_URL}/products`, {
+    data: {},
+  });
+  expect(response.status()).toBe(401);
+});
+
+test('rechaza crear un producto con un usuario no admin', async ({ request }) => {
+  const response = await request.post(`${API_URL}/products`, {
+    headers: { Authorization: 'Bearer mock:user:e2e-user' },
+    data: {},
+  });
+  expect(response.status()).toBe(403);
+});
+
+test('rechaza editar un producto con un usuario no admin', async ({ request }) => {
+  const response = await request.put(`${API_URL}/products/000000000000000000000000`, {
+    headers: { Authorization: 'Bearer mock:user:e2e-user' },
+    data: {},
+  });
+  expect(response.status()).toBe(403);
+});
+
+test('rechaza eliminar un producto con un usuario no admin', async ({ request }) => {
+  const response = await request.delete(`${API_URL}/products/000000000000000000000000`, {
+    headers: { Authorization: 'Bearer mock:user:e2e-user' },
+  });
+  expect(response.status()).toBe(403);
+});
+
+test('permite a un admin crear, editar y eliminar un producto', async ({ request }) => {
+  const createResponse = await request.post(`${API_URL}/products`, {
+    headers: { Authorization: 'Bearer mock:admin:e2e-admin' },
+    data: validProductBody,
+  });
+  expect(createResponse.status()).toBe(201);
+  const created = await createResponse.json();
+  const productId = created.data._id;
+  expect(productId).toBeTruthy();
+
+  const updateResponse = await request.put(`${API_URL}/products/${productId}`, {
+    headers: { Authorization: 'Bearer mock:admin:e2e-admin' },
+    data: { price: 150 },
+  });
+  expect(updateResponse.status()).toBe(200);
+
+  const deleteResponse = await request.delete(`${API_URL}/products/${productId}`, {
+    headers: { Authorization: 'Bearer mock:admin:e2e-admin' },
+  });
+  expect(deleteResponse.status()).toBe(200);
+});

--- a/e2e/product-create-agent.spec.ts
+++ b/e2e/product-create-agent.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test';
+import { resetE2EState } from './helpers';
+
+const API_URL = 'http://127.0.0.1:3001/api';
+const ADMIN_AUTH = { Authorization: 'Bearer mock:admin:e2e-admin' };
+const USER_AUTH = { Authorization: 'Bearer mock:user:e2e-user' };
+
+const validProductBody = {
+  name: 'Producto creado por agente IA',
+  description: 'Producto de prueba para HU-26 (create_product)',
+  price: 250,
+  stock: 3,
+  condition: 'B',
+  category: 'auriculares',
+};
+
+test.beforeEach(async ({ request }) => {
+  await resetE2EState(request);
+});
+
+test('crea un producto valido y devuelve su identificador', async ({ request }) => {
+  const response = await request.post(`${API_URL}/products`, {
+    headers: ADMIN_AUTH,
+    data: validProductBody,
+  });
+  expect(response.status()).toBe(201);
+
+  const body = await response.json();
+  expect(body.success).toBe(true);
+  expect(body.data._id).toBeTruthy();
+  expect(body.data.name).toBe(validProductBody.name);
+});
+
+test('rechaza una categoria invalida', async ({ request }) => {
+  const response = await request.post(`${API_URL}/products`, {
+    headers: ADMIN_AUTH,
+    data: { ...validProductBody, category: 'electrodomesticos' },
+  });
+  expect(response.status()).toBe(400);
+});
+
+test('rechaza una condicion invalida', async ({ request }) => {
+  const response = await request.post(`${API_URL}/products`, {
+    headers: ADMIN_AUTH,
+    data: { ...validProductBody, condition: 'Z' },
+  });
+  expect(response.status()).toBe(400);
+});
+
+test('rechaza un precio negativo', async ({ request }) => {
+  const response = await request.post(`${API_URL}/products`, {
+    headers: ADMIN_AUTH,
+    data: { ...validProductBody, price: -10 },
+  });
+  expect(response.status()).toBe(400);
+});
+
+test('rechaza un stock negativo', async ({ request }) => {
+  const response = await request.post(`${API_URL}/products`, {
+    headers: ADMIN_AUTH,
+    data: { ...validProductBody, stock: -1 },
+  });
+  expect(response.status()).toBe(400);
+});
+
+test('rechaza la creacion si el agente no tiene rol admin', async ({ request }) => {
+  const response = await request.post(`${API_URL}/products`, {
+    headers: USER_AUTH,
+    data: validProductBody,
+  });
+  expect(response.status()).toBe(403);
+});


### PR DESCRIPTION
## Summary
- HU-26 pide una herramienta `create_product` para que un agente IA cree productos, restringida a administradores, que valide categoria/condicion/precio/stock y devuelva el id creado.
- Siguiendo el mismo patron que HU-02 (`search_products`, la unica historia `[MCP]` ya implementada): la "herramienta" es el endpoint REST existente, no un servidor MCP nuevo (los docs de `historias-de-usuario.html` aclaran que el tag `[MCP]` solo marca candidatas a exposicion futura, no que el servidor deba existir hoy).
- `POST /api/products` ya cumple los 3 criterios de aceptacion una vez aplicado el admin-gating de HU-25 (#178): valida via zod (`category`/`condition`/`price`/`stock`), exige rol admin, y devuelve `data._id`.
- Se agrego cobertura e2e dedicada (`e2e/product-create-agent.spec.ts`) que documenta y verifica explicitamente esos 3 criterios desde la perspectiva de un agente IA: creacion valida devuelve id, rechazo de categoria/condicion invalida, rechazo de precio/stock negativo, y rechazo si el llamador no es admin.

**Depende de #178 (HU-25)** — esta rama incluye ese commit para poder probar el gating de admin; el diff se reducira una vez #178 se mergee a `main`.

Closes #135

## Test plan
- [x] `npx playwright test e2e/product-create-agent.spec.ts` — 6/6 pasan.
- [x] `npx playwright test` (suite completa) — 15/15 pasan, sin regresiones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)