### PR TITLE
HU-30: buscar productos con filtros avanzados (search_products_advanced)

### DIFF
--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -3,7 +3,38 @@ import { Product } from '../models/Product';
 
 export const getProducts = async (c: Context) => {
   try {
-    const products = await Product.find();
+    const query = c.req.valid('query' as any) as {
+      category?: string;
+      condition?: string;
+      minPrice?: number;
+      maxPrice?: number;
+      available?: 'true' | 'false';
+      limit?: number;
+    };
+
+    const hasFilters = Object.values(query).some((value) => value !== undefined);
+
+    if (!hasFilters) {
+      const products = await Product.find();
+      return c.json({ success: true, data: products });
+    }
+
+    const filter: Record<string, unknown> = {};
+    if (query.category) filter.category = query.category;
+    if (query.condition) filter.condition = query.condition;
+    if (query.minPrice !== undefined || query.maxPrice !== undefined) {
+      filter.price = {
+        ...(query.minPrice !== undefined && { $gte: query.minPrice }),
+        ...(query.maxPrice !== undefined && { $lte: query.maxPrice }),
+      };
+    }
+    if (query.available === 'true') filter.stock = { $gt: 0 };
+    if (query.available === 'false') filter.stock = { $lte: 0 };
+
+    const products = await Product.find(filter)
+      .sort({ price: 1 })
+      .limit(query.limit ?? 20);
+
     return c.json({ success: true, data: products });
   } catch (error: any) {
     return c.json({ success: false, message: error.message }, 500);

--- a/backend/src/routes/product.routes.ts
+++ b/backend/src/routes/product.routes.ts
@@ -9,14 +9,24 @@ import {
 } from '../controllers/product.controller';
 import {
   createProductSchema,
+  productFilterSchema,
   updateProductSchema,
 } from '../validators/product.validator';
 import { adminAuthMiddleware } from '../middlewares/auth.middleware';
 
 const productRoutes = new Hono();
 
-// Obtener todos los productos
-productRoutes.get('/', getProducts);
+// Obtener todos los productos, con filtros opcionales (categoria, condicion,
+// rango de precio, disponibilidad) para busquedas acotadas y ordenadas
+productRoutes.get(
+  '/',
+  zValidator('query', productFilterSchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  getProducts
+);
 
 // Obtener un producto por ID
 productRoutes.get('/:id', getProductById);

--- a/backend/src/validators/product.validator.ts
+++ b/backend/src/validators/product.validator.ts
@@ -23,3 +23,17 @@ export const createProductSchema = z.object({
 // `createProductSchema.partial()`: partial() no elimina los default() internos,
 // asi que un update parcial sin `stock` terminaria reseteandolo a 0.
 export const updateProductSchema = z.object(productFields).partial();
+
+export const productFilterSchema = z
+  .object({
+    category: productFields.category.optional(),
+    condition: productFields.condition.optional(),
+    minPrice: z.coerce.number().min(0, 'minPrice debe ser 0 o un valor positivo').optional(),
+    maxPrice: z.coerce.number().min(0, 'maxPrice debe ser 0 o un valor positivo').optional(),
+    available: z.enum(['true', 'false']).optional(),
+    limit: z.coerce.number().int().min(1).max(50).optional(),
+  })
+  .refine((data) => data.minPrice === undefined || data.maxPrice === undefined || data.minPrice <= data.maxPrice, {
+    message: 'minPrice no puede ser mayor que maxPrice',
+    path: ['minPrice'],
+  });

--- a/e2e/product-search-filters.spec.ts
+++ b/e2e/product-search-filters.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from '@playwright/test';
+import { resetE2EState } from './helpers';
+
+const API_URL = 'http://127.0.0.1:3001/api';
+const ADMIN_AUTH = { Authorization: 'Bearer mock:admin:e2e-admin' };
+
+// resetE2EState ya siembra 2 productos (iPhone/celular/A/stock8/$499 y
+// MacBook/laptop/A/stock5/$899). Se agregan variantes para poder ejercer
+// condition, disponibilidad y rango de precio con datos que realmente
+// discriminen entre si.
+const extraProducts = [
+  { name: 'PC Reacondicionada B', description: 'x', price: 300, stock: 0, condition: 'B', category: 'pc' },
+  { name: 'Auriculares C baratos', description: 'x', price: 50, stock: 10, condition: 'C', category: 'auriculares' },
+  { name: 'Tablet A premium', description: 'x', price: 700, stock: 3, condition: 'A', category: 'tablet' },
+];
+
+test.beforeEach(async ({ request }) => {
+  await resetE2EState(request);
+  for (const product of extraProducts) {
+    const response = await request.post(`${API_URL}/products`, { headers: ADMIN_AUTH, data: product });
+    expect(response.status()).toBe(201);
+  }
+});
+
+test('sin filtros devuelve el catalogo completo, sin acotar (compatibilidad con el catalogo publico)', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data.length).toBe(2 + extraProducts.length);
+});
+
+test('filtra por categoria', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?category=pc`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data).toHaveLength(1);
+  expect(body.data[0].name).toBe('PC Reacondicionada B');
+});
+
+test('filtra por condicion', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?condition=C`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data).toHaveLength(1);
+  expect(body.data[0].name).toBe('Auriculares C baratos');
+});
+
+test('filtra por rango de precio', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?minPrice=400&maxPrice=750`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  const names = body.data.map((p: { name: string }) => p.name).sort();
+  expect(names).toEqual(['Tablet A premium', 'iPhone 13 Reacondicionado'].sort());
+});
+
+test('filtra por disponibilidad (stock > 0)', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?available=true`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data.every((p: { stock: number }) => p.stock > 0)).toBe(true);
+  expect(body.data.some((p: { name: string }) => p.name === 'PC Reacondicionada B')).toBe(false);
+});
+
+test('filtra por no disponibilidad (stock <= 0)', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?available=false`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data).toHaveLength(1);
+  expect(body.data[0].name).toBe('PC Reacondicionada B');
+});
+
+test('devuelve resultados ordenados por precio ascendente cuando hay filtros', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?minPrice=0`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  const prices = body.data.map((p: { price: number }) => p.price);
+  const sorted = [...prices].sort((a, b) => a - b);
+  expect(prices).toEqual(sorted);
+});
+
+test('acota los resultados con limit', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?minPrice=0&limit=2`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data).toHaveLength(2);
+});
+
+test('rechaza una categoria de filtro invalida', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?category=electrodomesticos`);
+  expect(response.status()).toBe(400);
+});
+
+test('rechaza un precio de filtro no numerico', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?minPrice=abc`);
+  expect(response.status()).toBe(400);
+});
+
+test('rechaza un rango de precio invalido (minPrice mayor que maxPrice)', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?minPrice=500&maxPrice=100`);
+  expect(response.status()).toBe(400);
+});


