### PR TITLE
HU-31: paginacion en el catalogo de productos

### DIFF
--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -11,6 +11,7 @@ export const getProducts = async (c: Context) => {
       maxPrice?: number;
       available?: 'true' | 'false';
       limit?: number;
+      page?: number;
     };
 
     const hasFilters = Object.values(query).some((value) => value !== undefined);
@@ -33,11 +34,22 @@ export const getProducts = async (c: Context) => {
     if (query.available === 'true') filter.stock = { $gt: 0 };
     if (query.available === 'false') filter.stock = { $lte: 0 };
 
-    const products = await Product.find(filter)
-      .sort({ price: 1 })
-      .limit(query.limit ?? 20);
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
 
-    return c.json({ success: true, data: products });
+    const [products, total] = await Promise.all([
+      Product.find(filter)
+        .sort({ price: 1 })
+        .skip((page - 1) * limit)
+        .limit(limit),
+      Product.countDocuments(filter),
+    ]);
+
+    return c.json({
+      success: true,
+      data: products,
+      pagination: { page, limit, total },
+    });
   } catch (error: any) {
     return c.json({ success: false, message: error.message }, 500);
   }

--- a/backend/src/validators/product.validator.ts
+++ b/backend/src/validators/product.validator.ts
@@ -33,6 +33,7 @@ export const productFilterSchema = z
     maxPrice: z.coerce.number().min(0, 'maxPrice debe ser 0 o un valor positivo').optional(),
     available: z.enum(['true', 'false']).optional(),
     limit: z.coerce.number().int().min(1).max(50).optional(),
+    page: z.coerce.number().int().min(1).optional(),
   })
   .refine((data) => data.minPrice === undefined || data.maxPrice === undefined || data.minPrice <= data.maxPrice, {
     message: 'minPrice no puede ser mayor que maxPrice',

--- a/e2e/product-pagination.spec.ts
+++ b/e2e/product-pagination.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from '@playwright/test';
+import { resetE2EState } from './helpers';
+
+const API_URL = 'http://127.0.0.1:3001/api';
+const ADMIN_AUTH = { Authorization: 'Bearer mock:admin:e2e-admin' };
+
+// resetE2EState ya siembra 2 productos (iPhone/celular/A/stock8/$499 y
+// MacBook/laptop/A/stock5/$899). Se agregan variantes para tener suficiente
+// volumen y poder ejercer paginacion combinada con filtros.
+const extraProducts = [
+  { name: 'PC Reacondicionada B', description: 'x', price: 300, stock: 0, condition: 'B', category: 'pc' },
+  { name: 'Auriculares C baratos', description: 'x', price: 50, stock: 10, condition: 'C', category: 'auriculares' },
+  { name: 'Tablet A premium', description: 'x', price: 700, stock: 3, condition: 'A', category: 'tablet' },
+];
+
+test.beforeEach(async ({ request }) => {
+  await resetE2EState(request);
+  for (const product of extraProducts) {
+    const response = await request.post(`${API_URL}/products`, { headers: ADMIN_AUTH, data: product });
+    expect(response.status()).toBe(201);
+  }
+});
+
+test('sin page/limit no incluye metadata de paginacion (compatibilidad con el catalogo publico)', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data.length).toBe(2 + extraProducts.length);
+  expect(body.pagination).toBeUndefined();
+});
+
+test('page/limit devuelven pagina, limite y total', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?page=1&limit=2`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data).toHaveLength(2);
+  expect(body.pagination).toEqual({ page: 1, limit: 2, total: 5 });
+});
+
+test('avanza a la siguiente pagina sin repetir productos', async ({ request }) => {
+  const page1 = await (await request.get(`${API_URL}/products?page=1&limit=2`)).json();
+  const page2 = await (await request.get(`${API_URL}/products?page=2&limit=2`)).json();
+
+  expect(page1.data).toHaveLength(2);
+  expect(page2.data).toHaveLength(2);
+  expect(page2.pagination).toEqual({ page: 2, limit: 2, total: 5 });
+
+  const idsPage1 = page1.data.map((p: { _id: string }) => p._id);
+  const idsPage2 = page2.data.map((p: { _id: string }) => p._id);
+  expect(idsPage1.some((id: string) => idsPage2.includes(id))).toBe(false);
+});
+
+test('la ultima pagina puede devolver menos elementos que el limite', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?page=3&limit=2`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data).toHaveLength(1);
+  expect(body.pagination).toEqual({ page: 3, limit: 2, total: 5 });
+});
+
+test('una pagina fuera de rango devuelve una lista vacia con el total correcto', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?page=10&limit=2`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data).toEqual([]);
+  expect(body.pagination).toEqual({ page: 10, limit: 2, total: 5 });
+});
+
+test('la paginacion se combina con filtros de busqueda', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?condition=A&page=1&limit=1`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data).toHaveLength(1);
+  expect(body.data[0].condition).toBe('A');
+  // 3 productos con condition A: iPhone, MacBook, Tablet A premium
+  expect(body.pagination).toEqual({ page: 1, limit: 1, total: 3 });
+});
+
+test('sin page explicito, usar solo un filtro sigue defaulteando a la pagina 1', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?condition=A`);
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.pagination.page).toBe(1);
+  expect(body.pagination.total).toBe(3);
+});
+
+test('rechaza una pagina invalida', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products?page=0`);
+  expect(response.status()).toBe(400);
+});

