### PR TITLE
HU-33: informacion de envio y tracking en la orden

### DIFF
--- a/backend/src/controllers/order.controller.ts
+++ b/backend/src/controllers/order.controller.ts
@@ -253,3 +253,30 @@ export const confirmOrderPayment = async (c: Context) => {
     return c.json({ error: 'Failed to confirm payment' }, 500);
   }
 };
+
+export const updateShippingInfo = async (c: Context) => {
+  try {
+    const id = c.req.param('id');
+    const data = c.req.valid('json' as any) as {
+      status?: 'processing' | 'shipped' | 'delivered';
+      carrier?: string;
+      trackingNumber?: string;
+    };
+
+    const order = await Order.findById(id);
+    if (!order) {
+      return c.json({ error: 'Order not found' }, 404);
+    }
+
+    if (data.status !== undefined) order.status = data.status;
+    if (data.carrier !== undefined) order.carrier = data.carrier;
+    if (data.trackingNumber !== undefined) order.trackingNumber = data.trackingNumber;
+
+    await order.save();
+
+    return c.json(order);
+  } catch (error) {
+    console.error('Error updating shipping info:', error);
+    return c.json({ error: 'Failed to update shipping info' }, 500);
+  }
+};

--- a/backend/src/models/Order.ts
+++ b/backend/src/models/Order.ts
@@ -3,7 +3,14 @@ import { Schema, model } from 'mongoose';
 const orderSchema = new Schema({
   userId: { type: String, required: true },
   total_amount: { type: Number, required: true },
-  status: { type: String, enum: ['pending', 'paid', 'shipped', 'failed'], default: 'pending' },
+  status: {
+    type: String,
+    enum: ['pending', 'paid', 'processing', 'shipped', 'delivered', 'failed'],
+    default: 'pending',
+  },
+  // Info de envio y tracking (HU-33): se completan cuando el admin despacha la orden.
+  carrier: { type: String },
+  trackingNumber: { type: String },
   // Legacy field — kept for back-compat with old hosted-checkout orders.
   stripe_session_id: { type: String, index: true },
   // New field — used by embedded Payment Element flow.

--- a/backend/src/routes/order.routes.ts
+++ b/backend/src/routes/order.routes.ts
@@ -1,6 +1,8 @@
 import { Hono } from 'hono';
-import { getMyOrders, getOrderBySession, getAllOrders, confirmOrderPayment } from '../controllers/order.controller';
+import { zValidator } from '@hono/zod-validator';
+import { getMyOrders, getOrderBySession, getAllOrders, confirmOrderPayment, updateShippingInfo } from '../controllers/order.controller';
 import { clerkAuthMiddleware, adminAuthMiddleware } from '../middlewares/auth.middleware';
+import { updateShippingSchema } from '../validators/order.validator';
 
 const orderRouter = new Hono();
 
@@ -8,5 +10,17 @@ orderRouter.get('/mine', clerkAuthMiddleware, getMyOrders);
 orderRouter.get('/by-session/:sessionId', clerkAuthMiddleware, getOrderBySession);
 orderRouter.post('/confirm-payment', clerkAuthMiddleware, confirmOrderPayment);
 orderRouter.get('/', adminAuthMiddleware, getAllOrders);
+
+// Actualizar info de envio y tracking de una orden (solo admin)
+orderRouter.put(
+  '/:id/shipping',
+  adminAuthMiddleware,
+  zValidator('json', updateShippingSchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  updateShippingInfo
+);
 
 export default orderRouter;

--- a/backend/src/validators/order.validator.ts
+++ b/backend/src/validators/order.validator.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const updateShippingSchema = z.object({
+  status: z.enum(['processing', 'shipped', 'delivered']).optional(),
+  carrier: z.string().min(1).optional(),
+  trackingNumber: z.string().min(1).optional(),
+}).refine((data) => Object.values(data).some((value) => value !== undefined), {
+  message: 'Debe enviar al menos status, carrier o trackingNumber',
+});

--- a/e2e/order-shipping-tracking.spec.ts
+++ b/e2e/order-shipping-tracking.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from '@playwright/test';
+import { resetE2EState } from './helpers';
+
+const API_URL = 'http://127.0.0.1:3001/api';
+const USER_AUTH = { Authorization: 'Bearer mock:user:e2e-user' };
+const ADMIN_AUTH = { Authorization: 'Bearer mock:admin:e2e-admin' };
+
+async function getSeededOrderId(request: import('@playwright/test').APIRequestContext) {
+  const response = await request.get(`${API_URL}/orders/mine`, { headers: USER_AUTH });
+  const orders = await response.json();
+  return orders[0]._id as string;
+}
+
+test.beforeEach(async ({ request }) => {
+  await resetE2EState(request);
+});
+
+test('rechaza actualizar envio sin token', async ({ request }) => {
+  const orderId = await getSeededOrderId(request);
+  const response = await request.put(`${API_URL}/orders/${orderId}/shipping`, { data: { status: 'shipped' } });
+  expect(response.status()).toBe(401);
+});
+
+test('rechaza actualizar envio si el usuario no es admin', async ({ request }) => {
+  const orderId = await getSeededOrderId(request);
+  const response = await request.put(`${API_URL}/orders/${orderId}/shipping`, {
+    headers: USER_AUTH,
+    data: { status: 'shipped' },
+  });
+  expect(response.status()).toBe(403);
+});
+
+test('un admin actualiza el estado, transportista y numero de seguimiento', async ({ request }) => {
+  const orderId = await getSeededOrderId(request);
+
+  const response = await request.put(`${API_URL}/orders/${orderId}/shipping`, {
+    headers: ADMIN_AUTH,
+    data: { status: 'shipped', carrier: 'DHL', trackingNumber: 'DHL123456789' },
+  });
+  expect(response.status()).toBe(200);
+  const updated = await response.json();
+  expect(updated.status).toBe('shipped');
+  expect(updated.carrier).toBe('DHL');
+  expect(updated.trackingNumber).toBe('DHL123456789');
+});
+
+test('el cliente ve la info de envio en su historial de pedidos', async ({ request }) => {
+  const orderId = await getSeededOrderId(request);
+
+  await request.put(`${API_URL}/orders/${orderId}/shipping`, {
+    headers: ADMIN_AUTH,
+    data: { status: 'processing', carrier: 'Correos de Panama', trackingNumber: 'CP-000111' },
+  });
+
+  const response = await request.get(`${API_URL}/orders/mine`, { headers: USER_AUTH });
+  const orders = await response.json();
+  const order = orders.find((o: { _id: string }) => o._id === orderId);
+
+  expect(order.status).toBe('processing');
+  expect(order.carrier).toBe('Correos de Panama');
+  expect(order.trackingNumber).toBe('CP-000111');
+});
+
+test('soporta la transicion completa processing -> shipped -> delivered', async ({ request }) => {
+  const orderId = await getSeededOrderId(request);
+
+  for (const status of ['processing', 'shipped', 'delivered']) {
+    const response = await request.put(`${API_URL}/orders/${orderId}/shipping`, {
+      headers: ADMIN_AUTH,
+      data: { status },
+    });
+    expect(response.status()).toBe(200);
+    expect((await response.json()).status).toBe(status);
+  }
+});
+
+test('rechaza un estado invalido', async ({ request }) => {
+  const orderId = await getSeededOrderId(request);
+  const response = await request.put(`${API_URL}/orders/${orderId}/shipping`, {
+    headers: ADMIN_AUTH,
+    data: { status: 'en-camino' },
+  });
+  expect(response.status()).toBe(400);
+});
+
+test('rechaza un body vacio', async ({ request }) => {
+  const orderId = await getSeededOrderId(request);
+  const response = await request.put(`${API_URL}/orders/${orderId}/shipping`, {
+    headers: ADMIN_AUTH,
+    data: {},
+  });
+  expect(response.status()).toBe(400);
+});
+
+test('devuelve 404 para una orden inexistente', async ({ request }) => {
+  const response = await request.put(`${API_URL}/orders/000000000000000000000000/shipping`, {
+    headers: ADMIN_AUTH,
+    data: { status: 'shipped' },
+  });
+  expect(response.status()).toBe(404);
+});

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '../lib/auth';
 import { warrantyService } from '../services/warranty.service';
@@ -18,22 +19,26 @@ type SectionType = 'dashboard' | 'orders' | 'warranties' | 'products' | 'technic
 const PAGE_SIZE = 10;
 
 const statusVariant: Record<string, 'success' | 'warning' | 'error' | 'neutral'> = {
-  paid:      'success',
-  pending:   'warning',
-  review:    'neutral',
-  resolved:  'success',
-  rejected:  'error',
-  refunded:  'error',
-  shipped:   'neutral',
+  paid:       'success',
+  pending:    'warning',
+  review:     'neutral',
+  resolved:   'success',
+  rejected:   'error',
+  refunded:   'error',
+  processing: 'neutral',
+  shipped:    'neutral',
+  delivered:  'success',
 };
 const statusLabel: Record<string, string> = {
-  paid:      'Pagado',
-  pending:   'Pendiente',
-  review:    'En revisión',
-  resolved:  'Resuelto',
-  rejected:  'Rechazado',
-  refunded:  'Reembolsado',
-  shipped:   'Enviado',
+  paid:       'Pagado',
+  pending:    'Pendiente',
+  review:     'En revisión',
+  resolved:   'Resuelto',
+  rejected:   'Rechazado',
+  refunded:   'Reembolsado',
+  processing: 'En preparación',
+  shipped:    'Enviado',
+  delivered:  'Entregado',
 };
 
 const formatDate = (d: string | Date) =>
@@ -280,6 +285,18 @@ export default function AdminDashboard() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['technicians'] }),
   });
 
