### PR TITLE
HU-25: exigir rol admin en el CRUD de productos

### DIFF
--- a/backend/src/routes/product.routes.ts
+++ b/backend/src/routes/product.routes.ts
@@ -11,6 +11,7 @@ import {
   createProductSchema,
   updateProductSchema,
 } from '../validators/product.validator';
+import { adminAuthMiddleware } from '../middlewares/auth.middleware';
 
 const productRoutes = new Hono();
 
@@ -20,9 +21,10 @@ productRoutes.get('/', getProducts);
 // Obtener un producto por ID
 productRoutes.get('/:id', getProductById);
 
-// Crear un producto con validación de Zod
+// Crear un producto con validación de Zod (solo admin)
 productRoutes.post(
   '/',
+  adminAuthMiddleware,
   zValidator('json', createProductSchema, (result, c) => {
     if (!result.success) {
       return c.json({ success: false, errors: result.error.errors }, 400);
@@ -31,9 +33,10 @@ productRoutes.post(
   createProduct
 );
 
-// Actualizar un producto con validación parcial
+// Actualizar un producto con validación parcial (solo admin)
 productRoutes.put(
   '/:id',
+  adminAuthMiddleware,
   zValidator('json', updateProductSchema, (result, c) => {
     if (!result.success) {
       return c.json({ success: false, errors: result.error.errors }, 400);
@@ -42,7 +45,7 @@ productRoutes.put(
   updateProduct
 );
 
-// Eliminar un producto
-productRoutes.delete('/:id', deleteProduct);
+// Eliminar un producto (solo admin)
+productRoutes.delete('/:id', adminAuthMiddleware, deleteProduct);
 
 export default productRoutes;

--- a/e2e/product-admin-auth.spec.ts
+++ b/e2e/product-admin-auth.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test';
+import { resetE2EState } from './helpers';
+
+const API_URL = 'http://127.0.0.1:3001/api';
+
+const validProductBody = {
+  name: 'Producto E2E Auth',
+  description: 'Producto de prueba para HU-25',
+  price: 100,
+  stock: 5,
+  condition: 'A',
+  category: 'celular',
+};
+
+test.beforeEach(async ({ request }) => {
+  await resetE2EState(request);
+});
+
+test('rechaza crear un producto sin token', async ({ request }) => {
+  const response = await request.post(`${API_URL}/products`, {
+    data: {},
+  });
+  expect(response.status()).toBe(401);
+});
+
+test('rechaza crear un producto con un usuario no admin', async ({ request }) => {
+  const response = await request.post(`${API_URL}/products`, {
+    headers: { Authorization: 'Bearer mock:user:e2e-user' },
+    data: {},
+  });
+  expect(response.status()).toBe(403);
+});
+
+test('rechaza editar un producto con un usuario no admin', async ({ request }) => {
+  const response = await request.put(`${API_URL}/products/000000000000000000000000`, {
+    headers: { Authorization: 'Bearer mock:user:e2e-user' },
+    data: {},
+  });
+  expect(response.status()).toBe(403);
+});
+
+test('rechaza eliminar un producto con un usuario no admin', async ({ request }) => {
+  const response = await request.delete(`${API_URL}/products/000000000000000000000000`, {
+    headers: { Authorization: 'Bearer mock:user:e2e-user' },
+  });
+  expect(response.status()).toBe(403);
+});
+
+test('permite a un admin crear, editar y eliminar un producto', async ({ request }) => {
+  const createResponse = await request.post(`${API_URL}/products`, {
+    headers: { Authorization: 'Bearer mock:admin:e2e-admin' },
+    data: validProductBody,
+  });
+  expect(createResponse.status()).toBe(201);
+  const created = await createResponse.json();
+  const productId = created.data._id;
+  expect(productId).toBeTruthy();
+
+  const updateResponse = await request.put(`${API_URL}/products/${productId}`, {
+    headers: { Authorization: 'Bearer mock:admin:e2e-admin' },
+    data: { price: 150 },
+  });
+  expect(updateResponse.status()).toBe(200);
+
+  const deleteResponse = await request.delete(`${API_URL}/products/${productId}`, {
+    headers: { Authorization: 'Bearer mock:admin:e2e-admin' },
+  });
+  expect(deleteResponse.status()).toBe(200);
+});


### PR DESCRIPTION
## Summary
- El backend no protegia `POST/PUT/DELETE /api/products` con ningun middleware de auth; cualquiera podia crear/editar/borrar productos via acceso directo a la API.
- Se agrego `adminAuthMiddleware` a esas tres rutas, siguiendo el mismo patron ya usado en `technician.routes.ts`. Las rutas GET (catalogo publico) no se tocaron.
- El frontend no requirio cambios: `ProtectedAdminRoute` ya es el unico punto de entrada a `ProductTable`/`ProductModal`.

Closes #134

## Test plan
- [x] `npx playwright test e2e/product-admin-auth.spec.ts` — nuevo spec: sin token -> 401, usuario no-admin -> 403 en create/update/delete, flujo admin completo (crear -> editar -> borrar) -> exito.
- [x] `npx playwright test` (suite completa) — 9/9 pasan, sin regresiones en admin/auth/transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)