### PR TITLE
HU-28: eliminar productos desde un agente IA (delete_product)

### DIFF
--- a/e2e/product-delete-agent.spec.ts
+++ b/e2e/product-delete-agent.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+import { resetE2EState } from './helpers';
+
+const API_URL = 'http://127.0.0.1:3001/api';
+const ADMIN_AUTH = { Authorization: 'Bearer mock:admin:e2e-admin' };
+const USER_AUTH = { Authorization: 'Bearer mock:user:e2e-user' };
+
+const validProductBody = {
+  name: 'Producto para eliminar por agente IA',
+  description: 'Producto de prueba para HU-28 (delete_product)',
+  price: 120,
+  stock: 2,
+  condition: 'C',
+  category: 'pc',
+};
+
+test.beforeEach(async ({ request }) => {
+  await resetE2EState(request);
+});
+
+test('rechaza la eliminacion si el agente no tiene rol admin', async ({ request }) => {
+  const response = await request.delete(`${API_URL}/products/000000000000000000000000`, {
+    headers: USER_AUTH,
+  });
+  expect(response.status()).toBe(403);
+});
+
+test('elimina un producto y confirma que ya no esta disponible en el catalogo', async ({ request }) => {
+  const createResponse = await request.post(`${API_URL}/products`, {
+    headers: ADMIN_AUTH,
+    data: validProductBody,
+  });
+  expect(createResponse.status()).toBe(201);
+  const { data: created } = await createResponse.json();
+
+  const deleteResponse = await request.delete(`${API_URL}/products/${created._id}`, {
+    headers: ADMIN_AUTH,
+  });
+  expect(deleteResponse.status()).toBe(200);
+  const deleteBody = await deleteResponse.json();
+  expect(deleteBody.success).toBe(true);
+
+  // La confirmacion real de que ya no esta disponible en el catalogo:
+  // una consulta posterior por ese id ya no debe encontrarlo.
+  const getResponse = await request.get(`${API_URL}/products/${created._id}`);
+  expect(getResponse.status()).toBe(404);
+});
+
+test('devuelve 404 al intentar eliminar un producto inexistente', async ({ request }) => {
+  const response = await request.delete(`${API_URL}/products/000000000000000000000000`, {
+    headers: ADMIN_AUTH,
+  });
+  expect(response.status()).toBe(404);
+});


### PR DESCRIPTION
## Summary
- HU-28 pide una herramienta `delete_product` para que un agente IA elimine productos, exigiendo confirmacion humana en el cliente MCP, rechazando usuarios no admin, y confirmando que el producto ya no esta disponible en el catalogo.
- Mismo patron que HU-26/HU-27: la "herramienta" es el endpoint REST existente (`DELETE /api/products/:id`), ya admin-gated desde HU-25.
- **AC1 (confirmacion humana en el cliente MCP) se deja deliberadamente fuera del backend**: es una responsabilidad del futuro cliente MCP (destructive-hint + confirmacion del propio protocolo), no algo que un flag en la API pueda probar honestamente. Verifique que el frontend ya tiene su propia confirmacion humana independiente (`confirm()` en `ProductTable.tsx:212`) sin mandar ningun parametro extra al backend; forzar un flag de confirmacion en el endpoint hubiera roto ese flujo existente sin satisfacer realmente el criterio (que habla del cliente MCP, no de la API REST).
- AC2 (rechazo a no-admin) y AC3 (confirmacion real de que el producto ya no esta disponible) si son verificables end-to-end y se cubren con tests.
- Se agrego `e2e/product-delete-agent.spec.ts`: rechazo 403 para no-admin, eliminacion exitosa seguida de un `GET` que confirma `404` (la prueba real de "ya no disponible", no solo el mensaje de exito), y 404 al eliminar un id inexistente.

Closes #137

## Test plan
- [x] `npx playwright test e2e/product-delete-agent.spec.ts` — 3/3 pasan.
- [x] `npx playwright test` (suite completa) — 23/23 pasan, sin regresiones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)