### PR TITLE
feat: exponer tool MCP search_products

### DIFF
--- a/docs/plan-implementacion-mcp-safetech.md
+++ b/docs/plan-implementacion-mcp-safetech.md
@@ -156,15 +156,15 @@ Usar autenticacion de usuario final al conectar el MCP y, opcionalmente, credenc
 
 ### Reglas por categoria de tools
 
-#### Publicas
+#### De lectura autenticada
 
-No requieren sesion:
+Requieren sesion MCP valida, pero no rol especial. Pueden reutilizar endpoints backend publicos o de bajo riesgo:
 
 - `search_products`
 - `get_product`
 - `search_products_advanced`
 
-Nota: aunque puedan ser publicas, conviene mantener rate limit y sanitizacion de output.
+Nota: aunque el endpoint backend de alguna de estas tools pueda ser publico, en la infraestructura MCP actual el acceso al servidor requiere autenticacion. Si en el futuro se quieren tools MCP anonimas, eso debe resolverse como trabajo de infraestructura base.
 
 #### Privadas de usuario autenticado
 
@@ -551,7 +551,7 @@ Notas importantes:
 
 ## Definicion concreta de tools a exponer en la primera entrega
 
-### Publicos
+### De lectura autenticada
 
 #### `search_products`
 
@@ -559,18 +559,21 @@ Notas importantes:
 - Input minimo: `query?`
 - Input opcional: `name`, `limit`
 - Riesgo: bajo
+- Requiere autenticacion MCP, aunque el endpoint backend sea publico
 
 #### `get_product`
 
 - Fuente backend: `GET /api/products/:id`
 - Input: `productId`
 - Riesgo: bajo
+- Requiere autenticacion MCP, aunque el endpoint backend sea publico
 
 #### `search_products_advanced`
 
 - Fuente backend: `GET /api/products`
 - Input: `name?`, `category?`, `condition?`, `minPrice?`, `maxPrice?`, `available?`, `limit?`
 - Riesgo: bajo
+- Requiere autenticacion MCP, aunque el endpoint backend sea publico
 
 ### Privados de usuario
 

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test';
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { createApp } from './server.js';
 import type { Authenticator, AuthContext } from './types.js';
-import { BackendApiClient } from './services/backend-api.js';
+import { BackendApiClient, BackendApiError } from './services/backend-api.js';
 import { createLogger } from './utils/logger.js';
 
 const env = {
@@ -27,6 +27,8 @@ class FakeAuthenticator implements Authenticator {
 }
 
 class FakeBackendApi extends BackendApiClient {
+  shouldFailProducts = false;
+
   constructor() {
     super('http://backend.test/api');
   }
@@ -36,6 +38,41 @@ class FakeBackendApi extends BackendApiClient {
       status: 'ok',
       timestamp: Date.now(),
       dbConnected: true,
+    };
+  }
+
+  override async getProducts(filters: { name?: string; limit?: number }) {
+    if (this.shouldFailProducts) {
+      throw new BackendApiError('Bad request', 400, {
+        success: false,
+        errors: [{ message: 'Invalid filters' }],
+      });
+    }
+
+    const data = [
+      {
+        id: 'prod_1',
+        name: 'iPhone 13 Reacondicionado',
+        description: '128GB',
+        price: 699,
+        stock: 4,
+        condition: 'A' as const,
+        category: 'celular' as const,
+        primaryImageUrl: 'https://cdn.test/iphone.jpg',
+      },
+      {
+        id: 'prod_2',
+        name: 'Laptop ThinkPad X1',
+        price: 899,
+        stock: 0,
+        condition: 'B' as const,
+        category: 'laptop' as const,
+        primaryImageUrl: 'https://cdn.test/thinkpad.jpg',
+      },
+    ];
+
+    return {
+      data: filters.name ? data.filter((product) => product.name.includes(filters.name!)) : data,
     };
   }
 }
@@ -56,12 +93,13 @@ test('health endpoint reports backend connectivity', async () => {
   assert.equal(body.backend.status, 'ok');
 });
 
