### PR TITLE
feat: agregar soporte stdio local al MCP server

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,10 +1,11 @@
 # SafeTech MCP Server
 
-Base tecnica del servidor MCP de SafeTech para el issue `#187`.
+Base tecnica del servidor MCP de SafeTech para el issue `#187`, con transporte HTTP remoto y transporte local por `stdio`.
 
 ## Alcance
 
 - Servidor MCP remoto independiente.
+- Servidor MCP local por `stdio` para pruebas con clientes MCP.
 - Autenticacion base con Clerk.
 - Resolucion de identidad y rol.
 - Cliente HTTP interno hacia el backend de SafeTech.
@@ -19,13 +20,35 @@ Copiar `.env.example` y definir:
 
 - `BACKEND_API_URL`
 - `CLERK_SECRET_KEY`
+- `MCP_STDIO_USER_ID` opcional para modo local
+- `MCP_STDIO_ROLE` opcional para modo local (`user` o `admin`)
 
 ## Scripts
 
 - `npm run dev`
+- `npm run dev:stdio`
 - `npm run build`
 - `npm run start`
+- `npm run start:stdio`
 - `npm run test`
+
+## Uso local con cliente MCP
+
+Para probar el servidor como MCP local, levantar primero el backend de SafeTech y luego ejecutar:
+
+```bash
+npm run dev:stdio
+```
+
+Ese modo no expone URL HTTP. El cliente MCP debe lanzar el proceso por `stdio`, por ejemplo:
+
+```toml
+[mcp_servers.safetech]
+command = "npm"
+args = ["run", "start:stdio", "--prefix", "/ruta/absoluta/a/mcp-server"]
+```
+
+En modo `stdio`, el servidor usa una identidad local definida por `MCP_STDIO_USER_ID` y `MCP_STDIO_ROLE`. Esto sirve para pruebas locales y no reemplaza la autenticacion Clerk del transporte HTTP remoto.
 
 ## Despliegue
 

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -5,8 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
+    "dev:stdio": "tsx watch src/stdio.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
+    "start:stdio": "node dist/stdio.js",
     "test": "node --import tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {

--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -1,0 +1,31 @@
+import { McpServer } from '@modelcontextprotocol/server';
+import type { AuthInfo } from '@modelcontextprotocol/server';
+import type { AppEnv } from './config/env.js';
+import type { BackendApiClient } from './services/backend-api.js';
+import { registerSearchProductsTool } from './tools/public/search-products.tool.js';
+import type { Logger } from './utils/logger.js';
+
+interface ServerDependencies {
+  env: AppEnv;
+  logger: Logger;
+  backendApi: BackendApiClient;
+  authInfo?: AuthInfo;
+}
+
+export function buildServer({ env, logger, backendApi, authInfo }: ServerDependencies) {
+  const server = new McpServer({
+    name: env.MCP_SERVER_NAME,
+    version: env.MCP_SERVER_VERSION,
+    description: buildInstructions(authInfo),
+  });
+
+  registerSearchProductsTool(server, { env, logger, backendApi });
+
+  return server;
+}
+
+export function buildInstructions(authInfo?: AuthInfo) {
+  const role = authInfo?.scopes?.find((scope) => scope.startsWith('role:'))?.replace('role:', '') ?? 'unknown';
+
+  return `SafeTech MCP server. Authenticated role: ${role}.`;
+}