+  const updateShippingMutation = useMutation({
+    mutationFn: async ({ orderId, data }: { orderId: string; data: { status?: 'processing' | 'shipped' | 'delivered'; carrier?: string; trackingNumber?: string } }) => {
+      const token = await getToken();
+      if (!token) throw new Error('No token');
+      return ordersService.updateShipping(orderId, data, token);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['admin-orders'] }),
+  });
+
+  const [managingOrderId, setManagingOrderId] = useState<string | null>(null);
+  const [shippingForm, setShippingForm] = useState<{ status: '' | 'processing' | 'shipped' | 'delivered'; carrier: string; trackingNumber: string }>({ status: '', carrier: '', trackingNumber: '' });
+
   const handleSectionChange = (section: string) => {
     setActiveSection(section as SectionType);
     setOrdersPage(1);
@@ -364,21 +381,23 @@ export default function AdminDashboard() {
                       <th>Total</th>
                       <th>Items</th>
                       <th>Estado</th>
+                      <th>Envío</th>
                     </tr>
                   </thead>
                   <tbody>
                     {ordersLoading
-                      ? Array.from({ length: 6 }).map((_, i) => <SkeletonTableRow key={i} cols={5} />)
+                      ? Array.from({ length: 6 }).map((_, i) => <SkeletonTableRow key={i} cols={6} />)
                       : pagedOrders.length === 0
                         ? (
                           <tr>
-                            <td colSpan={5} style={{ padding: '3rem', textAlign: 'center', color: 'var(--ink3)', fontSize: '0.9rem' }}>
+                            <td colSpan={6} style={{ padding: '3rem', textAlign: 'center', color: 'var(--ink3)', fontSize: '0.9rem' }}>
                               No hay órdenes registradas.
                             </td>
                           </tr>
                         )
                         : pagedOrders.map((order) => (
-                          <tr key={order._id}>
+                          <React.Fragment key={order._id}>
+                          <tr>
                             <td style={{ fontWeight: 500 }}>{formatDate(order.createdAt)}</td>
                             <td style={{ color: 'var(--ink2)', fontSize: '0.85rem' }}>
                               {(order as any).userDoc?.email || order.userId || '—'}
@@ -396,7 +415,76 @@ export default function AdminDashboard() {
                                 {statusLabel[order.status] ?? order.status}
                               </Badge>
                             </td>
+                            <td>
+                              <button
+                                type="button"
+                                className="btn-outline"
+                                style={{ padding: '4px 10px', fontSize: '0.75rem' }}
+                                onClick={() => {
+                                  if (managingOrderId === order._id) {
+                                    setManagingOrderId(null);
+                                    return;
+                                  }
+                                  setManagingOrderId(order._id);
+                                  setShippingForm({
+                                    status: (['processing', 'shipped', 'delivered'].includes(order.status) ? order.status : '') as '' | 'processing' | 'shipped' | 'delivered',
+                                    carrier: order.carrier ?? '',
+                                    trackingNumber: order.trackingNumber ?? '',
+                                  });
+                                }}
+                              >
+                                {order.carrier || order.trackingNumber ? 'Editar envío' : 'Gestionar envío'}
+                              </button>
+                            </td>
                           </tr>
+                          {managingOrderId === order._id && (
+                            <tr>
+                              <td colSpan={6} style={{ background: 'var(--gray-light)', padding: '1rem' }}>
+                                <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}>
+                                  <select
+                                    className="input"
+                                    value={shippingForm.status}
+                                    onChange={(e) => setShippingForm((f) => ({ ...f, status: e.target.value as typeof f.status }))}
+                                  >
+                                    <option value="">Sin cambio de estado</option>
+                                    <option value="processing">En preparación</option>
+                                    <option value="shipped">Enviado</option>
+                                    <option value="delivered">Entregado</option>
+                                  </select>
+                                  <input
+                                    className="input"
+                                    placeholder="Transportista"
+                                    value={shippingForm.carrier}
+                                    onChange={(e) => setShippingForm((f) => ({ ...f, carrier: e.target.value }))}
+                                  />
+                                  <input
+                                    className="input"
+                                    placeholder="Numero de seguimiento"
+                                    value={shippingForm.trackingNumber}
+                                    onChange={(e) => setShippingForm((f) => ({ ...f, trackingNumber: e.target.value }))}
+                                  />
+                                  <button
+                                    type="button"
+                                    className="btn-primary"
+                                    disabled={updateShippingMutation.isPending}
+                                    onClick={() => {
+                                      const data: { status?: 'processing' | 'shipped' | 'delivered'; carrier?: string; trackingNumber?: string } = {};
+                                      if (shippingForm.status) data.status = shippingForm.status;
+                                      if (shippingForm.carrier.trim()) data.carrier = shippingForm.carrier.trim();
+                                      if (shippingForm.trackingNumber.trim()) data.trackingNumber = shippingForm.trackingNumber.trim();
+                                      updateShippingMutation.mutate(
+                                        { orderId: order._id, data },
+                                        { onSuccess: () => setManagingOrderId(null) },
+                                      );
+                                    }}
+                                  >
+                                    {updateShippingMutation.isPending ? 'Guardando...' : 'Guardar'}
+                                  </button>
+                                </div>
+                              </td>
+                            </tr>
+                          )}
+                          </React.Fragment>
                         ))
                     }
                   </tbody>

--- a/frontend/src/pages/Orders.tsx
+++ b/frontend/src/pages/Orders.tsx
@@ -33,10 +33,13 @@ const pad = (n: number) => String(n).padStart(3, '0');
 
 // ── Status map ─────────────────────────────────────────────────────────────
 const ST = {
-  paid:      { label: 'Pagado',    glyph: '●', ink: '#065f46', bg: 'rgba(16,185,129,0.12)', rim: 'rgba(16,185,129,0.35)', bar: '#10b981' },
-  pending:   { label: 'Pendiente', glyph: '◐', ink: '#92400e', bg: 'rgba(245,158,11,0.12)', rim: 'rgba(245,158,11,0.35)', bar: '#f59e0b' },
-  failed:    { label: 'Fallido',   glyph: '✕', ink: '#991b1b', bg: 'rgba(239,68,68,0.12)',  rim: 'rgba(239,68,68,0.35)',  bar: '#ef4444' },
-  cancelled: { label: 'Cancelado', glyph: '○', ink: '#4b5563', bg: 'rgba(107,114,128,0.1)', rim: 'rgba(107,114,128,0.3)', bar: '#9ca3af' },
+  paid:       { label: 'Pagado',       glyph: '●', ink: '#065f46', bg: 'rgba(16,185,129,0.12)', rim: 'rgba(16,185,129,0.35)', bar: '#10b981' },
+  pending:    { label: 'Pendiente',    glyph: '◐', ink: '#92400e', bg: 'rgba(245,158,11,0.12)', rim: 'rgba(245,158,11,0.35)', bar: '#f59e0b' },
+  processing: { label: 'En preparación', glyph: '◐', ink: '#1e40af', bg: 'rgba(59,130,246,0.12)', rim: 'rgba(59,130,246,0.35)', bar: '#3b82f6' },
+  shipped:    { label: 'Enviado',      glyph: '➤', ink: '#3730a3', bg: 'rgba(99,102,241,0.12)', rim: 'rgba(99,102,241,0.35)', bar: '#6366f1' },
+  delivered:  { label: 'Entregado',    glyph: '✓', ink: '#065f46', bg: 'rgba(16,185,129,0.12)', rim: 'rgba(16,185,129,0.35)', bar: '#10b981' },
+  failed:     { label: 'Fallido',      glyph: '✕', ink: '#991b1b', bg: 'rgba(239,68,68,0.12)',  rim: 'rgba(239,68,68,0.35)',  bar: '#ef4444' },
+  cancelled:  { label: 'Cancelado',    glyph: '○', ink: '#4b5563', bg: 'rgba(107,114,128,0.1)', rim: 'rgba(107,114,128,0.3)', bar: '#9ca3af' },
 } as const;
 type StatusKey = keyof typeof ST;
 const getST = (s: string) => ST[(s as StatusKey)] ?? ST.cancelled;
@@ -80,7 +83,17 @@ function ArcProgress({ pct, color, size = 52 }: { pct: number; color: string; si
 
 // ── OrderType ──────────────────────────────────────────────────────────────
 type Item = { quantity: number; price: number; product?: { name?: string; image_urls?: string[] } };
-type OrderT = { _id: string; createdAt?: string; status: string; total_amount?: number; items: Item[] };
+type ShippingAddressT = { recipientName: string; street: string; city: string; state: string; zipCode: string; country: string };
+type OrderT = {
+  _id: string;
+  createdAt?: string;
+  status: string;
+  total_amount?: number;
+  items: Item[];
+  shippingAddress?: ShippingAddressT;
+  carrier?: string;
+  trackingNumber?: string;
+};
 
 // ── Order Card ─────────────────────────────────────────────────────────────
 const OrderCard: React.FC<{ order: OrderT; idx: number }> = ({ order, idx }) => {
@@ -235,6 +248,23 @@ const OrderCard: React.FC<{ order: OrderT; idx: number }> = ({ order, idx }) => 
               </div>
             ))}
           </div>
+
+          {(order.shippingAddress || order.carrier || order.trackingNumber) && (
+            <div className="oc-shipping">
+              {order.shippingAddress && (
+                <p className="oc-shipping-line">
+                  {order.shippingAddress.recipientName} — {order.shippingAddress.street}, {order.shippingAddress.city}, {order.shippingAddress.state}, {order.shippingAddress.zipCode}, {order.shippingAddress.country}
+                </p>
+              )}
+              {(order.carrier || order.trackingNumber) && (
+                <p className="oc-shipping-line">
+                  {order.carrier ? `Transportista: ${order.carrier}` : ''}
+                  {order.carrier && order.trackingNumber ? ' · ' : ''}
+                  {order.trackingNumber ? `Seguimiento: ${order.trackingNumber}` : ''}
+                </p>
+              )}
+            </div>
+          )}
 
           <div className="oc-drawer-foot">
             <span className="oc-foot-label">Total del pedido</span>
@@ -885,6 +915,20 @@ const Orders: React.FC = () => {
           font-weight: 400;
           color: rgba(244,244,242,.85);
           flex-shrink: 0;
+        }
+
+        .oc-shipping {
+          padding: 1rem 2rem;
+          border-top: 1px solid rgba(244,244,242,.08);
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+        }
+        .oc-shipping-line {
+          font-family: var(--st-font-sans);
+          font-size: .8rem;
+          color: rgba(244,244,242,.65);
+          margin: 0;
         }
 
         .oc-drawer-foot {

--- a/frontend/src/services/orders.service.ts
+++ b/frontend/src/services/orders.service.ts
@@ -35,5 +35,17 @@ export const ordersService = {
       }
     });
     return response.data;
+  },
+  updateShipping: async (
+    orderId: string,
+    data: { status?: 'processing' | 'shipped' | 'delivered'; carrier?: string; trackingNumber?: string },
+    token: string,
+  ): Promise<Order> => {
+    const response = await axios.put(`${API_URL}/orders/${orderId}/shipping`, data, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    });
+    return response.data;
   }
 };

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -7,14 +7,27 @@ export interface OrderItem {
   price: number;
 }
 
