### PR TITLE
HU-32: registrar direcciones de entrega

### DIFF
--- a/backend/src/controllers/address.controller.ts
+++ b/backend/src/controllers/address.controller.ts
@@ -1,0 +1,68 @@
+import { Context } from 'hono';
+import { Address } from '../models/Address';
+
+export const getMyAddresses = async (c: Context) => {
+  try {
+    const userId = c.get('userId');
+    const addresses = await Address.find({ userId }).sort({ isDefault: -1, createdAt: -1 });
+    return c.json({ success: true, data: addresses });
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};
+
+export const createAddress = async (c: Context) => {
+  try {
+    const userId = c.get('userId');
+    const data = c.req.valid('json' as any) as Record<string, unknown>;
+
+    if (data.isDefault) {
+      await Address.updateMany({ userId }, { isDefault: false });
+    }
+
+    const address = await Address.create({ ...data, userId });
+    return c.json({ success: true, data: address }, 201);
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};
+
+export const updateAddress = async (c: Context) => {
+  try {
+    const userId = c.get('userId');
+    const id = c.req.param('id');
+    const data = c.req.valid('json' as any) as Record<string, unknown>;
+
+    const address = await Address.findOne({ _id: id, userId });
+    if (!address) {
+      return c.json({ success: false, message: 'Direccion no encontrada' }, 404);
+    }
+
+    if (data.isDefault) {
+      await Address.updateMany({ userId, _id: { $ne: id } }, { isDefault: false });
+    }
+
+    Object.assign(address, data);
+    await address.save();
+
+    return c.json({ success: true, data: address });
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};
+
+export const deleteAddress = async (c: Context) => {
+  try {
+    const userId = c.get('userId');
+    const id = c.req.param('id');
+
+    const deleted = await Address.findOneAndDelete({ _id: id, userId });
+    if (!deleted) {
+      return c.json({ success: false, message: 'Direccion no encontrada' }, 404);
+    }
+
+    return c.json({ success: true, message: 'Direccion eliminada correctamente' });
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};

--- a/backend/src/controllers/checkout.controller.ts
+++ b/backend/src/controllers/checkout.controller.ts
@@ -3,6 +3,7 @@ import Stripe from 'stripe';
 import { Product } from '../models/Product';
 import { Order } from '../models/Order';
 import { OrderItem } from '../models/OrderItem';
+import { Address } from '../models/Address';
 import { Types } from 'mongoose';
 import { isE2ETestMode } from '../lib/e2e';
 
@@ -53,6 +54,33 @@ export const createPaymentIntentController = async (c: Context) => {
     const invalidId = cartItems.find((item) => !Types.ObjectId.isValid(item.productId));
     if (invalidId) {
       return c.json({ error: `Invalid productId format: ${invalidId.productId}` }, 400);
+    }
+
+    // Direccion de entrega guardada (HU-32): opcional; si se envia, debe
+    // pertenecer al usuario autenticado. Se guarda como snapshot en la
+    // orden, no como referencia viva a la Address.
+    const addressId = body.addressId as string | undefined;
+    let shippingAddress: Record<string, string> | undefined;
+
+    if (addressId !== undefined) {
+      if (typeof addressId !== 'string' || !Types.ObjectId.isValid(addressId)) {
+        return c.json({ error: 'Invalid addressId format' }, 400);
+      }
+
+      const address = await Address.findOne({ _id: addressId, userId });
+      if (!address) {
+        return c.json({ error: 'Direccion de entrega no encontrada' }, 400);
+      }
+
+      shippingAddress = {
+        recipientName: address.recipientName,
+        phone: address.phone,
+        street: address.street,
+        city: address.city,
+        state: address.state,
+        zipCode: address.zipCode,
+        country: address.country,
+      };
     }
 
     const productIds = cartItems.map((item) => new Types.ObjectId(item.productId));
@@ -142,6 +170,7 @@ export const createPaymentIntentController = async (c: Context) => {
           total_amount: totalAmount,
           status: 'pending',
           payment_intent_id: e2ePaymentIntentId,
+          shippingAddress,
           items: validItems.map((item) => ({
             product: item.product._id,
             quantity: item.quantity,
@@ -160,6 +189,7 @@ export const createPaymentIntentController = async (c: Context) => {
       } else {
         order.total_amount = totalAmount;
         order.payment_intent_id = e2ePaymentIntentId;
+        if (shippingAddress) order.shippingAddress = shippingAddress;
         await order.save();
       }
 
@@ -224,6 +254,7 @@ export const createPaymentIntentController = async (c: Context) => {
         total_amount: totalAmount,
         status: 'pending',
         payment_intent_id: paymentIntent.id,
+        shippingAddress,
         items: validItems.map((item) => ({
           product: item.product._id,
           quantity: item.quantity,
@@ -243,6 +274,7 @@ export const createPaymentIntentController = async (c: Context) => {
       // Reusing an existing pending order — keep amount + PI in sync.
       order.total_amount = totalAmount;
       order.payment_intent_id = paymentIntent.id;
+      if (shippingAddress) order.shippingAddress = shippingAddress;
       await order.save();
     }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,6 +11,7 @@ import webhookRoutes from './routes/webhook.routes';
 import orderRoutes from './routes/order.routes';
 import authRoutes from './routes/auth.routes';
 import technicianRoutes from './routes/technician.routes';
+import addressRoutes from './routes/address.routes';
 import e2eRoutes from './routes/e2e.routes';
 import { isE2ETestMode } from './lib/e2e';
 
@@ -34,6 +35,7 @@ app.route('/api/webhooks', webhookRoutes);
 app.route('/api/orders', orderRoutes);
 app.route('/api/auth', authRoutes);
 app.route('/api/technicians', technicianRoutes);
+app.route('/api/addresses', addressRoutes);
 if (isE2ETestMode) {
   app.route('/api/e2e', e2eRoutes);
 }

--- a/backend/src/models/Address.ts
+++ b/backend/src/models/Address.ts
@@ -1,0 +1,32 @@
+import { Schema, model, Document } from 'mongoose';
+
+export interface IAddress extends Document {
+  userId: string;
+  recipientName: string;
+  phone: string;
+  street: string;
+  city: string;
+  state: string;
+  zipCode: string;
+  country: string;
+  isDefault: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const addressSchema = new Schema<IAddress>(
+  {
+    userId: { type: String, required: true, index: true },
+    recipientName: { type: String, required: true },
+    phone: { type: String, required: true },
+    street: { type: String, required: true },
+    city: { type: String, required: true },
+    state: { type: String, required: true },
+    zipCode: { type: String, required: true },
+    country: { type: String, required: true },
+    isDefault: { type: Boolean, default: false },
+  },
+  { timestamps: true }
+);
+
+export const Address = model<IAddress>('Address', addressSchema);

--- a/backend/src/models/Order.ts
+++ b/backend/src/models/Order.ts
@@ -8,6 +8,18 @@ const orderSchema = new Schema({
   stripe_session_id: { type: String, index: true },
   // New field — used by embedded Payment Element flow.
   payment_intent_id: { type: String, index: true },
+  // Snapshot de la direccion de entrega seleccionada al momento del checkout
+  // (no una referencia viva a Address, para que la orden no cambie si el
+  // usuario despues edita o borra esa direccion guardada).
+  shippingAddress: {
+    recipientName: { type: String },
+    phone: { type: String },
+    street: { type: String },
+    city: { type: String },
+    state: { type: String },
+    zipCode: { type: String },
+    country: { type: String },
+  },
   items: [{
     product: { type: Schema.Types.ObjectId, ref: 'Product' },
     quantity: { type: Number, required: true },

--- a/backend/src/routes/address.routes.ts
+++ b/backend/src/routes/address.routes.ts
@@ -1,0 +1,44 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import {
+  createAddress,
+  deleteAddress,
+  getMyAddresses,
+  updateAddress,
+} from '../controllers/address.controller';
+import { createAddressSchema, updateAddressSchema } from '../validators/address.validator';
+import { clerkAuthMiddleware } from '../middlewares/auth.middleware';
+
+const addressRoutes = new Hono();
+
+addressRoutes.use('*', clerkAuthMiddleware);
+
+// Listar las direcciones guardadas del usuario autenticado
+addressRoutes.get('/', getMyAddresses);
+
+// Crear una direccion de entrega
+addressRoutes.post(
+  '/',
+  zValidator('json', createAddressSchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  createAddress
+);
+
+// Editar una direccion propia
+addressRoutes.put(
+  '/:id',
+  zValidator('json', updateAddressSchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  updateAddress
+);
+
+// Eliminar una direccion propia
+addressRoutes.delete('/:id', deleteAddress);
+
+export default addressRoutes;

--- a/backend/src/routes/e2e.routes.ts
+++ b/backend/src/routes/e2e.routes.ts
@@ -5,6 +5,7 @@ import { OrderItem } from '../models/OrderItem';
 import { WarrantyReport } from '../models/WarrantyReport';
 import { Technician } from '../models/Technician';
 import { User } from '../models/User';
+import { Address } from '../models/Address';
 import { isE2ETestMode } from '../lib/e2e';
 
 const e2eRoutes = new Hono();
@@ -25,6 +26,7 @@ e2eRoutes.post('/reset', async (c) => {
     Product.deleteMany({}),
     Technician.deleteMany({}),
     User.deleteMany({}),
+    Address.deleteMany({}),
   ]);
 
   await User.insertMany([

--- a/backend/src/validators/address.validator.ts
+++ b/backend/src/validators/address.validator.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+const addressFields = {
+  recipientName: z.string().min(1, 'El nombre del destinatario es requerido'),
+  phone: z.string().min(1, 'El telefono es requerido'),
+  street: z.string().min(1, 'La calle es requerida'),
+  city: z.string().min(1, 'La ciudad es requerida'),
+  state: z.string().min(1, 'La provincia/estado es requerido'),
+  zipCode: z.string().min(1, 'El codigo postal es requerido'),
+  country: z.string().min(1, 'El pais es requerido'),
+  isDefault: z.boolean().optional(),
+};
+
+export const createAddressSchema = z.object(addressFields);
+
+export const updateAddressSchema = z.object(addressFields).partial();

--- a/e2e/address-management.spec.ts
+++ b/e2e/address-management.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test } from '@playwright/test';
+import { resetE2EState } from './helpers';
+
+const API_URL = 'http://127.0.0.1:3001/api';
+const USER_AUTH = { Authorization: 'Bearer mock:user:e2e-user' };
+const OTHER_USER_AUTH = { Authorization: 'Bearer mock:user:e2e-other-user' };
+
+const validAddress = {
+  recipientName: 'Ana Aparicio',
+  phone: '+507 6123-4567',
+  street: 'Calle 50, Edificio Plaza',
+  city: 'Ciudad de Panama',
+  state: 'Panama',
+  zipCode: '0801',
+  country: 'Panama',
+};
+
+test.beforeEach(async ({ request }) => {
+  await resetE2EState(request);
+});
+
+test('rechaza listar direcciones sin token', async ({ request }) => {
+  const response = await request.get(`${API_URL}/addresses`);
+  expect(response.status()).toBe(401);
+});
+
+test('crea una direccion valida', async ({ request }) => {
+  const response = await request.post(`${API_URL}/addresses`, { headers: USER_AUTH, data: validAddress });
+  expect(response.status()).toBe(201);
+  const body = await response.json();
+  expect(body.data.recipientName).toBe(validAddress.recipientName);
+  expect(body.data.userId).toBe('e2e-user');
+});
+
+test('rechaza crear una direccion con campos faltantes', async ({ request }) => {
+  const response = await request.post(`${API_URL}/addresses`, {
+    headers: USER_AUTH,
+    data: { recipientName: 'Ana Aparicio' },
+  });
+  expect(response.status()).toBe(400);
+});
+
+test('lista solo las direcciones propias del usuario autenticado', async ({ request }) => {
+  await request.post(`${API_URL}/addresses`, { headers: USER_AUTH, data: validAddress });
+  await request.post(`${API_URL}/addresses`, {
+    headers: OTHER_USER_AUTH,
+    data: { ...validAddress, recipientName: 'Otro Usuario' },
+  });
+
+  const response = await request.get(`${API_URL}/addresses`, { headers: USER_AUTH });
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data).toHaveLength(1);
+  expect(body.data[0].recipientName).toBe('Ana Aparicio');
+});
+
+test('la primera direccion marcada default desmarca las demas', async ({ request }) => {
+  const first = await (
+    await request.post(`${API_URL}/addresses`, { headers: USER_AUTH, data: { ...validAddress, isDefault: true } })
+  ).json();
+  const second = await (
+    await request.post(`${API_URL}/addresses`, {
+      headers: USER_AUTH,
+      data: { ...validAddress, recipientName: 'Segunda direccion', isDefault: true },
+    })
+  ).json();
+
+  const list = await (await request.get(`${API_URL}/addresses`, { headers: USER_AUTH })).json();
+  const byId = Object.fromEntries(list.data.map((a: { _id: string; isDefault: boolean }) => [a._id, a.isDefault]));
+
+  expect(byId[first.data._id]).toBe(false);
+  expect(byId[second.data._id]).toBe(true);
+});
+
+test('edita una direccion propia', async ({ request }) => {
+  const created = await (
+    await request.post(`${API_URL}/addresses`, { headers: USER_AUTH, data: validAddress })
+  ).json();
+
+  const response = await request.put(`${API_URL}/addresses/${created.data._id}`, {
+    headers: USER_AUTH,
+    data: { city: 'David' },
+  });
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data.city).toBe('David');
+  expect(body.data.street).toBe(validAddress.street);
+});
+
+test('rechaza editar una direccion de otro usuario', async ({ request }) => {
+  const created = await (
+    await request.post(`${API_URL}/addresses`, { headers: USER_AUTH, data: validAddress })
+  ).json();
+
+  const response = await request.put(`${API_URL}/addresses/${created.data._id}`, {
+    headers: OTHER_USER_AUTH,
+    data: { city: 'David' },
+  });
+  expect(response.status()).toBe(404);
+});
+
+test('elimina una direccion propia', async ({ request }) => {
+  const created = await (
+    await request.post(`${API_URL}/addresses`, { headers: USER_AUTH, data: validAddress })
+  ).json();
+
+  const deleteResponse = await request.delete(`${API_URL}/addresses/${created.data._id}`, { headers: USER_AUTH });
+  expect(deleteResponse.status()).toBe(200);
+
+  const list = await (await request.get(`${API_URL}/addresses`, { headers: USER_AUTH })).json();
+  expect(list.data).toEqual([]);
+});
+
+test('rechaza eliminar una direccion de otro usuario', async ({ request }) => {
+  const created = await (
+    await request.post(`${API_URL}/addresses`, { headers: USER_AUTH, data: validAddress })
+  ).json();
+
+  const response = await request.delete(`${API_URL}/addresses/${created.data._id}`, { headers: OTHER_USER_AUTH });
+  expect(response.status()).toBe(404);
+});
+
+test('el checkout acepta una direccion guardada y la snapshotea en la orden', async ({ request }) => {
+  const address = await (
+    await request.post(`${API_URL}/addresses`, { headers: USER_AUTH, data: validAddress })
+  ).json();
+
+  const productsResponse = await request.get(`${API_URL}/products`);
+  const products = (await productsResponse.json()).data;
+  const productId = products[0]._id;
+
+  const checkoutResponse = await request.post(`${API_URL}/checkout`, {
+    headers: USER_AUTH,
+    data: { items: [{ productId, quantity: 1 }], addressId: address.data._id },
+  });
+  expect(checkoutResponse.status()).toBe(200);
+  const checkoutBody = await checkoutResponse.json();
+
+  const ordersResponse = await request.get(`${API_URL}/orders/mine`, { headers: USER_AUTH });
+  const orders = await ordersResponse.json();
+  const order = orders.find((o: { _id: string }) => o._id === checkoutBody.orderId);
+  expect(order.shippingAddress?.city).toBe(validAddress.city);
+});
+
+test('el checkout rechaza un addressId que no pertenece al usuario', async ({ request }) => {
+  const address = await (
+    await request.post(`${API_URL}/addresses`, { headers: USER_AUTH, data: validAddress })
+  ).json();
+
+  const productsResponse = await request.get(`${API_URL}/products`);
+  const products = (await productsResponse.json()).data;
+  const productId = products[0]._id;
+
+  const checkoutResponse = await request.post(`${API_URL}/checkout`, {
+    headers: OTHER_USER_AUTH,
+    data: { items: [{ productId, quantity: 1 }], addressId: address.data._id },
+  });
+  expect(checkoutResponse.status()).toBe(400);
+});

--- a/frontend/src/hooks/useAddresses.ts
+++ b/frontend/src/hooks/useAddresses.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '../lib/auth';
+import { addressesService } from '../services/addresses.service';
+import type { Address, AddressDTO } from '../services/addresses.service';
+
+export const useAddresses = () => {
+  const { getToken, isSignedIn } = useAuth();
+
+  return useQuery<Address[], Error>({
+    queryKey: ['addresses'],
+    queryFn: async () => {
+      const token = await getToken();
+      if (!token) throw new Error('No autenticado');
+      return addressesService.getMine(token);
+    },
+    enabled: Boolean(isSignedIn),
+  });
+};
+
+export const useCreateAddress = () => {
+  const { getToken } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation<Address, Error, AddressDTO>({
+    mutationFn: async (data) => {
+      const token = await getToken();
+      if (!token) throw new Error('No autenticado');
+      return addressesService.create(data, token);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['addresses'] }),
+  });
+};
+
+export const useDeleteAddress = () => {
+  const { getToken } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, string>({
+    mutationFn: async (id) => {
+      const token = await getToken();
+      if (!token) throw new Error('No autenticado');
+      return addressesService.delete(id, token);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['addresses'] }),
+  });
+};

--- a/frontend/src/pages/Checkout.tsx
+++ b/frontend/src/pages/Checkout.tsx
@@ -6,6 +6,7 @@ import { loadStripe } from '@stripe/stripe-js';
 import { checkoutService } from '../services/checkout.service';
 import { ordersService } from '../services/orders.service';
 import { useCartStore } from '../store/cart.store';
+import { useAddresses, useCreateAddress } from '../hooks/useAddresses';
 
 const stripePublishableKey = import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY as string | undefined;
 const stripePromise = stripePublishableKey ? loadStripe(stripePublishableKey) : null;
@@ -124,7 +125,16 @@ export default function Checkout() {
   const [error, setError] = useState<string | null>(null);
   const [isCreatingIntent, setIsCreatingIntent] = useState(false);
   const [isConfirmingTestPayment, setIsConfirmingTestPayment] = useState(false);
+  const [selectedAddressId, setSelectedAddressId] = useState<string | null>(null);
   const createdSignatureRef = useRef<string | null>(null);
+
+  const { data: addresses } = useAddresses();
+
+  useEffect(() => {
+    if (selectedAddressId || !addresses || addresses.length === 0) return;
+    const defaultAddress = addresses.find((a) => a.isDefault) ?? addresses[0];
+    setSelectedAddressId(defaultAddress._id);
+  }, [addresses, selectedAddressId]);
 
   const cartPayload = useMemo(
     () => items.map((item) => ({ productId: item._id, quantity: item.quantity })),
@@ -132,10 +142,10 @@ export default function Checkout() {
   );
 
   const clientSubtotal = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
-  const cartSignature = cartPayload
-    .map((item) => `${item.productId}:${item.quantity}`)
-    .sort()
-    .join('|');
+  const cartSignature = [
+    cartPayload.map((item) => `${item.productId}:${item.quantity}`).sort().join('|'),
+    selectedAddressId ?? '',
+  ].join('::');
 
   useEffect(() => {
     const createIntent = async () => {
@@ -149,7 +159,7 @@ export default function Checkout() {
       try {
         const token = await getToken();
         if (!token) throw new Error('No autenticado');
-        const response = await checkoutService.createPaymentIntent(cartPayload, token);
+        const response = await checkoutService.createPaymentIntent(cartPayload, token, selectedAddressId ?? undefined);
         setClientSecret(response.clientSecret);
         setPaymentIntentId(response.paymentIntentId ?? null);
         setServerAmount(response.amount);
@@ -162,7 +172,7 @@ export default function Checkout() {
     };
 
     createIntent();
-  }, [cartPayload, cartSignature, getToken, isLoaded, isSignedIn]);
+  }, [cartPayload, cartSignature, getToken, isLoaded, isSignedIn, selectedAddressId]);
 
   const handleTestPayment = async () => {
     if (!paymentIntentId) return;
@@ -267,50 +277,59 @@ export default function Checkout() {
 
       <main className="op-body">
         <div className="page-container checkout-grid">
-          <section className="oc-card" style={{ padding: '1.5rem' }}>
-            <h2 style={{ fontFamily: 'var(--font-display)', fontSize: '1rem', marginBottom: '1rem' }}>
-              Datos de pago
-            </h2>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+            <section className="oc-card" style={{ padding: '1.5rem' }}>
+              <h2 style={{ fontFamily: 'var(--font-display)', fontSize: '1rem', marginBottom: '1rem' }}>
+                Direccion de entrega
+              </h2>
+              <AddressPicker selectedAddressId={selectedAddressId} onSelect={setSelectedAddressId} />
+            </section>
 
-            {isCreatingIntent && <p style={{ color: 'var(--ink2)' }}>Preparando formulario de pago...</p>}
-            {error && <div className="alert alert-error">{error}</div>}
+            <section className="oc-card" style={{ padding: '1.5rem' }}>
+              <h2 style={{ fontFamily: 'var(--font-display)', fontSize: '1rem', marginBottom: '1rem' }}>
+                Datos de pago
+              </h2>
 
-            {isE2ETestMode && paymentIntentId && serverAmount !== null && (
-              <div style={{ display: 'grid', gap: '1rem' }}>
-                <div className="alert alert-success">
-                  Modo de prueba activo. El pago se confirma localmente sin usar Stripe.
+              {isCreatingIntent && <p style={{ color: 'var(--ink2)' }}>Preparando formulario de pago...</p>}
+              {error && <div className="alert alert-error">{error}</div>}
+
+              {isE2ETestMode && paymentIntentId && serverAmount !== null && (
+                <div style={{ display: 'grid', gap: '1rem' }}>
+                  <div className="alert alert-success">
+                    Modo de prueba activo. El pago se confirma localmente sin usar Stripe.
+                  </div>
+                  <button
+                    className="btn-primary"
+                    type="button"
+                    onClick={handleTestPayment}
+                    disabled={isConfirmingTestPayment}
+                    data-testid="test-payment-button"
+                    style={{ width: '100%', padding: '14px', justifyContent: 'center' }}
+                  >
+                    {isConfirmingTestPayment ? 'Confirmando pago...' : `Confirmar pago de prueba por $${serverAmount.toFixed(2)}`}
+                  </button>
                 </div>
-                <button
-                  className="btn-primary"
-                  type="button"
-                  onClick={handleTestPayment}
-                  disabled={isConfirmingTestPayment}
-                  data-testid="test-payment-button"
-                  style={{ width: '100%', padding: '14px', justifyContent: 'center' }}
-                >
-                  {isConfirmingTestPayment ? 'Confirmando pago...' : `Confirmar pago de prueba por $${serverAmount.toFixed(2)}`}
-                </button>
-              </div>
-            )}
+              )}
 
-            {!isE2ETestMode && clientSecret && serverAmount !== null && (
-              <Elements
-                stripe={stripePromise}
-                options={{
-                  clientSecret,
-                  appearance: {
-                    theme: 'stripe',
-                    variables: {
-                      colorPrimary: '#171614',
-                      borderRadius: '8px',
+              {!isE2ETestMode && clientSecret && serverAmount !== null && (
+                <Elements
+                  stripe={stripePromise}
+                  options={{
+                    clientSecret,
+                    appearance: {
+                      theme: 'stripe',
+                      variables: {
+                        colorPrimary: '#171614',
+                        borderRadius: '8px',
+                      },
                     },
-                  },
-                }}
-              >
-                <CheckoutForm amount={serverAmount} clientSecret={clientSecret} />
-              </Elements>
-            )}
-          </section>
+                  }}
+                >
+                  <CheckoutForm amount={serverAmount} clientSecret={clientSecret} />
+                </Elements>
+              )}
+            </section>
+          </div>
 
           <aside className="oc-card" style={{ padding: '1.25rem' }}>
             <h2 style={{ fontFamily: 'var(--font-display)', fontSize: '1rem', marginBottom: '1rem' }}>
@@ -334,6 +353,120 @@ export default function Checkout() {
           </aside>
         </div>
       </main>
+    </div>
+  );
+}
+
+const emptyAddressForm = {
+  recipientName: '',
+  phone: '',
+  street: '',
+  city: '',
+  state: '',
+  zipCode: '',
+  country: '',
+};
+
+function AddressPicker({
+  selectedAddressId,
+  onSelect,
+}: {
+  selectedAddressId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  const { data: addresses, isLoading } = useAddresses();
+  const createAddress = useCreateAddress();
+  const [isAdding, setIsAdding] = useState(false);
+  const [form, setForm] = useState(emptyAddressForm);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const handleFormChange = (field: keyof typeof emptyAddressForm) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm((prev) => ({ ...prev, [field]: e.target.value }));
+  };
+
+  const handleAddAddress = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError(null);
+
+    if (Object.values(form).some((value) => !value.trim())) {
+      setFormError('Todos los campos son obligatorios.');
+      return;
+    }
+
+    try {
+      const created = await createAddress.mutateAsync({ ...form, isDefault: !addresses || addresses.length === 0 });
+      onSelect(created._id);
+      setForm(emptyAddressForm);
+      setIsAdding(false);
+    } catch (err: any) {
+      setFormError(err.message || 'No pudimos guardar la direccion.');
+    }
+  };
+
+  if (isLoading) {
+    return <p style={{ color: 'var(--ink2)' }}>Cargando direcciones...</p>;
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+      {addresses && addresses.length > 0 && (
+        <div role="radiogroup" aria-label="Direcciones guardadas" style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          {addresses.map((address) => (
+            <label
+              key={address._id}
+              style={{
+                display: 'flex',
+                gap: '0.6rem',
+                alignItems: 'flex-start',
+                border: `1px solid ${selectedAddressId === address._id ? 'var(--ink)' : 'var(--line)'}`,
+                borderRadius: 'var(--radius-ui)',
+                padding: '0.75rem',
+                cursor: 'pointer',
+              }}
+            >
+              <input
+                type="radio"
+                name="shipping-address"
+                checked={selectedAddressId === address._id}
+                onChange={() => onSelect(address._id)}
+                style={{ marginTop: 4 }}
+              />
+              <span style={{ fontSize: '0.85rem', lineHeight: 1.5 }}>
+                <strong>{address.recipientName}</strong>{address.isDefault ? ' · Predeterminada' : ''}<br />
+                {address.street}, {address.city}, {address.state}, {address.zipCode}, {address.country}<br />
+                {address.phone}
+              </span>
+            </label>
+          ))}
+        </div>
+      )}
+
+      {!isAdding ? (
+        <button type="button" className="btn-outline" onClick={() => setIsAdding(true)} style={{ alignSelf: 'flex-start' }}>
+          + Agregar direccion
+        </button>
+      ) : (
+        <form onSubmit={handleAddAddress} style={{ display: 'grid', gap: '0.5rem', gridTemplateColumns: '1fr 1fr' }}>
+          <input className="input" placeholder="Nombre de quien recibe" value={form.recipientName} onChange={handleFormChange('recipientName')} style={{ gridColumn: '1 / -1' }} />
+          <input className="input" placeholder="Telefono" value={form.phone} onChange={handleFormChange('phone')} />
+          <input className="input" placeholder="Calle y numero" value={form.street} onChange={handleFormChange('street')} />
+          <input className="input" placeholder="Ciudad" value={form.city} onChange={handleFormChange('city')} />
+          <input className="input" placeholder="Provincia/Estado" value={form.state} onChange={handleFormChange('state')} />
+          <input className="input" placeholder="Codigo postal" value={form.zipCode} onChange={handleFormChange('zipCode')} />
+          <input className="input" placeholder="Pais" value={form.country} onChange={handleFormChange('country')} />
+
+          {formError && <div className="alert alert-error" style={{ gridColumn: '1 / -1' }}>{formError}</div>}
+
+          <div style={{ gridColumn: '1 / -1', display: 'flex', gap: '0.5rem' }}>
+            <button type="submit" className="btn-primary" disabled={createAddress.isPending}>
+              {createAddress.isPending ? 'Guardando...' : 'Guardar direccion'}
+            </button>
+            <button type="button" className="btn-outline" onClick={() => setIsAdding(false)}>
+              Cancelar
+            </button>
+          </div>
+        </form>
+      )}
     </div>
   );
 }

--- a/frontend/src/services/addresses.service.ts
+++ b/frontend/src/services/addresses.service.ts
@@ -1,0 +1,73 @@
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
+
+export interface Address {
+  _id: string;
+  userId: string;
+  recipientName: string;
+  phone: string;
+  street: string;
+  city: string;
+  state: string;
+  zipCode: string;
+  country: string;
+  isDefault: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AddressDTO {
+  recipientName: string;
+  phone: string;
+  street: string;
+  city: string;
+  state: string;
+  zipCode: string;
+  country: string;
+  isDefault?: boolean;
+}
+
+async function parseErrorOrJson(response: Response) {
+  if (!response.ok) {
+    const result = await response.json().catch(() => ({}));
+    throw new Error(result?.message || result?.errors?.[0]?.message || 'Failed to reach addresses API');
+  }
+  return response.json();
+}
+
+export const addressesService = {
+  async getMine(token: string): Promise<Address[]> {
+    const response = await fetch(`${API_URL}/addresses`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const result = await parseErrorOrJson(response);
+    return result.data || [];
+  },
+
+  async create(data: AddressDTO, token: string): Promise<Address> {
+    const response = await fetch(`${API_URL}/addresses`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify(data),
+    });
+    const result = await parseErrorOrJson(response);
+    return result.data;
+  },
+
+  async update(id: string, data: Partial<AddressDTO>, token: string): Promise<Address> {
+    const response = await fetch(`${API_URL}/addresses/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify(data),
+    });
+    const result = await parseErrorOrJson(response);
+    return result.data;
+  },
+
+  async delete(id: string, token: string): Promise<void> {
+    const response = await fetch(`${API_URL}/addresses/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    await parseErrorOrJson(response);
+  },
+};

--- a/frontend/src/services/checkout.service.ts
+++ b/frontend/src/services/checkout.service.ts
@@ -11,6 +11,7 @@ export const checkoutService = {
   createPaymentIntent: async (
     items: { productId: string; quantity: number }[],
     token: string,
+    addressId?: string,
   ): Promise<CreatePaymentIntentResponse> => {
     const response = await fetch(`${BACKEND_URL}/api/checkout`, {
       method: 'POST',
@@ -18,7 +19,7 @@ export const checkoutService = {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify({ items }),
+      body: JSON.stringify({ items, ...(addressId ? { addressId } : {}) }),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- HU-32 pide que el comprador pueda registrar direcciones de entrega (CRUD), seleccionar una guardada en el checkout, y que el sistema valide los campos obligatorios.
- Nuevo modelo `Address` (`recipientName`, `phone`, `street`, `city`, `state`, `zipCode`, `country`, `isDefault`) con CRUD scoped al usuario autenticado en `/api/addresses` (`clerkAuthMiddleware`, igual que warranties). Marcar una direccion `isDefault` desmarca automaticamente las demas del mismo usuario. Editar/eliminar una direccion de otro usuario devuelve `404` (no se filtra su existencia entre cuentas).
- `POST /api/checkout` acepta un `addressId` opcional; si se envia, se valida que pertenezca al usuario autenticado y se guarda como **snapshot** en `Order.shippingAddress` (no como referencia viva a `Address`, para que la orden no cambie si despues se edita o borra esa direccion).
- Frontend: `addressesService` + `useAddresses`/`useCreateAddress`, y un selector de direcciones en `Checkout.tsx` (arriba de "Datos de pago") que lista las guardadas, preselecciona la default, y permite agregar una nueva sin salir del checkout. El `addressId` seleccionado viaja al crear el PaymentIntent.
- Compatibilidad: `addressId` es opcional en el checkout — el flujo e2e existente (`transaction.spec.ts`, sin direcciones guardadas) sigue funcionando igual.

## Test plan
- [x] `npx playwright test e2e/address-management.spec.ts` — 11/11 pasan (CRUD, aislamiento por usuario con 401/404, logica de default unico, snapshot en checkout, rechazo de `addressId` ajeno).
- [x] `npx playwright test` (suite completa) — 49/49 pasan, sin regresiones.
- [x] Verificacion manual en navegador: agregar direccion desde el checkout, quedar preseleccionada, agregar una segunda y alternar entre ambas con el radio group.

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)