### PR TITLE
HU-34: correos transaccionales de compra, garantia y ordenes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ R2_SECRET_ACCESS_KEY=
 R2_ENDPOINT=
 R2_BUCKET_NAME=
 R2_PUBLIC_URL=
+RESEND_API_KEY=
+EMAIL_FROM=
 ```
 
 **`frontend/.env.local`**
@@ -79,6 +81,8 @@ All routes are mounted in `index.ts` under `/api/*`. Each feature follows the pa
 **Clerk sync**: `POST /api/webhooks/clerk` handles `user.created`, `user.updated`, and `user.deleted` to keep the local `User` collection in sync with Clerk.
 
 **File uploads** (`upload.controller.ts` + `r2.service.ts`): generates presigned R2 URLs for direct browser uploads.
+
+**Transactional emails** (`services/email.service.ts`): sends purchase confirmations, warranty-created, and warranty/order status-change notifications via the Resend HTTP API (`RESEND_API_KEY`/`EMAIL_FROM`). Without `RESEND_API_KEY` it logs to the console instead of sending. In `E2E_TEST_MODE` it captures messages in memory, inspectable via `GET /api/e2e/emails`.
 
 ### Frontend (`frontend/src/`)
 

--- a/backend/src/controllers/order.controller.ts
+++ b/backend/src/controllers/order.controller.ts
@@ -2,8 +2,10 @@ import { Context } from 'hono';
 import Stripe from 'stripe';
 import { Order } from '../models/Order';
 import { OrderItem } from '../models/OrderItem';
-import { finalizePaidOrder } from '../services/order.service';
+import { User } from '../models/User';
+import { finalizePaidOrder, notifyPurchaseConfirmed } from '../services/order.service';
 import { isE2EPaymentIntent, isE2ETestMode } from '../lib/e2e';
+import { sendOrderStatusChangedEmail } from '../services/email.service';
 
 const getStripeClient = () => {
   const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
@@ -145,6 +147,10 @@ export const confirmOrderPayment = async (c: Context) => {
         false,
       );
 
+      if (!confirmation.wasAlreadyPaid) {
+        await notifyPurchaseConfirmed(userId, confirmation.lockedOrder);
+      }
+
       const paidOrder = await Order.findById(confirmation.lockedOrder._id).lean();
       const relatedItems = await OrderItem.find({ order_id: confirmation.lockedOrder._id }).populate('product_id').lean();
       const items = relatedItems.map((item) => ({
@@ -228,6 +234,10 @@ export const confirmOrderPayment = async (c: Context) => {
         );
       }
 
+      if (!confirmation.wasAlreadyPaid) {
+        await notifyPurchaseConfirmed(userId, confirmation.lockedOrder);
+      }
+
       const paidOrder = await Order.findById(confirmation.lockedOrder._id).lean();
       const relatedItems = await OrderItem.find({ order_id: confirmation.lockedOrder._id }).populate('product_id').lean();
       const items = relatedItems.map((item) => ({
@@ -268,11 +278,20 @@ export const updateShippingInfo = async (c: Context) => {
       return c.json({ error: 'Order not found' }, 404);
     }
 
+    const statusChanged = data.status !== undefined && data.status !== order.status;
+
     if (data.status !== undefined) order.status = data.status;
     if (data.carrier !== undefined) order.carrier = data.carrier;
     if (data.trackingNumber !== undefined) order.trackingNumber = data.trackingNumber;
 
     await order.save();
+
+    if (statusChanged) {
+      const owner = await User.findOne({ clerk_id: order.userId });
+      if (owner?.email) {
+        await sendOrderStatusChangedEmail(owner.email, order);
+      }
+    }
 
     return c.json(order);
   } catch (error) {

--- a/backend/src/controllers/warranty.controller.ts
+++ b/backend/src/controllers/warranty.controller.ts
@@ -1,6 +1,8 @@
 import { Context } from 'hono';
 import { WarrantyReport } from '../models/WarrantyReport';
 import { Order } from '../models/Order';
+import { User } from '../models/User';
+import { sendWarrantyCreatedEmail, sendWarrantyStatusChangedEmail } from '../services/email.service';
 
 export const createWarrantyReport = async (c: Context) => {
   try {
@@ -53,6 +55,11 @@ export const createWarrantyReport = async (c: Context) => {
 
     await report.save();
 
+    const reporter = await User.findOne({ clerk_id: userId });
+    if (reporter?.email) {
+      await sendWarrantyCreatedEmail(reporter.email, report);
+    }
+
     return c.json({
       ticketId: report._id,
       status: report.status
@@ -95,9 +102,11 @@ export const updateWarrantyStatus = async (c: Context) => {
 
     if (!report) return c.json({ error: 'Report not found' }, 404);
 
+    let statusChanged = false;
     if (body.status) {
       const previousStatus = report.status;
       report.status = body.status;
+      statusChanged = previousStatus !== body.status;
       if (body.status === 'resolved' && (previousStatus !== 'resolved' || !report.resolvedAt)) {
         report.resolvedAt = new Date();
       } else if (body.status !== 'resolved') {
@@ -110,6 +119,14 @@ export const updateWarrantyStatus = async (c: Context) => {
     }
 
     await report.save();
+
+    if (statusChanged) {
+      const owner = await User.findOne({ clerk_id: report.userId });
+      if (owner?.email) {
+        await sendWarrantyStatusChangedEmail(owner.email, report);
+      }
+    }
+
     return c.json(report);
   } catch (error: any) {
     return c.json({ error: error.message }, 400);
@@ -125,6 +142,10 @@ export const assignTechnician = async (c: Context) => {
       return c.json({ error: 'Missing technicianId or technicianName' }, 400);
     }
 
+    const previous = await WarrantyReport.findById(id);
+    if (!previous) return c.json({ error: 'Report not found' }, 404);
+    const statusChanged = previous.status !== 'review';
+
     const report = await WarrantyReport.findByIdAndUpdate(
       id,
       {
@@ -137,6 +158,14 @@ export const assignTechnician = async (c: Context) => {
     );
 
     if (!report) return c.json({ error: 'Report not found' }, 404);
+
+    if (statusChanged) {
+      const owner = await User.findOne({ clerk_id: report.userId });
+      if (owner?.email) {
+        await sendWarrantyStatusChangedEmail(owner.email, report);
+      }
+    }
+
     return c.json(report);
   } catch (error: any) {
     return c.json({ error: error.message }, 400);
@@ -172,9 +201,11 @@ export const technicianUpdateWarranty = async (c: Context) => {
       return c.json({ error: 'Invalid status' }, 400);
     }
 
+    let statusChanged = false;
     if (body.status) {
       const previousStatus = report.status;
       report.status = body.status;
+      statusChanged = previousStatus !== body.status;
       if (body.status === 'resolved' && (previousStatus !== 'resolved' || !report.resolvedAt)) {
         report.resolvedAt = new Date();
       } else if (body.status !== 'resolved') {
@@ -183,6 +214,14 @@ export const technicianUpdateWarranty = async (c: Context) => {
     }
     if (body.repairNotes !== undefined) report.repairNotes = body.repairNotes;
     await report.save();
+
+    if (statusChanged) {
+      const owner = await User.findOne({ clerk_id: report.userId });
+      if (owner?.email) {
+        await sendWarrantyStatusChangedEmail(owner.email, report);
+      }
+    }
+
     return c.json(report);
   } catch (error: any) {
     return c.json({ error: error.message }, 400);

--- a/backend/src/controllers/webhook.controller.ts
+++ b/backend/src/controllers/webhook.controller.ts
@@ -2,7 +2,7 @@ import { Context } from 'hono';
 import Stripe from 'stripe';
 import { User } from '../models/User';
 import { Order } from '../models/Order';
-import { finalizePaidOrder } from '../services/order.service';
+import { finalizePaidOrder, notifyPurchaseConfirmed } from '../services/order.service';
 
 export const stripeWebhookController = async (c: Context) => {
   const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
@@ -67,6 +67,8 @@ export const stripeWebhookController = async (c: Context) => {
           console.warn('[Stripe Webhook] MongoDB transactions unsupported, retrying without transaction.');
           await finalizePaidOrder(clerkUserId, orderId, paymentIntent.id, false);
         }
+
+        await notifyPurchaseConfirmed(clerkUserId, order);
 
         console.log('[Stripe Webhook] Order marked as paid:', orderId);
         break;

--- a/backend/src/routes/e2e.routes.ts
+++ b/backend/src/routes/e2e.routes.ts
@@ -7,6 +7,7 @@ import { Technician } from '../models/Technician';
 import { User } from '../models/User';
 import { Address } from '../models/Address';
 import { isE2ETestMode } from '../lib/e2e';
+import { clearSentEmails, getSentEmails } from '../services/email.service';
 
 const e2eRoutes = new Hono();
 
@@ -19,6 +20,8 @@ e2eRoutes.use('*', async (c, next) => {
 });
 
 e2eRoutes.post('/reset', async (c) => {
+  clearSentEmails();
+
   await Promise.all([
     WarrantyReport.deleteMany({}),
     OrderItem.deleteMany({}),
@@ -95,6 +98,12 @@ e2eRoutes.post('/reset', async (c) => {
       laptop: laptop._id,
     },
   });
+});
+
+// Inspeccion de correos "enviados" durante E2E_TEST_MODE (HU-34), para poder
+// verificar desde los tests que se dispararon sin depender de un proveedor real.
+e2eRoutes.get('/emails', (c) => {
+  return c.json({ emails: getSentEmails() });
 });
 
 export default e2eRoutes;

--- a/backend/src/services/email.service.ts
+++ b/backend/src/services/email.service.ts
@@ -1,0 +1,111 @@
+import { isE2ETestMode } from '../lib/e2e';
+
+export interface SentEmail {
+  to: string;
+  subject: string;
+  html: string;
+  sentAt: string;
+}
+
+// Captura en memoria de los correos "enviados" durante E2E_TEST_MODE, para
+// poder verificarlos desde los tests sin depender de un proveedor real.
+const sentEmails: SentEmail[] = [];
+
+export function getSentEmails(): SentEmail[] {
+  return sentEmails;
+}
+
+export function clearSentEmails(): void {
+  sentEmails.length = 0;
+}
+
+async function sendEmail(to: string, subject: string, html: string): Promise<void> {
+  const message: SentEmail = { to, subject, html, sentAt: new Date().toISOString() };
+
+  if (isE2ETestMode) {
+    sentEmails.push(message);
+    return;
+  }
+
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.EMAIL_FROM || 'SafeTech <no-reply@safetech.test>';
+
+  if (!apiKey) {
+    console.log(`[Email] Sin proveedor configurado (falta RESEND_API_KEY) — Para: ${to} | Asunto: ${subject}`);
+    return;
+  }
+
+  try {
+    const response = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ from, to, subject, html }),
+    });
+
+    if (!response.ok) {
+      console.error('[Email] Error al enviar via Resend:', response.status, await response.text());
+    }
+  } catch (error) {
+    console.error('[Email] Error al enviar via Resend:', error);
+  }
+}
+
+const ORDER_STATUS_LABEL: Record<string, string> = {
+  pending: 'Pendiente',
+  paid: 'Pagado',
+  processing: 'En preparación',
+  shipped: 'Enviado',
+  delivered: 'Entregado',
+  failed: 'Fallido',
+};
+
+const WARRANTY_STATUS_LABEL: Record<string, string> = {
+  pending: 'Pendiente',
+  review: 'En revisión',
+  resolved: 'Resuelto',
+  rejected: 'Rechazado',
+  refunded: 'Reembolsado',
+};
+
+export async function sendPurchaseConfirmationEmail(to: string, order: { _id: unknown; total_amount: number }): Promise<void> {
+  await sendEmail(
+    to,
+    `Confirmamos tu compra en SafeTech (#${String(order._id).slice(-6)})`,
+    `<p>Tu pago fue confirmado.</p><p>Orden: <strong>#${String(order._id).slice(-6)}</strong></p><p>Total: <strong>$${order.total_amount.toFixed(2)}</strong></p>`,
+  );
+}
+
+export async function sendOrderStatusChangedEmail(
+  to: string,
+  order: { _id: unknown; status: string },
+): Promise<void> {
+  const label = ORDER_STATUS_LABEL[order.status] ?? order.status;
+  await sendEmail(
+    to,
+    `Actualizacion de tu pedido SafeTech (#${String(order._id).slice(-6)})`,
+    `<p>El estado de tu pedido <strong>#${String(order._id).slice(-6)}</strong> cambio a: <strong>${label}</strong>.</p>`,
+  );
+}
+
+export async function sendWarrantyCreatedEmail(to: string, warranty: { _id: unknown }): Promise<void> {
+  await sendEmail(
+    to,
+    `Recibimos tu reclamo de garantia (#${String(warranty._id).slice(-6)})`,
+    `<p>Registramos tu reclamo de garantia <strong>#${String(warranty._id).slice(-6)}</strong>. Te avisaremos por correo ante cualquier actualizacion.</p>`,
+  );
+}
+
+export async function sendWarrantyStatusChangedEmail(
+  to: string,
+  warranty: { _id: unknown; status: string },
+): Promise<void> {
+  const label = WARRANTY_STATUS_LABEL[warranty.status] ?? warranty.status;
+  await sendEmail(
+    to,
+    `Actualizacion de tu garantia SafeTech (#${String(warranty._id).slice(-6)})`,
+    `<p>El estado de tu garantia <strong>#${String(warranty._id).slice(-6)}</strong> cambio a: <strong>${label}</strong>.</p>`,
+  );
+}

--- a/backend/src/services/order.service.ts
+++ b/backend/src/services/order.service.ts
@@ -2,10 +2,13 @@ import mongoose from 'mongoose';
 import { Order } from '../models/Order';
 import { OrderItem } from '../models/OrderItem';
 import { Product } from '../models/Product';
+import { User } from '../models/User';
+import { sendPurchaseConfirmationEmail } from './email.service';
 
 export interface FinalizeResult {
   lockedOrder: any;
   stockWarnings: Array<{ productId: string; reason: string }>;
+  wasAlreadyPaid: boolean;
 }
 
 export const finalizePaidOrder = async (
@@ -32,7 +35,7 @@ export const finalizePaidOrder = async (
       if (session) {
         await session.commitTransaction();
       }
-      return { lockedOrder, stockWarnings: [] };
+      return { lockedOrder, stockWarnings: [], wasAlreadyPaid: true };
     }
 
     const orderItemsQuery = OrderItem.find({ order_id: lockedOrder._id });
@@ -63,7 +66,7 @@ export const finalizePaidOrder = async (
       await lockedOrder.save();
     }
 
-    return { lockedOrder, stockWarnings };
+    return { lockedOrder, stockWarnings, wasAlreadyPaid: false };
   } catch (error) {
     if (session) {
       try {
@@ -77,5 +80,19 @@ export const finalizePaidOrder = async (
     if (session) {
       session.endSession();
     }
+  }
+};
+
+export const notifyPurchaseConfirmed = async (userId: string, order: { _id: unknown; total_amount: number }) => {
+  // Se llama despues de que la transaccion de pago ya se confirmo (fuera del
+  // try/catch de finalizePaidOrder): un fallo aca no debe revertir un pago
+  // ya procesado ni devolver 500 sobre una orden que en realidad quedo paga.
+  try {
+    const user = await User.findOne({ clerk_id: userId });
+    if (user?.email) {
+      await sendPurchaseConfirmationEmail(user.email, order);
+    }
+  } catch (error) {
+    console.error('[Order] Error al enviar el correo de confirmacion de compra:', error);
   }
 };

--- a/e2e/transactional-emails.spec.ts
+++ b/e2e/transactional-emails.spec.ts
@@ -1,0 +1,176 @@
+import { expect, test } from '@playwright/test';
+import { resetE2EState } from './helpers';
+
+const API_URL = 'http://127.0.0.1:3001/api';
+const USER_AUTH = { Authorization: 'Bearer mock:user:e2e-user' };
+const ADMIN_AUTH = { Authorization: 'Bearer mock:admin:e2e-admin' };
+
+const SHOPPER_EMAIL = 'shopper@safetech.test';
+
+async function getEmails(request: import('@playwright/test').APIRequestContext) {
+  const response = await request.get(`${API_URL}/e2e/emails`);
+  return (await response.json()).emails as { to: string; subject: string; html: string }[];
+}
+
+async function getSeededOrderId(request: import('@playwright/test').APIRequestContext) {
+  const response = await request.get(`${API_URL}/orders/mine`, { headers: USER_AUTH });
+  const orders = await response.json();
+  return orders[0]._id as string;
+}
+
+async function getSeededWarrantyId(request: import('@playwright/test').APIRequestContext) {
+  const response = await request.get(`${API_URL}/warranties`, { headers: ADMIN_AUTH });
+  const warranties = await response.json();
+  return warranties[0]._id as string;
+}
+
+test.beforeEach(async ({ request }) => {
+  await resetE2EState(request);
+});
+
+test('no hay correos pendientes justo despues del reset', async ({ request }) => {
+  const emails = await getEmails(request);
+  expect(emails).toEqual([]);
+});
+
+test('envia un correo de confirmacion al completar una compra', async ({ request }) => {
+  const products = (await (await request.get(`${API_URL}/products`)).json()).data;
+  const productId = products[0]._id;
+
+  const checkout = await (
+    await request.post(`${API_URL}/checkout`, {
+      headers: USER_AUTH,
+      data: { items: [{ productId, quantity: 1 }] },
+    })
+  ).json();
+
+  const confirmResponse = await request.post(`${API_URL}/orders/confirm-payment`, {
+    headers: USER_AUTH,
+    data: { paymentIntentId: checkout.paymentIntentId },
+  });
+  expect(confirmResponse.status()).toBe(200);
+
+  const emails = await getEmails(request);
+  const purchaseEmail = emails.find((e) => e.to === SHOPPER_EMAIL && /compra/i.test(e.subject));
+  expect(purchaseEmail).toBeTruthy();
+});
+
+test('no reenvia el correo de compra si la orden ya estaba pagada', async ({ request }) => {
+  const products = (await (await request.get(`${API_URL}/products`)).json()).data;
+  const productId = products[0]._id;
+
+  const checkout = await (
+    await request.post(`${API_URL}/checkout`, {
+      headers: USER_AUTH,
+      data: { items: [{ productId, quantity: 1 }] },
+    })
+  ).json();
+
+  await request.post(`${API_URL}/orders/confirm-payment`, {
+    headers: USER_AUTH,
+    data: { paymentIntentId: checkout.paymentIntentId },
+  });
+  await request.post(`${API_URL}/orders/confirm-payment`, {
+    headers: USER_AUTH,
+    data: { paymentIntentId: checkout.paymentIntentId },
+  });
+
+  const emails = await getEmails(request);
+  const purchaseEmails = emails.filter((e) => e.to === SHOPPER_EMAIL && /compra/i.test(e.subject));
+  expect(purchaseEmails).toHaveLength(1);
+});
+
+test('envia un correo al crear un reclamo de garantia', async ({ request }) => {
+  // El seed ya deja una garantia registrada para la orden sembrada (409 si se
+  // repite); se crea una orden pagada nueva para poder reclamar una garantia.
+  const products = (await (await request.get(`${API_URL}/products`)).json()).data;
+  const productId = products[0]._id;
+
+  const checkout = await (
+    await request.post(`${API_URL}/checkout`, {
+      headers: USER_AUTH,
+      data: { items: [{ productId, quantity: 1 }] },
+    })
+  ).json();
+  await request.post(`${API_URL}/orders/confirm-payment`, {
+    headers: USER_AUTH,
+    data: { paymentIntentId: checkout.paymentIntentId },
+  });
+
+  const response = await request.post(`${API_URL}/warranties`, {
+    headers: USER_AUTH,
+    data: {
+      orderId: checkout.orderId,
+      reason: 'defecto de fabrica',
+      description: 'La bateria no carga correctamente desde el segundo dia de uso.',
+    },
+  });
+  expect(response.status()).toBe(201);
+
+  const emails = await getEmails(request);
+  const warrantyEmail = emails.find((e) => e.to === SHOPPER_EMAIL && /garant/i.test(e.subject) && /reclamo|recibimos/i.test(e.subject));
+  expect(warrantyEmail).toBeTruthy();
+});
+
+test('envia un correo cuando un admin cambia el estado de una garantia', async ({ request }) => {
+  const warrantyId = await getSeededWarrantyId(request);
+
+  const response = await request.put(`${API_URL}/warranties/${warrantyId}/status`, {
+    headers: ADMIN_AUTH,
+    data: { status: 'review' },
+  });
+  expect(response.status()).toBe(200);
+
+  const emails = await getEmails(request);
+  const statusEmail = emails.find((e) => e.to === SHOPPER_EMAIL && /garant/i.test(e.subject));
+  expect(statusEmail).toBeTruthy();
+});
+
+test('no envia un segundo correo si el estado de la garantia no cambia', async ({ request }) => {
+  const warrantyId = await getSeededWarrantyId(request);
+
+  const first = await request.put(`${API_URL}/warranties/${warrantyId}/status`, {
+    headers: ADMIN_AUTH,
+    data: { status: 'review' },
+  });
+  expect(first.status()).toBe(200);
+
+  const second = await request.put(`${API_URL}/warranties/${warrantyId}/status`, {
+    headers: ADMIN_AUTH,
+    data: { status: 'review' },
+  });
+  expect(second.status()).toBe(200);
+
+  const emails = await getEmails(request);
+  const statusEmails = emails.filter((e) => e.to === SHOPPER_EMAIL && /garant/i.test(e.subject));
+  expect(statusEmails).toHaveLength(1);
+});
+
+test('envia un correo cuando un admin asigna un tecnico (pending -> review)', async ({ request }) => {
+  const warrantyId = await getSeededWarrantyId(request);
+
+  const response = await request.put(`${API_URL}/warranties/${warrantyId}/assign`, {
+    headers: ADMIN_AUTH,
+    data: { technicianId: 'tech-1', technicianName: 'Tecnico de Prueba' },
+  });
+  expect(response.status()).toBe(200);
+  expect((await response.json()).status).toBe('review');
+
+  const emails = await getEmails(request);
+  const statusEmail = emails.find((e) => e.to === SHOPPER_EMAIL && /garant/i.test(e.subject));
+  expect(statusEmail).toBeTruthy();
+});
+
+test('envia un correo cuando un admin cambia el estado de envio de una orden', async ({ request }) => {
+  const orderId = await getSeededOrderId(request);
+
+  const response = await request.put(`${API_URL}/orders/${orderId}/shipping`, {
+    headers: ADMIN_AUTH,
+    data: { status: 'shipped', carrier: 'DHL' },
+  });
+  expect(response.status()).toBe(200);
+
+  const emails = await getEmails(request);
+  const shippingEmail = emails.find((e) => e.to === SHOPPER_EMAIL && /pedido/i.test(e.subject));
+  expect(shippingEmail).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- HU-34 pide correos transaccionales de compra, garantia y cambios de estado, sin depender del panel web.
- Nuevo `backend/src/services/email.service.ts`: envia via la API HTTP de Resend cuando `RESEND_API_KEY`/`EMAIL_FROM` estan configurados; sin esa config cae a `console.log` (no falla, no bloquea nada); en `E2E_TEST_MODE` captura los mensajes en memoria, inspeccionables via `GET /api/e2e/emails` (mismo patron que el resto de endpoints solo-test en `e2e.routes.ts`).
- Disparadores:
  - **Compra confirmada**: `order.service.ts` expone `notifyPurchaseConfirmed`, llamado desde los 3 puntos que marcan una orden `paid` (confirm-payment e2e y stripe, webhook de stripe) — solo en la transicion real, no en confirmaciones idempotentes repetidas. Vive fuera del `try/catch` transaccional de `finalizePaidOrder` a proposito: un fallo al buscar el email del usuario ya no puede abortar una transaccion que ya se confirmo ni devolver `500` sobre un pago que en realidad tuvo exito.
  - **Reclamo de garantia creado** (`createWarrantyReport`).
  - **Cambio de estado de garantia**: `updateWarrantyStatus` (admin), `technicianUpdateWarranty`, y `assignTechnician` (transicion `pending -> review` al asignar tecnico) — solo cuando el estado efectivamente cambia.
  - **Cambio de estado de envio de orden**: `updateShippingInfo` (HU-33, ya en develop).
- Se documentan `RESEND_API_KEY` y `EMAIL_FROM` en `CLAUDE.md`.

## Test plan
- [x] `npx playwright test e2e/transactional-emails.spec.ts` — 8/8 pasan (los 4 disparadores, no reenvio de correo de compra en confirmaciones repetidas, no envio si el estado de garantia no cambia, envio al asignar tecnico).
- [x] `npx playwright test` (suite completa) — 73/73 pasan, sin regresiones.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)