### PR TITLE
HU-35: alertas de stock bajo para administradores

### DIFF
--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -103,6 +103,21 @@ export const updateProduct = async (c: Context) => {
   }
 };
 
+const DEFAULT_LOW_STOCK_THRESHOLD = 5;
+
+export const getLowStockProducts = async (c: Context) => {
+  try {
+    const { threshold } = c.req.valid('query' as any) as { threshold?: number };
+    const effectiveThreshold = threshold ?? DEFAULT_LOW_STOCK_THRESHOLD;
+
+    const products = await Product.find({ stock: { $lte: effectiveThreshold } }).sort({ stock: 1 });
+
+    return c.json({ success: true, threshold: effectiveThreshold, data: products });
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};
+
 export const deleteProduct = async (c: Context) => {
   try {
     const id = c.req.param('id');

--- a/backend/src/routes/product.routes.ts
+++ b/backend/src/routes/product.routes.ts
@@ -3,12 +3,14 @@ import { zValidator } from '@hono/zod-validator';
 import {
   createProduct,
   deleteProduct,
+  getLowStockProducts,
   getProductById,
   getProducts,
   updateProduct,
 } from '../controllers/product.controller';
 import {
   createProductSchema,
+  lowStockQuerySchema,
   productFilterSchema,
   updateProductSchema,
 } from '../validators/product.validator';
@@ -26,6 +28,19 @@ productRoutes.get(
     }
   }),
   getProducts
+);
+
+// Productos con stock igual o por debajo de un umbral (alerta de stock bajo, solo admin)
+// Registrada antes de '/:id' para que "low-stock" no se interprete como un id.
+productRoutes.get(
+  '/low-stock',
+  adminAuthMiddleware,
+  zValidator('query', lowStockQuerySchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  getLowStockProducts
 );
 
 // Obtener un producto por ID

--- a/backend/src/validators/product.validator.ts
+++ b/backend/src/validators/product.validator.ts
@@ -39,3 +39,7 @@ export const productFilterSchema = z
     message: 'minPrice no puede ser mayor que maxPrice',
     path: ['minPrice'],
   });
+
+export const lowStockQuerySchema = z.object({
+  threshold: z.coerce.number().int().min(0, 'threshold debe ser 0 o un entero positivo').optional(),
+});

--- a/e2e/product-low-stock-alert.spec.ts
+++ b/e2e/product-low-stock-alert.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test';
+import { resetE2EState } from './helpers';
+
+const API_URL = 'http://127.0.0.1:3001/api';
+const ADMIN_AUTH = { Authorization: 'Bearer mock:admin:e2e-admin' };
+const USER_AUTH = { Authorization: 'Bearer mock:user:e2e-user' };
+
+// resetE2EState siembra 2 productos con stock 8 y 5 (por encima del umbral por
+// defecto de 5... el de stock 5 queda justo en el limite). Se agregan mas
+// variantes para poder discriminar bien que cruza el umbral y que no.
+const extraProducts = [
+  { name: 'Producto sin stock', description: 'x', price: 100, stock: 0, condition: 'B', category: 'pc' },
+  { name: 'Producto stock bajo', description: 'x', price: 80, stock: 3, condition: 'C', category: 'auriculares' },
+  { name: 'Producto stock alto', description: 'x', price: 200, stock: 50, condition: 'A', category: 'tablet' },
+];
+
+test.beforeEach(async ({ request }) => {
+  await resetE2EState(request);
+  for (const product of extraProducts) {
+    const response = await request.post(`${API_URL}/products`, { headers: ADMIN_AUTH, data: product });
+    expect(response.status()).toBe(201);
+  }
+});
+
+test('rechaza la consulta de stock bajo si el llamador no es admin', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products/low-stock`, { headers: USER_AUTH });
+  expect(response.status()).toBe(403);
+});
+
+test('devuelve solo los productos con stock igual o por debajo del umbral por defecto', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products/low-stock`, { headers: ADMIN_AUTH });
+  expect(response.status()).toBe(200);
+
+  const body = await response.json();
+  expect(body.threshold).toBe(5);
+
+  const names = body.data.map((p: { name: string }) => p.name).sort();
+  // stock: iPhone=8 (no), MacBook=5 (si, <=5), sin stock=0 (si), stock bajo=3 (si), stock alto=50 (no)
+  expect(names).toEqual(
+    ['MacBook Air M1 Refurbished', 'Producto sin stock', 'Producto stock bajo'].sort()
+  );
+  expect(body.data.every((p: { stock: number }) => p.stock <= 5)).toBe(true);
+});
+
+test('respeta un umbral personalizado', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products/low-stock?threshold=1`, { headers: ADMIN_AUTH });
+  expect(response.status()).toBe(200);
+
+  const body = await response.json();
+  expect(body.threshold).toBe(1);
+  expect(body.data).toHaveLength(1);
+  expect(body.data[0].name).toBe('Producto sin stock');
+});
+
+test('rechaza un umbral invalido', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products/low-stock?threshold=-1`, { headers: ADMIN_AUTH });
+  expect(response.status()).toBe(400);
+});

