### PR TITLE
HU-27: actualizar productos desde un agente IA (update_product)

### DIFF
--- a/backend/src/validators/product.validator.ts
+++ b/backend/src/validators/product.validator.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 
-export const createProductSchema = z.object({
+const productFields = {
   name: z.string().min(1, 'El nombre es requerido'),
   description: z.string().optional(),
   price: z.number().min(0, 'El precio debe ser un valor positivo'),
-  stock: z.number().int().min(0, 'El stock debe ser 0 o un entero positivo').default(0),
+  stock: z.number().int().min(0, 'El stock debe ser 0 o un entero positivo'),
   condition: z.enum(['A', 'B', 'C'], {
     errorMap: () => ({ message: 'La condición debe ser A, B o C' }),
   }),
@@ -12,6 +12,14 @@ export const createProductSchema = z.object({
     errorMap: () => ({ message: 'Categoría inválida' }),
   }),
   image_urls: z.array(z.string().url('Debe ser una URL válida')).optional(),
+};
+
+export const createProductSchema = z.object({
+  ...productFields,
+  stock: productFields.stock.default(0),
 });
 
-export const updateProductSchema = createProductSchema.partial();
+// Se construye desde `productFields` (sin el `.default(0)` de stock) en vez de
+// `createProductSchema.partial()`: partial() no elimina los default() internos,
+// asi que un update parcial sin `stock` terminaria reseteandolo a 0.
+export const updateProductSchema = z.object(productFields).partial();

--- a/e2e/product-update-agent.spec.ts
+++ b/e2e/product-update-agent.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test';
+import { resetE2EState } from './helpers';
+
+const API_URL = 'http://127.0.0.1:3001/api';
+const ADMIN_AUTH = { Authorization: 'Bearer mock:admin:e2e-admin' };
+const USER_AUTH = { Authorization: 'Bearer mock:user:e2e-user' };
+
+const validProductBody = {
+  name: 'Producto para actualizar por agente IA',
+  description: 'Producto de prueba para HU-27 (update_product)',
+  price: 300,
+  stock: 5,
+  condition: 'B',
+  category: 'tablet',
+};
+
+test.beforeEach(async ({ request }) => {
+  await resetE2EState(request);
+});
+
+test('aplica un cambio parcial y preserva los campos no enviados', async ({ request }) => {
+  const createResponse = await request.post(`${API_URL}/products`, {
+    headers: ADMIN_AUTH,
+    data: validProductBody,
+  });
+  expect(createResponse.status()).toBe(201);
+  const { data: created } = await createResponse.json();
+
+  const updateResponse = await request.put(`${API_URL}/products/${created._id}`, {
+    headers: ADMIN_AUTH,
+    data: { price: 350 },
+  });
+  expect(updateResponse.status()).toBe(200);
+
+  const body = await updateResponse.json();
+  expect(body.data.price).toBe(350);
+  // Los campos no enviados en el payload parcial deben preservarse tal cual.
+  expect(body.data.stock).toBe(validProductBody.stock);
+  expect(body.data.category).toBe(validProductBody.category);
+  expect(body.data.condition).toBe(validProductBody.condition);
+  expect(body.data.name).toBe(validProductBody.name);
+});
+
+test('rechaza un payload de actualizacion con categoria invalida', async ({ request }) => {
+  const response = await request.put(`${API_URL}/products/000000000000000000000000`, {
+    headers: ADMIN_AUTH,
+    data: { category: 'electrodomesticos' },
+  });
+  expect(response.status()).toBe(400);
+});
+
+test('rechaza un payload de actualizacion con condicion invalida', async ({ request }) => {
+  const response = await request.put(`${API_URL}/products/000000000000000000000000`, {
+    headers: ADMIN_AUTH,
+    data: { condition: 'Z' },
+  });
+  expect(response.status()).toBe(400);
+});
+
+test('rechaza un payload de actualizacion con precio negativo', async ({ request }) => {
+  const response = await request.put(`${API_URL}/products/000000000000000000000000`, {
+    headers: ADMIN_AUTH,
+    data: { price: -5 },
+  });
+  expect(response.status()).toBe(400);
+});
+
+test('rechaza la actualizacion si el agente no tiene rol admin', async ({ request }) => {
+  const response = await request.put(`${API_URL}/products/000000000000000000000000`, {
+    headers: USER_AUTH,
+    data: { price: 400 },
+  });
+  expect(response.status()).toBe(403);
+});


### PR DESCRIPTION
## Summary
- HU-27 pide una herramienta `update_product` para que un agente IA aplique cambios parciales a productos, restringida a administradores y con validacion del payload.
- Mismo patron que HU-26: la "herramienta" es el endpoint REST existente (`PUT /api/products/:id`), ya admin-gated desde HU-25 y con validacion zod via `updateProductSchema`.
- **Bug real encontrado y corregido**: `updateProductSchema` se derivaba de `createProductSchema.partial()`, pero `.partial()` no elimina los `.default()` internos de zod. Un update parcial que no incluyera `stock` reseteaba silenciosamente ese campo a `0` en la base — una violacion directa del criterio "cambios parciales" de HU-27. Se separo el shape base de los campos de producto para que `createProductSchema` (con `stock` default `0`, usado en creacion) y `updateProductSchema` (sin ese default, todos los campos opcionales) no compartan ese comportamiento.
- Se agrego cobertura e2e dedicada (`e2e/product-update-agent.spec.ts`) que verifica los 3 criterios: un update parcial preserva los campos no enviados (el test que expuso el bug), rechazo de payload invalido (categoria/condicion/precio), y rechazo si el llamador no es admin.

Closes #136

## Test plan
- [x] `npx playwright test e2e/product-update-agent.spec.ts` — 5/5 pasan.
- [x] `npx playwright test` (suite completa) — 20/20 pasan, sin regresiones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)