--- a/mcp-server/src/config/env.ts
+++ b/mcp-server/src/config/env.ts
@@ -7,6 +7,8 @@ const envSchema = z.object({
   MCP_SERVER_VERSION: z.string().default('0.1.0'),
   BACKEND_API_URL: z.string().url(),
   CLERK_SECRET_KEY: z.string().min(1),
+  MCP_STDIO_USER_ID: z.string().default('local_stdio_user'),
+  MCP_STDIO_ROLE: z.enum(['user', 'admin']).default('admin'),
 });
 
 export type AppEnv = z.infer<typeof envSchema>;

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -23,6 +23,7 @@ serve(
       host: info.address,
       port: info.port,
       backendApiUrl: env.BACKEND_API_URL,
+      transport: 'http',
     });
   },
 );

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -13,6 +13,8 @@ const env = {
   MCP_SERVER_VERSION: '0.1.0-test',
   BACKEND_API_URL: 'http://backend.test/api',
   CLERK_SECRET_KEY: 'test',
+  MCP_STDIO_USER_ID: 'local_stdio_user',
+  MCP_STDIO_ROLE: 'admin' as const,
 };
 
 class FakeAuthenticator implements Authenticator {

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -1,12 +1,12 @@
 import { Hono } from 'hono';
-import { createMcpHandler, McpServer } from '@modelcontextprotocol/server';
+import { createMcpHandler } from '@modelcontextprotocol/server';
 import type { AuthInfo } from '@modelcontextprotocol/server';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { logAuditEvent } from './services/audit-log.js';
 import type { BackendApiClient } from './services/backend-api.js';
 import type { Authenticator, AuthContext } from './types.js';
 import type { AppEnv } from './config/env.js';
-import { registerSearchProductsTool } from './tools/public/search-products.tool.js';
+import { buildServer } from './bootstrap.js';
 import type { Logger } from './utils/logger.js';
 import { getRequestId } from './utils/request-context.js';
 import { AuthError } from './auth/clerk-authenticator.js';
@@ -93,23 +93,6 @@ export function createApp({ env, logger, authenticator, backendApi }: AppDepende
   return { app, handler };
 }
 
-function buildServer({
-  env,
-  logger,
-  backendApi,
-  authInfo,
-}: Pick<AppDependencies, 'env' | 'logger' | 'backendApi'> & { authInfo?: AuthInfo }) {
-  const server = new McpServer({
-    name: env.MCP_SERVER_NAME,
-    version: env.MCP_SERVER_VERSION,
-    description: buildInstructions(authInfo),
-  });
-
-  registerSearchProductsTool(server, { env, logger, backendApi });
-
-  return server;
-}
-
 function toAuthInfo(auth: AuthContext): AuthInfo {
   return {
     token: auth.token,
@@ -117,12 +100,6 @@ function toAuthInfo(auth: AuthContext): AuthInfo {
     scopes: ['mcp', `role:${auth.role}`],
     expiresAt: auth.expiresAt,
   };
-}
-
-function buildInstructions(authInfo?: AuthInfo) {
-  const role = authInfo?.scopes?.find((scope) => scope.startsWith('role:'))?.replace('role:', '') ?? 'unknown';
-
-  return `SafeTech MCP base server. Authenticated role: ${role}. This infrastructure issue does not expose business tools.`;
 }
 
 function normalizeAuthError(error: unknown): AuthError {

--- a/mcp-server/src/stdio.ts
+++ b/mcp-server/src/stdio.ts
@@ -1,0 +1,32 @@
+import 'dotenv/config';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
+import { buildServer } from './bootstrap.js';
+import { loadEnv } from './config/env.js';
+import { BackendApiClient } from './services/backend-api.js';
+import { createLogger } from './utils/logger.js';
+
+const env = loadEnv();
+const logger = createLogger();
+const backendApi = new BackendApiClient(env.BACKEND_API_URL);
+
+serveStdio(
+  () =>
+    buildServer({
+      env,
+      logger,
+      backendApi,
+      authInfo: {
+        token: 'stdio-local-session',
+        clientId: env.MCP_STDIO_USER_ID,
+        scopes: ['mcp', `role:${env.MCP_STDIO_ROLE}`],
+        expiresAt: Math.floor(Date.now() / 1000) + 60 * 60,
+      },
+    }),
+  {
+    onerror: (error) => {
+      logger.error('stdio.server_error', {
+        error: error.message,
+      });
+    },
+  },
+);


### PR DESCRIPTION
## Resumen

Este PR agrega soporte local por `stdio` al `mcp-server` de SafeTech para facilitar pruebas y consumo desde clientes MCP como Codex, sin cambiar el comportamiento del transporte HTTP remoto existente.

## Cambios realizados

- se extrajo un bootstrap compartido del `mcp-server`
- se agregó un entrypoint local por `stdio`
- se agregaron scripts para ejecutar el servidor en modo local
- se agregaron variables de entorno para identidad local en pruebas
- se ajustó el entrypoint HTTP para reutilizar el bootstrap compartido
- se actualizó la documentación para explicar el uso local con clientes MCP
- se ajustó el fixture de pruebas para reflejar las nuevas variables de entorno

## Validaciones ejecutadas

- `npm run build --prefix mcp-server`
- `npm test --prefix mcp-server`

## Alcance y decisiones

- este PR agrega una capacidad de infraestructura para desarrollo y pruebas locales
- no cambia la lógica de negocio de las tools MCP
- no modifica la autenticación del transporte HTTP remoto
- no agrega tools nuevas de negocio

## Riesgos o pendientes

- el modo `stdio` usa una identidad local controlada por variables de entorno para pruebas
- la documentación puede ampliarse después con ejemplos específicos para más clientes MCP si el equipo lo necesita