--- a/frontend/src/components/ProductList.tsx
+++ b/frontend/src/components/ProductList.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { useProducts } from '../hooks/useProducts';
+import { useProductsPaginated } from '../hooks/useProducts';
 import { useCartStore } from '../store/cart.store';
 import { SkeletonCard } from './ui/Skeleton';
 import { EmptyState } from './ui/EmptyState';
@@ -57,18 +57,18 @@ export const ProductList: React.FC = () => {
     [search, category, condition, priceIdx]
   );
 
-  const { data: products, isLoading, isError, error } = useProducts(filters);
+  const { data: result, isLoading, isError, error } = useProductsPaginated({
+    ...filters,
+    page,
+    limit: ITEMS_PER_PAGE,
+  });
+  const products = result?.data;
+  const totalPages = Math.max(1, Math.ceil((result?.pagination.total ?? 0) / ITEMS_PER_PAGE));
+  const paginatedProducts = products ?? [];
   const addItem = useCartStore((s) => s.addItem);
   const toggleDrawer = useCartStore((s) => s.toggleDrawer);
 
   useEffect(() => setPage(1), [filters]);
-
-  const totalPages = Math.ceil((products?.length ?? 0) / ITEMS_PER_PAGE);
-  const paginatedProducts = useMemo(() => {
-    if (!products) return [];
-    const start = (page - 1) * ITEMS_PER_PAGE;
-    return products.slice(start, start + ITEMS_PER_PAGE);
-  }, [products, page]);
 
   const handlePageChange = (newPage: number) => {
     if (newPage >= 1 && newPage <= totalPages) {
@@ -102,8 +102,8 @@ export const ProductList: React.FC = () => {
     <div>
       <FilterBar category={category} setCategory={setCategory} condition={condition} setCondition={setCondition} priceIdx={priceIdx} setPriceIdx={setPriceIdx} search={search} setSearch={setSearch} />
 
-      {/* Productos destacados (solo si no hay filtros activos) */}
-      {!search && !category && !condition && priceIdx === 0 && (
+      {/* Productos destacados (solo si no hay filtros activos, en la primera pagina) */}
+      {!search && !category && !condition && priceIdx === 0 && page === 1 && (
         <div style={{ marginBottom: '3rem' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '1.5rem' }}>
             <h2 style={{ fontSize: '1.25rem', fontWeight: 400, color: 'var(--ink)', fontFamily: 'var(--font-display)', letterSpacing: '-0.01em' }}>Productos destacados</h2>

--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -1,12 +1,20 @@
 import { useQuery } from '@tanstack/react-query';
 import { productsService } from '../services/products.service';
 import type { Product } from '../types/product';
-import type { ProductFilters } from '../services/products.service';
+import type { PaginatedProducts, ProductFilters } from '../services/products.service';
 
 export const useProducts = (filters?: ProductFilters) => {
   return useQuery<Product[], Error>({
     queryKey: ['products', filters],
     queryFn: () => productsService.getAll(filters),
+  });
+};
+
+export const useProductsPaginated = (filters?: ProductFilters) => {
+  return useQuery<PaginatedProducts, Error>({
+    queryKey: ['products', 'paginated', filters],
+    queryFn: () => productsService.getAllPaginated(filters),
+    placeholderData: (previousData) => previousData,
   });
 };
 

--- a/frontend/src/services/products.service.ts
+++ b/frontend/src/services/products.service.ts
@@ -28,6 +28,19 @@ export interface ProductFilters {
   condition?: string;
   minPrice?: number;
   maxPrice?: number;
+  page?: number;
+  limit?: number;
+}
+
+export interface ProductPagination {
+  page: number;
+  limit: number;
+  total: number;
+}
+
+export interface PaginatedProducts {
+  data: Product[];
+  pagination: ProductPagination;
 }
 
 function buildQueryString(filters?: ProductFilters): string {
@@ -42,6 +55,8 @@ function buildQueryString(filters?: ProductFilters): string {
   if (filters.maxPrice !== undefined && !Number.isNaN(filters.maxPrice)) {
     params.set('maxPrice', String(filters.maxPrice));
   }
+  if (filters.page !== undefined) params.set('page', String(filters.page));
+  if (filters.limit !== undefined) params.set('limit', String(filters.limit));
   const qs = params.toString();
   return qs ? `?${qs}` : '';
 }
@@ -57,6 +72,24 @@ export const productsService = {
     }
     const result = await response.json();
     return result.data || [];
+  },
+
+  // Usa page/limit del backend (HU-31); a diferencia de getAll(), no descarta
+  // la metadata de paginacion que necesita el catalogo para armar el paginador.
+  async getAllPaginated(filters?: ProductFilters, token?: string): Promise<PaginatedProducts> {
+    const response = await fetch(`${API_URL}/products${buildQueryString(filters)}`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (!response.ok) {
+      const result = await response.json().catch(() => ({}));
+      throw new Error(result?.message || result?.errors?.[0]?.message || 'Failed to fetch products');
+    }
+    const result = await response.json();
+    const data: Product[] = result.data || [];
+    return {
+      data,
+      pagination: result.pagination ?? { page: 1, limit: data.length, total: data.length },
+    };
   },
 
   async getById(id: string, token?: string): Promise<Product> {


### PR DESCRIPTION
## Summary
- HU-31 pide que el catalogo soporte paginacion: la API debe devolver pagina, limite y total; el frontend debe poder avanzar/retroceder entre paginas; y la paginacion debe combinarse con los filtros existentes (HU-29/HU-30).
- `GET /api/products` ahora acepta `page` (entero >= 1) junto a `limit`. Igual que con los demas filtros, cuando se envia al menos un parametro de query la respuesta incluye `pagination: { page, limit, total }` (con `total` via `countDocuments` sobre el mismo filtro).
- **Compatibilidad con consumidores existentes**: una llamada sin ningun parametro sigue devolviendo el catalogo completo sin `pagination` ni acotar — asi `FeaturedProducts` y las estadisticas del panel admin (`ProductTable`), que dependen del listado completo, no se ven afectados.
- En el frontend se agrega `productsService.getAllPaginated` + `useProductsPaginated` (sin tocar `getAll`/`useProducts`, que siguen usando los consumidores actuales) y `ProductList` pasa de paginar en el cliente (slice sobre el array completo) a pedir `page`/`limit` reales al backend.
- La seccion "Productos destacados" del catalogo ahora solo se renderiza en la pagina 1, para no repetirse al navegar entre paginas.

## Test plan
- [x] `npx playwright test e2e/product-pagination.spec.ts` — 8/8 pasan (metadata de paginacion, avance sin solapamiento, ultima pagina parcial, pagina fuera de rango, combinacion con filtros, pagina invalida rechazada).
- [x] `npx playwright test` (suite completa) — 46/46 pasan, sin regresiones.
- [x] Verificacion manual en navegador: catalogo con 27 productos sembrados, paginado en bloques de 12, navegacion "Siguiente" muestra productos 13-24 sin duplicados ni "Productos destacados" repetido.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)