### PR TITLE
HU-29: filtrar el catalogo por nombre, categoria, condicion y rango de precio

### DIFF
--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -4,6 +4,7 @@ import { Product } from '../models/Product';
 export const getProducts = async (c: Context) => {
   try {
     const query = c.req.valid('query' as any) as {
+      name?: string;
       category?: string;
       condition?: string;
       minPrice?: number;
@@ -20,6 +21,7 @@ export const getProducts = async (c: Context) => {
     }
 
     const filter: Record<string, unknown> = {};
+    if (query.name) filter.name = { $regex: query.name, $options: 'i' };
     if (query.category) filter.category = query.category;
     if (query.condition) filter.condition = query.condition;
     if (query.minPrice !== undefined || query.maxPrice !== undefined) {

--- a/backend/src/validators/product.validator.ts
+++ b/backend/src/validators/product.validator.ts
@@ -26,6 +26,7 @@ export const updateProductSchema = z.object(productFields).partial();
 
 export const productFilterSchema = z
   .object({
+    name: z.string().min(1, 'El nombre debe tener al menos 1 caracter').max(100, 'El nombre no puede superar los 100 caracteres').optional(),
     category: productFields.category.optional(),
     condition: productFields.condition.optional(),
     minPrice: z.coerce.number().min(0, 'minPrice debe ser 0 o un valor positivo').optional(),

--- a/e2e/product-search-filters.spec.ts
+++ b/e2e/product-search-filters.spec.ts
@@ -95,6 +95,37 @@ test('rechaza un precio de filtro no numerico', async ({ request }) => {
   expect(response.status()).toBe(400);
 });
 
+test('filtra por nombre con coincidencia parcial', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?name=iPhone`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data.length).toBeGreaterThan(0);
+  expect(body.data.every((p: { name: string }) => p.name.toLowerCase().includes('iphone'))).toBe(true);
+});
+
+test('filtra por nombre ignorando mayusculas y minusculas', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?name=IPHONE`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data.length).toBeGreaterThan(0);
+  expect(body.data.every((p: { name: string }) => p.name.toLowerCase().includes('iphone'))).toBe(true);
+});
+
+test('combina filtros de nombre, categoria, condicion y rango de precio', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?name=iPhone&category=celular&condition=A&minPrice=400&maxPrice=750`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data.length).toBe(1);
+  expect(body.data[0].name).toBe('iPhone 13 Reacondicionado');
+});
+
+test('devuelve lista vacia cuando el nombre no coincide con ningun producto', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?name=xyzxyz`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data).toEqual([]);
+});
+
 test('rechaza un rango de precio invalido (minPrice mayor que maxPrice)', async ({ request }) => {
   const response = await request.get(`${API_URL}/products?minPrice=500&maxPrice=100`);
   expect(response.status()).toBe(400);

--- a/frontend/src/components/ProductList.tsx
+++ b/frontend/src/components/ProductList.tsx
@@ -16,6 +16,13 @@ const CATEGORIES = [
   { label: 'Tablets', value: 'tablet' },
 ];
 
+const CONDITIONS = [
+  { label: 'Todas', value: '' },
+  { label: 'Cond. A', value: 'A' },
+  { label: 'Cond. B', value: 'B' },
+  { label: 'Cond. C', value: 'C' },
+];
+
 const PRICE_RANGES = [
   { label: 'Cualquier precio', min: 0, max: Infinity },
   { label: 'Menos de $200', min: 0, max: 200 },
@@ -24,37 +31,44 @@ const PRICE_RANGES = [
   { label: 'Más de $1000', min: 1000, max: Infinity },
 ];
 
-export const ProductList: React.FC = () => {
-  const { data: products, isLoading, isError, error } = useProducts();
-  const addItem = useCartStore((s) => s.addItem);
-  const toggleDrawer = useCartStore((s) => s.toggleDrawer);
+function priceRangeToFilters(priceIdx: number): { minPrice?: number; maxPrice?: number } {
+  if (priceIdx === 0) return {};
+  const range = PRICE_RANGES[priceIdx];
+  return {
+    ...(range.min > 0 && { minPrice: range.min }),
+    ...(range.max !== Infinity && { maxPrice: range.max }),
+  };
+}
 
+export const ProductList: React.FC = () => {
   const [category, setCategory] = useState('');
+  const [condition, setCondition] = useState('');
   const [priceIdx, setPriceIdx] = useState(0);
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
 
-  const filtered = useMemo(() => {
-    if (!products) return [];
-    const range = PRICE_RANGES[priceIdx];
-    const searchLower = search.toLowerCase().trim();
-    return products.filter((p) => {
-      const catOk = !category || p.category === category;
-      const priceOk = p.price >= range.min && p.price < range.max;
-      const searchOk = !searchLower ||
-        p.name.toLowerCase().includes(searchLower) ||
-        p.description?.toLowerCase().includes(searchLower);
-      return catOk && priceOk && searchOk;
-    });
-  }, [products, category, priceIdx, search]);
+  const filters = useMemo(
+    () => ({
+      name: search.trim() || undefined,
+      category: category || undefined,
+      condition: condition || undefined,
+      ...priceRangeToFilters(priceIdx),
+    }),
+    [search, category, condition, priceIdx]
+  );
 
-  useEffect(() => setPage(1), [category, priceIdx, search]);
+  const { data: products, isLoading, isError, error } = useProducts(filters);
+  const addItem = useCartStore((s) => s.addItem);
+  const toggleDrawer = useCartStore((s) => s.toggleDrawer);
 
-  const totalPages = Math.ceil(filtered.length / ITEMS_PER_PAGE);
+  useEffect(() => setPage(1), [filters]);
+
+  const totalPages = Math.ceil((products?.length ?? 0) / ITEMS_PER_PAGE);
   const paginatedProducts = useMemo(() => {
+    if (!products) return [];
     const start = (page - 1) * ITEMS_PER_PAGE;
-    return filtered.slice(start, start + ITEMS_PER_PAGE);
-  }, [filtered, page]);
+    return products.slice(start, start + ITEMS_PER_PAGE);
+  }, [products, page]);
 
   const handlePageChange = (newPage: number) => {
     if (newPage >= 1 && newPage <= totalPages) {
@@ -65,9 +79,9 @@ export const ProductList: React.FC = () => {
 
   if (isLoading) {
     return (
-      <div>
-        <FilterBar category={category} setCategory={setCategory} priceIdx={priceIdx} setPriceIdx={setPriceIdx} search={search} setSearch={setSearch} disabled />
-        <div className="products-grid">
+        <div>
+          <FilterBar category={category} setCategory={setCategory} condition={condition} setCondition={setCondition} priceIdx={priceIdx} setPriceIdx={setPriceIdx} search={search} setSearch={setSearch} disabled />
+          <div className="products-grid">
           {Array.from({ length: 6 }).map((_, i) => <SkeletonCard key={i} />)}
         </div>
       </div>
@@ -86,29 +100,29 @@ export const ProductList: React.FC = () => {
 
   return (
     <div>
-      <FilterBar category={category} setCategory={setCategory} priceIdx={priceIdx} setPriceIdx={setPriceIdx} search={search} setSearch={setSearch} />
+      <FilterBar category={category} setCategory={setCategory} condition={condition} setCondition={setCondition} priceIdx={priceIdx} setPriceIdx={setPriceIdx} search={search} setSearch={setSearch} />
 
       {/* Productos destacados (solo si no hay filtros activos) */}
-      {!search && !category && priceIdx === 0 && (
+      {!search && !category && !condition && priceIdx === 0 && (
         <div style={{ marginBottom: '3rem' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '1.5rem' }}>
             <h2 style={{ fontSize: '1.25rem', fontWeight: 400, color: 'var(--ink)', fontFamily: 'var(--font-display)', letterSpacing: '-0.01em' }}>Productos destacados</h2>
             <div style={{ flex: 1, height: '1px', background: 'var(--line)' }} />
           </div>
           <div className="products-grid">
-            {filtered.filter(p => p.condition === 'A').slice(0, 4).map((product) => (
+            {products?.filter(p => p.condition === 'A').slice(0, 4).map((product) => (
               <ProductCard key={product._id} product={product} onAdd={() => { addItem(product); toggleDrawer(); }} featured />
             ))}
           </div>
         </div>
       )}
 
-      {filtered.length === 0 ? (
+      {products?.length === 0 ? (
         <EmptyState
           icon={<svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 15.803 7.5 7.5 0 0016.803 15.803z" /></svg>}
           title="Sin resultados"
           description="Ningún producto coincide con los filtros seleccionados."
-          cta={<button className="btn-outline" onClick={() => { setCategory(''); setPriceIdx(0); setSearch(''); }}>Limpiar filtros</button>}
+          cta={<button className="btn-outline" onClick={() => { setCategory(''); setCondition(''); setPriceIdx(0); setSearch(''); }}>Limpiar filtros</button>}
         />
       ) : (
         <>
@@ -298,6 +312,8 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onAdd, featured }) =
 interface FilterBarProps {
   category: string;
   setCategory: (v: string) => void;
+  condition: string;
+  setCondition: (v: string) => void;
   priceIdx: number;
   setPriceIdx: (v: number) => void;
   search: string;
@@ -305,14 +321,16 @@ interface FilterBarProps {
   disabled?: boolean;
 }
 
-const FilterBar: React.FC<FilterBarProps> = ({ category, setCategory, priceIdx, setPriceIdx, search, setSearch, disabled }) => {
+const FilterBar: React.FC<FilterBarProps> = ({ category, setCategory, condition, setCondition, priceIdx, setPriceIdx, search, setSearch, disabled }) => {
   const activeCount =
     (category ? 1 : 0) +
+    (condition ? 1 : 0) +
     (priceIdx !== 0 ? 1 : 0) +
     (search.trim() ? 1 : 0);
 
   const handleClearAll = () => {
     setCategory('');
+    setCondition('');
     setPriceIdx(0);
     setSearch('');
   };
@@ -392,6 +410,27 @@ const FilterBar: React.FC<FilterBarProps> = ({ category, setCategory, priceIdx, 
                   className={`filter-chip${active ? ' is-active' : ''}`}
                 >
                   {cat.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="filter-group">
+          <span className="filter-group__label">Condición</span>
+          <div className="filter-chips" role="group" aria-label="Filtrar por condición">
+            {CONDITIONS.map((cond) => {
+              const active = condition === cond.value;
+              return (
+                <button
+                  key={cond.value || 'all-cond'}
+                  type="button"
+                  onClick={() => setCondition(cond.value)}
+                  disabled={disabled}
+                  aria-pressed={active}
+                  className={`filter-chip${active ? ' is-active' : ''}`}
+                >
+                  {cond.label}
                 </button>
               );
             })}

--- a/frontend/src/components/ProductTable.tsx
+++ b/frontend/src/components/ProductTable.tsx
@@ -167,7 +167,7 @@ export default function ProductTable() {
     queryFn: async () => {
       const t = await getToken();
       if (!t) throw new Error('No token');
-      return productsService.getAll(t);
+      return productsService.getAll(undefined, t);
     },
   });
 

--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -1,11 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { productsService } from '../services/products.service';
 import type { Product } from '../types/product';
+import type { ProductFilters } from '../services/products.service';
 
-export const useProducts = () => {
+export const useProducts = (filters?: ProductFilters) => {
   return useQuery<Product[], Error>({
-    queryKey: ['products'],
-    queryFn: () => productsService.getAll(),
+    queryKey: ['products', filters],
+    queryFn: () => productsService.getAll(filters),
   });
 };
 

--- a/frontend/src/services/products.service.ts
+++ b/frontend/src/services/products.service.ts
@@ -22,12 +22,39 @@ export interface UpdateProductDTO {
   image_urls?: string[];
 }
 
+export interface ProductFilters {
+  name?: string;
+  category?: string;
+  condition?: string;
+  minPrice?: number;
+  maxPrice?: number;
+}
+
+function buildQueryString(filters?: ProductFilters): string {
+  if (!filters) return '';
+  const params = new URLSearchParams();
+  if (filters.name?.trim()) params.set('name', filters.name.trim());
+  if (filters.category) params.set('category', filters.category);
+  if (filters.condition) params.set('condition', filters.condition);
+  if (filters.minPrice !== undefined && !Number.isNaN(filters.minPrice)) {
+    params.set('minPrice', String(filters.minPrice));
+  }
+  if (filters.maxPrice !== undefined && !Number.isNaN(filters.maxPrice)) {
+    params.set('maxPrice', String(filters.maxPrice));
+  }
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+}
+
 export const productsService = {
-  async getAll(token?: string): Promise<Product[]> {
-    const response = await fetch(`${API_URL}/products`, {
+  async getAll(filters?: ProductFilters, token?: string): Promise<Product[]> {
+    const response = await fetch(`${API_URL}/products${buildQueryString(filters)}`, {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     });
-    if (!response.ok) throw new Error('Failed to fetch products');
+    if (!response.ok) {
+      const result = await response.json().catch(() => ({}));
+      throw new Error(result?.message || result?.errors?.[0]?.message || 'Failed to fetch products');
+    }
     const result = await response.json();
     return result.data || [];
   },


### PR DESCRIPTION
## Summary
- HU-29 pide que los visitantes puedan filtrar el catalogo por nombre, categoria, condicion y rango de precio, aplicando uno o varios filtros al mismo tiempo.
- El backend ya soportaba categoria, condicion, precio y disponibilidad; este PR agrega el filtro por nombre con coincidencia parcial case-insensitive en `GET /api/products`.
- El frontend pasaba de filtrar los productos en memoria a enviar los filtros como query params al backend, lo que permite combinarlos correctamente del lado del servidor.
- Se agrego el selector de condicion (A, B, C) al panel de filtros y se mantuvo el estado de sin resultados.
- Los filtros invalidos (categoria/condicion fuera del enum, precio no numerico, `minPrice > maxPrice`) responden `400` via `zValidator('query', ...)`.

## Cambios
- `backend/src/validators/product.validator.ts`: agrega parametro `name` al `productFilterSchema`.
- `backend/src/controllers/product.controller.ts`: aplica filtro regex case-insensitive sobre `name`.
- `frontend/src/services/products.service.ts`: extiende `getAll` para aceptar filtros y construir query string.
- `frontend/src/hooks/useProducts.ts`: parametriza el hook con `ProductFilters`.
- `frontend/src/components/ProductList.tsx`: envia filtros al backend, agrega selector de condicion y actualiza contador/limpieza de filtros.
- `frontend/src/components/ProductTable.tsx`: ajusta llamada a `getAll` por compatibilidad de firma.
- `e2e/product-search-filters.spec.ts`: agrega tests para filtro por nombre parcial, case-insensitive, combinado y sin coincidencias.

## Issue relacionado
Closes #138

## Test plan
- [x] `npx playwright test e2e/product-search-filters.spec.ts` — 15/15 pasan.
- [x] `cd frontend && npm run build` — sin errores de TypeScript.
- [x] Verificacion manual del catalogo con filtros por categoria, nombre, condicion y precio.