-test('mcp handshake works and exposes no tools', async () => {
+test('mcp handshake works and exposes search_products tool', async () => {
+  const backendApi = new FakeBackendApi();
   const { app } = createApp({
     env,
     logger: createLogger(),
     authenticator: new FakeAuthenticator(),
-    backendApi: new FakeBackendApi(),
+    backendApi,
   });
 
   const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
@@ -82,7 +120,80 @@ test('mcp handshake works and exposes no tools', async () => {
   assert.equal(serverVersion?.name, 'SafeTech MCP Server');
 
   const tools = await client.listTools();
-  assert.deepEqual(tools.tools, []);
+  assert.equal(tools.tools.length, 1);
+  assert.equal(tools.tools[0]?.name, 'search_products');
+
+  const result = await client.callTool({
+    name: 'search_products',
+    arguments: {
+      query: 'iPhone',
+      limit: 5,
+    },
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.deepEqual(result.structuredContent, {
+    products: [
+      {
+        id: 'prod_1',
+        name: 'iPhone 13 Reacondicionado',
+        description: '128GB',
+        price: 699,
+        stock: 4,
+        condition: 'A',
+        category: 'celular',
+        primaryImageUrl: 'https://cdn.test/iphone.jpg',
+      },
+    ],
+    count: 1,
+    appliedFilters: {
+      name: 'iPhone',
+      limit: 5,
+    },
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('search_products normalizes backend validation errors', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldFailProducts = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'search_products',
+    arguments: {
+      name: 'bad-filter',
+      limit: 5,
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'INVALID_BACKEND_REQUEST',
+    message: 'La busqueda no pudo ejecutarse por parametros invalidos.',
+  });
 
   await transport.terminateSession();
   await client.close();

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -6,6 +6,7 @@ import { logAuditEvent } from './services/audit-log.js';
 import type { BackendApiClient } from './services/backend-api.js';
 import type { Authenticator, AuthContext } from './types.js';
 import type { AppEnv } from './config/env.js';
+import { registerSearchProductsTool } from './tools/public/search-products.tool.js';
 import type { Logger } from './utils/logger.js';
 import { getRequestId } from './utils/request-context.js';
 import { AuthError } from './auth/clerk-authenticator.js';
@@ -21,11 +22,7 @@ export function createApp({ env, logger, authenticator, backendApi }: AppDepende
   const app = new Hono();
 
   const handler = createMcpHandler(({ authInfo }) =>
-    new McpServer({
-      name: env.MCP_SERVER_NAME,
-      version: env.MCP_SERVER_VERSION,
-      description: buildInstructions(authInfo),
-    }),
+    buildServer({ env, logger, backendApi, authInfo }),
   );
 
   app.get('/health', async (c) => {
@@ -94,6 +91,23 @@ export function createApp({ env, logger, authenticator, backendApi }: AppDepende
   });
 
   return { app, handler };
+}
+
+function buildServer({
+  env,
+  logger,
+  backendApi,
+  authInfo,
+}: Pick<AppDependencies, 'env' | 'logger' | 'backendApi'> & { authInfo?: AuthInfo }) {
+  const server = new McpServer({
+    name: env.MCP_SERVER_NAME,
+    version: env.MCP_SERVER_VERSION,
+    description: buildInstructions(authInfo),
+  });
+
+  registerSearchProductsTool(server, { env, logger, backendApi });
+
+  return server;
 }
 
 function toAuthInfo(auth: AuthContext): AuthInfo {

--- a/mcp-server/src/services/backend-api.ts
+++ b/mcp-server/src/services/backend-api.ts
@@ -1,4 +1,4 @@
-import type { BackendHealth } from '../types.js';
+import type { BackendHealth, ProductListResponse, ProductSummary } from '../types.js';
 
 export class BackendApiError extends Error {
   constructor(
@@ -20,6 +20,42 @@ export class BackendApiClient {
         'x-request-id': requestId,
       },
     });
+  }
+
+  async getProducts(
+    filters: { name?: string; limit?: number },
+    requestId: string,
+  ): Promise<{ data: ProductSummary[] }> {
+    const search = new URLSearchParams();
+
+    if (filters.name) {
+      search.set('name', filters.name);
+    }
+
+    if (filters.limit !== undefined) {
+      search.set('limit', String(filters.limit));
+    }
+
+    const path = search.size > 0 ? `/products?${search.toString()}` : '/products';
+    const response = await this.request<ProductListResponse>(path, {
+      method: 'GET',
+      headers: {
+        'x-request-id': requestId,
+      },
+    });
+
+    return {
+      data: response.data.map((product) => ({
+        id: product._id,
+        name: product.name,
+        description: product.description,
+        price: product.price,
+        stock: product.stock,
+        condition: product.condition,
+        category: product.category,
+        primaryImageUrl: product.image_urls?.[0],
+      })),
+    };
   }
 
   private async request<T>(path: string, init: RequestInit): Promise<T> {

--- a/mcp-server/src/tools/public/search-products.tool.ts
+++ b/mcp-server/src/tools/public/search-products.tool.ts
@@ -1,0 +1,164 @@
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+import { logAuditEvent } from '../../services/audit-log.js';
+import { BackendApiError, type BackendApiClient } from '../../services/backend-api.js';
+import type { AppEnv } from '../../config/env.js';
+import type { ProductSummary } from '../../types.js';
+import type { Logger } from '../../utils/logger.js';
+import type { McpServer } from '@modelcontextprotocol/server';
+
+const searchProductsInputSchema = z
+  .object({
+    query: z.string().trim().min(1).max(100).optional(),
+    name: z.string().trim().min(1).max(100).optional(),
+    limit: z.number().int().min(1).max(50).optional(),
+  })
+  .refine((input) => input.query === undefined || input.name === undefined, {
+    message: 'Use query o name, pero no ambos al mismo tiempo.',
+    path: ['query'],
+  });
+
+const productSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  price: z.number(),
+  stock: z.number().int(),
+  condition: z.enum(['A', 'B', 'C']),
+  category: z.enum(['celular', 'laptop', 'pc', 'auriculares', 'tablet']),
+  primaryImageUrl: z.string().url().optional(),
+});
+
+const searchProductsOutputSchema = z.object({
+  products: z.array(productSummarySchema),
+  count: z.number().int().min(0),
+  appliedFilters: z.object({
+    name: z.string().optional(),
+    limit: z.number().int().min(1).max(50).optional(),
+  }),
+});
+
+interface RegisterSearchProductsToolDependencies {
+  env: AppEnv;
+  logger: Logger;
+  backendApi: BackendApiClient;
+}
+
+export function registerSearchProductsTool(
+  server: McpServer,
+  { env, logger, backendApi }: RegisterSearchProductsToolDependencies,
+) {
+  server.registerTool(
+    'search_products',
+    {
+      title: 'Search Products',
+      description: 'Busca productos del catalogo de SafeTech por nombre y devuelve datos basicos normalizados.',
+      inputSchema: searchProductsInputSchema,
+      outputSchema: searchProductsOutputSchema,
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
+      _meta: {
+        issue: '#188',
+        source: `${env.BACKEND_API_URL}/products`,
+      },
+    },
+    async (input, ctx) => {
+      const auditRequestId = randomUUID();
+      const startedAt = Date.now();
+      const actor = ctx.http?.authInfo?.clientId ?? 'anonymous';
+      const normalizedName = input.query ?? input.name;
+
+      try {
+        const response = await backendApi.getProducts(
+          {
+            name: normalizedName,
+            limit: input.limit,
+          },
+          auditRequestId,
+        );
+
+        const output = {
+          products: response.data.map(normalizeProduct),
+          count: response.data.length,
+          appliedFilters: {
+            ...(normalizedName ? { name: normalizedName } : {}),
+            ...(input.limit !== undefined ? { limit: input.limit } : {}),
+          },
+        };
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role: extractRole(ctx),
+          action: 'tool.search_products',
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output) }],
+          structuredContent: output,
+        };
+      } catch (error) {
+        const normalizedError = normalizeToolError(error);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role: extractRole(ctx),
+          action: 'tool.search_products',
+          outcome: 'error',
+          durationMs: Date.now() - startedAt,
+          errorCode: normalizedError.code,
+        });
+
+        return {
+          content: [{ type: 'text', text: normalizedError.message }],
+          structuredContent: normalizedError,
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function normalizeProduct(product: ProductSummary): z.infer<typeof productSummarySchema> {
+  return {
+    id: product.id,
+    name: product.name,
+    ...(product.description ? { description: product.description } : {}),
+    price: product.price,
+    stock: product.stock,
+    condition: product.condition,
+    category: product.category,
+    ...(product.primaryImageUrl ? { primaryImageUrl: product.primaryImageUrl } : {}),
+  };
+}
+
+function extractRole(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  const roleScope = ctx.http?.authInfo?.scopes?.find((scope) => scope.startsWith('role:'));
+  return roleScope?.replace('role:', '') ?? 'unknown';
+}
+
+function normalizeToolError(error: unknown) {
+  if (error instanceof BackendApiError) {
+    if (error.status === 400) {
+      return {
+        code: 'INVALID_BACKEND_REQUEST',
+        message: 'La busqueda no pudo ejecutarse por parametros invalidos.',
+      };
+    }
+
+    return {
+      code: `BACKEND_${error.status}`,
+      message: 'No fue posible consultar el catalogo en este momento.',
+    };
+  }
+
+  return {
+    code: 'INTERNAL_ERROR',
+    message: 'Ocurrio un error inesperado al consultar productos.',
+  };
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -16,3 +16,31 @@ export interface BackendHealth {
   timestamp: number;
   dbConnected: boolean;
 }
+
+export interface ProductSummary {
+  id: string;
+  name: string;
+  description?: string;
+  price: number;
+  stock: number;
+  condition: 'A' | 'B' | 'C';
+  category: 'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet';
+  primaryImageUrl?: string;
+}
+
+export interface ProductListResponse {
+  success: boolean;
+  data: Array<{
+    _id: string;
+    name: string;
+    description?: string;
+    price: number;
+    stock: number;
+    condition: 'A' | 'B' | 'C';
+    category: 'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet';
+    image_urls?: string[];
+    createdAt?: string;
+    updatedAt?: string;
+    __v?: number;
+  }>;
+}


### PR DESCRIPTION
## Resumen

Este PR expone el tool MCP `search_products` sobre la capacidad ya existente de catálogo en SafeTech, reutilizando el backend actual sin rehacer lógica de negocio.

## Cambios realizados

- se registró el tool `search_products` en el `mcp-server`
- se definió `inputSchema` para `query`, `name` y `limit`
- se definió `outputSchema` con productos normalizados para uso por agentes
- se integró la llamada al backend existente `GET /api/products`
- se normalizó la salida para no exponer campos internos innecesarios
- se agregó manejo consistente de errores del tool
- se agregó auditoría/logging para la ejecución del tool
- se agregaron pruebas MCP para descubrimiento, caso exitoso y error de validación/backend
- se alineó la documentación MCP para reflejar que estas tools son de lectura autenticada en la infraestructura actual

## Validaciones ejecutadas

- `npm test --prefix mcp-server`
- `npm run build --prefix mcp-server`

## Prueba manual

Se validó localmente el tool `search_products` desde un cliente MCP y respondió correctamente para búsquedas como `iphone`, incluyendo validación de límite máximo y salida normalizada.

## Alcance y decisiones

- este PR implementa solo el issue técnico `#188`
- no se rehizo lógica de catálogo en backend
- no se incluyeron cambios de infraestructura adicional para transporte local `stdio` en este PR
- la búsqueda por detalle de producto por ID se mantiene fuera de alcance y corresponde a `#189`

## Riesgos o pendientes

- el tool actual no expone un parámetro MCP `available`; si el agente pide “disponibles”, esa interpretación se resuelve a partir del `stock` retornado, no como filtro backend explícito
- el soporte `stdio` local del MCP se tratará aparte para no mezclar alcance con `#188`

## Issue relacionado

Closes #188