### PR DESCRIPTION
## Summary
- HU-30 pide una herramienta `search_products_advanced` para que un agente IA busque productos filtrando por categoria, condicion, precio y disponibilidad, con resultados ordenados y acotados, y errores controlados ante filtros invalidos.
- Mismo patron que HU-02 (`search_products`, ya "Done"): la "herramienta" es el endpoint REST publico existente (`GET /api/products`), sin servidor MCP ni autenticacion nueva — sigue siendo lectura publica igual que el catalogo de HU-01.
- `GET /api/products` ahora acepta query params opcionales: `category`, `condition`, `minPrice`, `maxPrice`, `available` (`true`/`false` segun `stock`), `limit`.
- **Compatibilidad con el catalogo publico existente**: los defaults (orden por precio ascendente + limite acotado a 20, maximo 50) solo se aplican cuando se envia al menos un parametro de query. Una llamada sin parametros (la que ya hace el catalogo/`useProducts`) sigue devolviendo exactamente el mismo resultado que antes, sin orden forzado ni limite — para no romper esa pantalla.
- Filtros invalidos (categoria/condicion fuera del enum, precio no numerico, `minPrice > maxPrice`) responden `400` via `zValidator('query', ...)`, igual que el resto del CRUD de productos.
- Se agrego `e2e/product-search-filters.spec.ts` con productos de fixture variados (condition/categoria/stock/precio distintos, ya que los 2 productos sembrados por `resetE2EState` no alcanzan para discriminar filtros) cubriendo: filtro por categoria, condicion, rango de precio, disponibilidad (true/false), orden ascendente, `limit`, y los 3 casos de error controlado.

Closes #139

## Test plan
- [x] `npx playwright test e2e/product-search-filters.spec.ts` — 11/11 pasan.
- [x] `npx playwright test` (suite completa) — 34/34 pasan, sin regresiones (incluyendo que el catalogo sin filtros sigue devolviendo todo el listado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)