+export interface ShippingAddress {
+  recipientName: string;
+  phone: string;
+  street: string;
+  city: string;
+  state: string;
+  zipCode: string;
+  country: string;
+}
+
 export interface Order {
   _id: string;
   userId: string;
   userDoc?: { email?: string };
   total_amount: number;
-  status: 'pending' | 'paid' | 'shipped' | 'failed';
+  status: 'pending' | 'paid' | 'processing' | 'shipped' | 'delivered' | 'failed';
   stripe_session_id?: string;
   payment_intent_id?: string;
+  shippingAddress?: ShippingAddress;
+  carrier?: string;
+  trackingNumber?: string;
   items: OrderItem[];
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary
- HU-33 pide que la orden guarde direccion, transportista y numero de seguimiento, soporte estados adicionales (`processing`, `shipped`, `delivered`) y que el cliente pueda consultar esa info desde su historial de pedidos.
- `Order.status` pasa de `['pending','paid','shipped','failed']` a `['pending','paid','processing','shipped','delivered','failed']`, y se agregan los campos `carrier` y `trackingNumber` (la direccion de entrega ya se persiste en `Order.shippingAddress` desde HU-32, en el PR #204).
- Nuevo endpoint `PUT /api/orders/:id/shipping` (solo admin) para actualizar `status`/`carrier`/`trackingNumber` de forma parcial (exige al menos un campo).
- Admin dashboard: la tabla de ordenes suma una columna "Envío" con un formulario inline (estado + transportista + tracking) para gestionar el despacho sin salir de la tabla.
- Historial de pedidos del cliente (`Orders.tsx`): el badge de estado reconoce `processing`/`shipped`/`delivered`, y el detalle expandido de cada pedido muestra la direccion de entrega y transportista/seguimiento cuando existen.

## Test plan
- [x] `npx playwright test e2e/order-shipping-tracking.spec.ts` — 8/8 pasan (autorizacion 401/403, transicion completa `processing -> shipped -> delivered`, estado invalido y body vacio rechazados con 400, 404 en orden inexistente, y el cliente ve la info actualizada en `/orders/mine`).
- [x] `npx playwright test` (suite completa) — 46/46 pasan, sin regresiones.
- [x] Verificacion manual en navegador: admin marca una orden como "Enviado" con transportista/tracking desde el dashboard, y el cliente lo ve reflejado en su historial de pedidos.

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)