--- a/frontend/src/components/LowStockAlerts.tsx
+++ b/frontend/src/components/LowStockAlerts.tsx
@@ -1,0 +1,59 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '../lib/auth';
+import { productsService } from '../services/products.service';
+
+const LOW_STOCK_THRESHOLD = 5;
+
+export default function LowStockAlerts() {
+  const { getToken, isLoaded } = useAuth();
+
+  const { data } = useQuery({
+    queryKey: ['admin-low-stock', LOW_STOCK_THRESHOLD],
+    queryFn: async () => {
+      const token = await getToken();
+      if (!token) throw new Error('No token');
+      return productsService.getLowStock(token, LOW_STOCK_THRESHOLD);
+    },
+    enabled: isLoaded,
+  });
+
+  const products = data?.data ?? [];
+  if (products.length === 0) return null;
+
+  return (
+    <div
+      role="alert"
+      style={{
+        background: '#FEF3C7',
+        border: '1px solid #D97706',
+        borderRadius: 'var(--radius-ui, 4px)',
+        padding: '1rem 1.25rem',
+        marginBottom: '1.5rem',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.5rem',
+      }}
+    >
+      <p style={{ fontSize: '0.8rem', fontWeight: 600, color: '#92400E', fontFamily: 'var(--font-sans)' }}>
+        ⚠ {products.length} producto{products.length !== 1 ? 's' : ''} con stock bajo (≤ {data?.threshold ?? LOW_STOCK_THRESHOLD} unidades)
+      </p>
+      <ul style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', listStyle: 'none', padding: 0, margin: 0 }}>
+        {products.map((p) => (
+          <li
+            key={p._id}
+            style={{
+              fontSize: '0.72rem',
+              color: '#92400E',
+              background: 'rgba(217,119,6,0.12)',
+              borderRadius: '2px',
+              padding: '3px 8px',
+              fontFamily: 'var(--font-sans)',
+            }}
+          >
+            {p.name} · {p.stock} en stock
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -10,6 +10,7 @@ import type { Technician } from '../types/technician';
 import { useState } from 'react';
 import AdminSidebar from '../components/AdminSidebar';
 import StatsCards from '../components/StatsCards';
+import LowStockAlerts from '../components/LowStockAlerts';
 import ProductTable from '../components/ProductTable';
 import { Badge } from '../components/ui/Badge';
 import { SkeletonTableRow } from '../components/ui/Skeleton';
@@ -364,6 +365,7 @@ export default function AdminDashboard() {
                   Resumen general
                 </h1>
               </div>
+              <LowStockAlerts />
               <StatsCards orders={orders} warranties={warranties} />
             </div>
           )}

--- a/frontend/src/services/products.service.ts
+++ b/frontend/src/services/products.service.ts
@@ -92,6 +92,19 @@ export const productsService = {
     };
   },
 
+  async getLowStock(token: string, threshold?: number): Promise<{ threshold: number; data: Product[] }> {
+    const qs = threshold !== undefined ? `?threshold=${threshold}` : '';
+    const response = await fetch(`${API_URL}/products/low-stock${qs}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) {
+      const result = await response.json().catch(() => ({}));
+      throw new Error(result?.message || result?.errors?.[0]?.message || 'Failed to fetch low-stock products');
+    }
+    const result = await response.json();
+    return { threshold: result.threshold, data: result.data || [] };
+  },
+
   async getById(id: string, token?: string): Promise<Product> {
     const response = await fetch(`${API_URL}/products/${id}`, {
       headers: token ? { Authorization: `Bearer ${token}` } : {},


### PR DESCRIPTION
## Summary
- HU-35 pide que el admin pueda definir un umbral de stock bajo y recibir una alerta (panel o correo) cuando un producto lo cruce.
- `GET /api/products/low-stock` (admin-gated, registrada antes de `GET /:id` para que "low-stock" no se interprete como un id de Mongo): devuelve los productos con `stock <= threshold` (default 5, configurable por query param), ordenados por stock ascendente. Un producto en o por debajo del umbral **es** la alerta, calculada al consultar el endpoint — no se persiste un log de eventos separado.
- Frontend: `LowStockAlerts`, un banner en el "Resumen general" del admin dashboard que consulta ese endpoint y lista los productos afectados con su stock actual. Cierra el lado de "panel" de la AC con datos reales (antes solo existía un conteo agregado en las stats de productos).

## Test plan
- [x] `npx playwright test e2e/product-low-stock-alert.spec.ts` — 4/4 pasan (rechaza no-admins, filtra por umbral default, respeta umbral personalizado, rechaza umbral invalido).
- [x] `npx playwright test` (suite completa) — 77/77 pasan, sin regresiones.
- [x] Verificacion manual en navegador: banner de alerta visible en el dashboard admin listando los productos con stock bajo y su cantidad.

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)