### PR TITLE
HU-36: historial de movimientos de inventario

### DIFF
--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -1,5 +1,7 @@
 import { Context } from 'hono';
 import { Product } from '../models/Product';
+import { InventoryMovement } from '../models/InventoryMovement';
+import { recordInventoryMovement } from '../services/inventory.service';
 
 export const getProducts = async (c: Context) => {
   try {
@@ -74,8 +76,21 @@ export const createProduct = async (c: Context) => {
   try {
     // Validated by zod-validator middleware
     const data = c.req.valid('json' as any);
-    
-    const newProduct = await Product.create(data);
+    const userId = c.get('userId');
+
+    const newProduct = (await Product.create(data)) as unknown as { _id: unknown; stock: number };
+
+    if (newProduct.stock > 0) {
+      await recordInventoryMovement({
+        productId: newProduct._id as any,
+        type: 'restock',
+        previousStock: 0,
+        newStock: newProduct.stock,
+        reason: 'Alta de producto',
+        performedBy: userId ?? 'system',
+      });
+    }
+
     return c.json({ success: true, data: newProduct }, 201);
   } catch (error: any) {
     return c.json({ success: false, message: error.message }, 500);
@@ -86,18 +101,54 @@ export const updateProduct = async (c: Context) => {
   try {
     const id = c.req.param('id');
     // Validated by zod-validator middleware
-    const data = c.req.valid('json' as any);
-    
-    const updatedProduct = await Product.findByIdAndUpdate(id, data, {
+    const data = c.req.valid('json' as any) as { stock?: number; reason?: string; [key: string]: unknown };
+    const userId = c.get('userId');
+
+    const previousProduct = await Product.findById(id);
+    if (!previousProduct) {
+      return c.json({ success: false, message: 'Producto no encontrado' }, 404);
+    }
+
+    const { reason, ...updateData } = data;
+
+    const updatedProduct = await Product.findByIdAndUpdate(id, updateData, {
       new: true,
       runValidators: true,
     });
-    
+
     if (!updatedProduct) {
       return c.json({ success: false, message: 'Producto no encontrado' }, 404);
     }
-    
+
+    if (data.stock !== undefined && data.stock !== previousProduct.stock) {
+      await recordInventoryMovement({
+        productId: updatedProduct._id,
+        type: 'manual_adjustment',
+        previousStock: previousProduct.stock,
+        newStock: updatedProduct.stock,
+        reason: reason?.trim() || 'Ajuste manual de stock',
+        performedBy: userId ?? 'system',
+      });
+    }
+
     return c.json({ success: true, data: updatedProduct });
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};
+
+export const getProductInventoryMovements = async (c: Context) => {
+  try {
+    const id = c.req.param('id');
+
+    const product = await Product.findById(id);
+    if (!product) {
+      return c.json({ success: false, message: 'Producto no encontrado' }, 404);
+    }
+
+    const movements = await InventoryMovement.find({ productId: id }).sort({ createdAt: -1 });
+
+    return c.json({ success: true, data: movements });
   } catch (error: any) {
     return c.json({ success: false, message: error.message }, 500);
   }

--- a/backend/src/models/InventoryMovement.ts
+++ b/backend/src/models/InventoryMovement.ts
@@ -1,0 +1,30 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface IInventoryMovement extends Document {
+  productId: Types.ObjectId;
+  type: 'restock' | 'manual_adjustment' | 'sale';
+  quantityChange: number;
+  previousStock: number;
+  newStock: number;
+  reason: string;
+  performedBy: string;
+  createdAt: Date;
+}
+
+const inventoryMovementSchema = new Schema<IInventoryMovement>(
+  {
+    productId: { type: Schema.Types.ObjectId, ref: 'Product', required: true, index: true },
+    // restock: alta de producto o reposicion manual de stock (entrada)
+    // manual_adjustment: correccion manual de stock por un admin (entrada o salida)
+    // sale: descuento automatico de stock al confirmarse una compra (salida)
+    type: { type: String, enum: ['restock', 'manual_adjustment', 'sale'], required: true },
+    quantityChange: { type: Number, required: true },
+    previousStock: { type: Number, required: true },
+    newStock: { type: Number, required: true },
+    reason: { type: String, required: true },
+    performedBy: { type: String, required: true },
+  },
+  { timestamps: { createdAt: true, updatedAt: false } }
+);
+
+export const InventoryMovement = model<IInventoryMovement>('InventoryMovement', inventoryMovementSchema);

--- a/backend/src/routes/e2e.routes.ts
+++ b/backend/src/routes/e2e.routes.ts
@@ -6,6 +6,7 @@ import { WarrantyReport } from '../models/WarrantyReport';
 import { Technician } from '../models/Technician';
 import { User } from '../models/User';
 import { Address } from '../models/Address';
+import { InventoryMovement } from '../models/InventoryMovement';
 import { isE2ETestMode } from '../lib/e2e';
 import { clearSentEmails, getSentEmails } from '../services/email.service';
 
@@ -30,6 +31,7 @@ e2eRoutes.post('/reset', async (c) => {
     Technician.deleteMany({}),
     User.deleteMany({}),
     Address.deleteMany({}),
+    InventoryMovement.deleteMany({}),
   ]);
 
   await User.insertMany([

--- a/backend/src/routes/product.routes.ts
+++ b/backend/src/routes/product.routes.ts
@@ -5,6 +5,7 @@ import {
   deleteProduct,
   getLowStockProducts,
   getProductById,
+  getProductInventoryMovements,
   getProducts,
   updateProduct,
 } from '../controllers/product.controller';
@@ -45,6 +46,9 @@ productRoutes.get(
 
 // Obtener un producto por ID
 productRoutes.get('/:id', getProductById);
+
+// Historial de movimientos de inventario de un producto (solo admin)
+productRoutes.get('/:id/inventory-movements', adminAuthMiddleware, getProductInventoryMovements);
 
 // Crear un producto con validación de Zod (solo admin)
 productRoutes.post(

--- a/backend/src/services/inventory.service.ts
+++ b/backend/src/services/inventory.service.ts
@@ -1,0 +1,33 @@
+import type { ClientSession, Types } from 'mongoose';
+import { InventoryMovement } from '../models/InventoryMovement';
+
+export interface RecordMovementParams {
+  productId: Types.ObjectId | string;
+  type: 'restock' | 'manual_adjustment' | 'sale';
+  previousStock: number;
+  newStock: number;
+  reason: string;
+  performedBy: string;
+  session?: ClientSession;
+}
+
+export async function recordInventoryMovement(params: RecordMovementParams) {
+  const { productId, type, previousStock, newStock, reason, performedBy, session } = params;
+
+  const [movement] = await InventoryMovement.create(
+    [
+      {
+        productId,
+        type,
+        quantityChange: newStock - previousStock,
+        previousStock,
+        newStock,
+        reason,
+        performedBy,
+      },
+    ],
+    session ? { session } : undefined,
+  );
+
+  return movement;
+}

--- a/backend/src/services/order.service.ts
+++ b/backend/src/services/order.service.ts
@@ -4,6 +4,7 @@ import { OrderItem } from '../models/OrderItem';
 import { Product } from '../models/Product';
 import { User } from '../models/User';
 import { sendPurchaseConfirmationEmail } from './email.service';
+import { recordInventoryMovement } from './inventory.service';
 
 export interface FinalizeResult {
   lockedOrder: any;
@@ -43,18 +44,30 @@ export const finalizePaidOrder = async (
     const stockWarnings: Array<{ productId: string; reason: string }> = [];
 
     for (const item of orderItems) {
-      const updateQuery = Product.updateOne(
+      const updateQuery = Product.findOneAndUpdate(
         { _id: item.product_id, stock: { $gte: item.quantity } },
         { $inc: { stock: -item.quantity } },
+        { new: true },
       );
-      const result = session ? await updateQuery.session(session) : await updateQuery;
+      const updatedProduct = session ? await updateQuery.session(session) : await updateQuery;
 
-      if (result.modifiedCount === 0) {
+      if (!updatedProduct) {
         stockWarnings.push({
           productId: String(item.product_id),
           reason: 'insufficient_stock_or_missing_product',
         });
+        continue;
       }
+
+      await recordInventoryMovement({
+        productId: item.product_id,
+        type: 'sale',
+        previousStock: updatedProduct.stock + item.quantity,
+        newStock: updatedProduct.stock,
+        reason: `Venta confirmada (orden #${String(lockedOrder._id).slice(-6)})`,
+        performedBy: userId,
+        session: session ?? undefined,
+      });
     }
 
     lockedOrder.status = 'paid';

--- a/backend/src/validators/product.validator.ts
+++ b/backend/src/validators/product.validator.ts
@@ -22,7 +22,11 @@ export const createProductSchema = z.object({
 // Se construye desde `productFields` (sin el `.default(0)` de stock) en vez de
 // `createProductSchema.partial()`: partial() no elimina los default() internos,
 // asi que un update parcial sin `stock` terminaria reseteandolo a 0.
-export const updateProductSchema = z.object(productFields).partial();
+// `reason` (HU-36) es el motivo del ajuste de stock, para el historial de
+// movimientos de inventario; no es un campo del producto en si.
+export const updateProductSchema = z.object(productFields).partial().extend({
+  reason: z.string().min(1).optional(),
+});
 
 export const productFilterSchema = z
   .object({

--- a/e2e/inventory-movements.spec.ts
+++ b/e2e/inventory-movements.spec.ts
@@ -1,0 +1,165 @@
+import { expect, test } from '@playwright/test';
+import { resetE2EState } from './helpers';
+
+const API_URL = 'http://127.0.0.1:3001/api';
+const ADMIN_AUTH = { Authorization: 'Bearer mock:admin:e2e-admin' };
+const USER_AUTH = { Authorization: 'Bearer mock:user:e2e-user' };
+
+test.beforeEach(async ({ request }) => {
+  await resetE2EState(request);
+});
+
+test('rechaza consultar el historial si el llamador no es admin', async ({ request }) => {
+  const products = (await (await request.get(`${API_URL}/products`)).json()).data;
+  const response = await request.get(`${API_URL}/products/${products[0]._id}/inventory-movements`, {
+    headers: USER_AUTH,
+  });
+  expect(response.status()).toBe(403);
+});
+
+test('devuelve 404 para un producto inexistente', async ({ request }) => {
+  const response = await request.get(`${API_URL}/products/000000000000000000000000/inventory-movements`, {
+    headers: ADMIN_AUTH,
+  });
+  expect(response.status()).toBe(404);
+});
+
+test('registra un movimiento de alta al crear un producto con stock inicial', async ({ request }) => {
+  const created = await (
+    await request.post(`${API_URL}/products`, {
+      headers: ADMIN_AUTH,
+      data: { name: 'Producto Nuevo', description: 'x', price: 100, stock: 10, condition: 'A', category: 'pc' },
+    })
+  ).json();
+
+  const response = await request.get(`${API_URL}/products/${created.data._id}/inventory-movements`, {
+    headers: ADMIN_AUTH,
+  });
+  expect(response.status()).toBe(200);
+  const body = await response.json();
+  expect(body.data).toHaveLength(1);
+  expect(body.data[0]).toMatchObject({
+    type: 'restock',
+    quantityChange: 10,
+    previousStock: 0,
+    newStock: 10,
+    reason: 'Alta de producto',
+    performedBy: 'e2e-admin',
+  });
+});
+
+test('no registra movimiento al crear un producto sin stock inicial', async ({ request }) => {
+  const created = await (
+    await request.post(`${API_URL}/products`, {
+      headers: ADMIN_AUTH,
+      data: { name: 'Producto Sin Stock', description: 'x', price: 100, stock: 0, condition: 'A', category: 'pc' },
+    })
+  ).json();
+
+  const response = await request.get(`${API_URL}/products/${created.data._id}/inventory-movements`, {
+    headers: ADMIN_AUTH,
+  });
+  expect((await response.json()).data).toEqual([]);
+});
+
+test('registra un ajuste manual con motivo, usuario y fecha al editar el stock', async ({ request }) => {
+  const products = (await (await request.get(`${API_URL}/products`)).json()).data;
+  const product = products[0];
+
+  const updateResponse = await request.put(`${API_URL}/products/${product._id}`, {
+    headers: ADMIN_AUTH,
+    data: { stock: product.stock + 20, reason: 'Reposicion de proveedor' },
+  });
+  expect(updateResponse.status()).toBe(200);
+
+  const response = await request.get(`${API_URL}/products/${product._id}/inventory-movements`, {
+    headers: ADMIN_AUTH,
+  });
+  const body = await response.json();
+  expect(body.data).toHaveLength(1);
+  expect(body.data[0]).toMatchObject({
+    type: 'manual_adjustment',
+    quantityChange: 20,
+    previousStock: product.stock,
+    newStock: product.stock + 20,
+    reason: 'Reposicion de proveedor',
+    performedBy: 'e2e-admin',
+  });
+  expect(body.data[0].createdAt).toBeTruthy();
+});
+
+test('usa un motivo por defecto si no se envia reason', async ({ request }) => {
+  const products = (await (await request.get(`${API_URL}/products`)).json()).data;
+  const product = products[0];
+
+  await request.put(`${API_URL}/products/${product._id}`, {
+    headers: ADMIN_AUTH,
+    data: { stock: product.stock + 1 },
+  });
+
+  const response = await request.get(`${API_URL}/products/${product._id}/inventory-movements`, {
+    headers: ADMIN_AUTH,
+  });
+  expect((await response.json()).data[0].reason).toBe('Ajuste manual de stock');
+});
+
+test('no registra movimiento si se edita el producto sin cambiar el stock', async ({ request }) => {
+  const products = (await (await request.get(`${API_URL}/products`)).json()).data;
+  const product = products[0];
+
+  await request.put(`${API_URL}/products/${product._id}`, {
+    headers: ADMIN_AUTH,
+    data: { price: product.price + 5 },
+  });
+
+  const response = await request.get(`${API_URL}/products/${product._id}/inventory-movements`, {
+    headers: ADMIN_AUTH,
+  });
+  expect((await response.json()).data).toEqual([]);
+});
+
+test('registra una venta automatica al confirmarse una compra', async ({ request }) => {
+  const products = (await (await request.get(`${API_URL}/products`)).json()).data;
+  const product = products[0];
+
+  const checkout = await (
+    await request.post(`${API_URL}/checkout`, {
+      headers: USER_AUTH,
+      data: { items: [{ productId: product._id, quantity: 2 }] },
+    })
+  ).json();
+
+  await request.post(`${API_URL}/orders/confirm-payment`, {
+    headers: USER_AUTH,
+    data: { paymentIntentId: checkout.paymentIntentId },
+  });
+
+  const response = await request.get(`${API_URL}/products/${product._id}/inventory-movements`, {
+    headers: ADMIN_AUTH,
+  });
+  const body = await response.json();
+  const saleMovement = body.data.find((m: { type: string }) => m.type === 'sale');
+  expect(saleMovement).toMatchObject({
+    quantityChange: -2,
+    previousStock: product.stock,
+    newStock: product.stock - 2,
+    performedBy: 'e2e-user',
+  });
+  expect(saleMovement.reason).toMatch(/venta/i);
+});
+
+test('permite consultar movimientos por producto de forma independiente', async ({ request }) => {
+  const products = (await (await request.get(`${API_URL}/products`)).json()).data;
+  const [productA, productB] = products;
+
+  await request.put(`${API_URL}/products/${productA._id}`, {
+    headers: ADMIN_AUTH,
+    data: { stock: productA.stock + 1 },
+  });
+
+  const responseA = await request.get(`${API_URL}/products/${productA._id}/inventory-movements`, { headers: ADMIN_AUTH });
+  const responseB = await request.get(`${API_URL}/products/${productB._id}/inventory-movements`, { headers: ADMIN_AUTH });
+
+  expect((await responseA.json()).data).toHaveLength(1);
+  expect((await responseB.json()).data).toEqual([]);
+});

--- a/frontend/src/components/InventoryHistoryModal.tsx
+++ b/frontend/src/components/InventoryHistoryModal.tsx
@@ -1,0 +1,79 @@
+import { createPortal } from 'react-dom';
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '../lib/auth';
+import { productsService } from '../services/products.service';
+
+interface InventoryHistoryModalProps {
+  productId: string | null;
+  productName?: string;
+  onClose: () => void;
+}
+
+const TYPE_LABEL: Record<string, string> = {
+  restock: 'Alta / reposición',
+  manual_adjustment: 'Ajuste manual',
+  sale: 'Venta',
+};
+
+export default function InventoryHistoryModal({ productId, productName, onClose }: InventoryHistoryModalProps) {
+  const { getToken } = useAuth();
+
+  const { data: movements, isLoading } = useQuery({
+    queryKey: ['inventory-movements', productId],
+    queryFn: async () => {
+      const token = await getToken();
+      if (!token) throw new Error('No token');
+      return productsService.getInventoryMovements(productId as string, token);
+    },
+    enabled: Boolean(productId),
+  });
+
+  if (!productId) return null;
+
+  return createPortal(
+    <div
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}
+      onClick={onClose}
+    >
+      <div
+        style={{ background: 'var(--white)', width: 'min(560px, 92vw)', maxHeight: '80vh', overflowY: 'auto', borderRadius: 'var(--radius-md, 8px)', padding: '1.5rem' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
+          <h2 style={{ fontFamily: 'var(--font-display)', fontSize: '1.1rem', fontWeight: 500 }}>
+            Historial de inventario{productName ? ` — ${productName}` : ''}
+          </h2>
+          <button onClick={onClose} style={{ background: 'transparent', border: 'none', cursor: 'pointer', fontSize: '1.25rem', lineHeight: 1 }} aria-label="Cerrar">
+            ×
+          </button>
+        </div>
+
+        {isLoading && <p style={{ color: 'var(--gray)' }}>Cargando movimientos...</p>}
+
+        {!isLoading && (movements?.length ?? 0) === 0 && (
+          <p style={{ color: 'var(--gray)' }}>Sin movimientos registrados para este producto.</p>
+        )}
+
+        {!isLoading && movements && movements.length > 0 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+            {movements.map((m) => (
+              <div key={m._id} style={{ border: '1px solid var(--line)', borderRadius: '4px', padding: '0.75rem' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.8rem', fontWeight: 600 }}>
+                  <span>{TYPE_LABEL[m.type] ?? m.type}</span>
+                  <span style={{ color: m.quantityChange >= 0 ? '#059669' : '#DC2626' }}>
+                    {m.quantityChange >= 0 ? '+' : ''}{m.quantityChange}
+                  </span>
+                </div>
+                <p style={{ fontSize: '0.75rem', color: 'var(--ink2)', margin: '0.25rem 0' }}>{m.reason}</p>
+                <p style={{ fontSize: '0.7rem', color: 'var(--gray)' }}>
+                  {m.previousStock} → {m.newStock} unidades · {m.performedBy} · {new Date(m.createdAt).toLocaleString('es-ES')}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/ProductModal.tsx
+++ b/frontend/src/components/ProductModal.tsx
@@ -57,6 +57,7 @@ export default function ProductModal({ isOpen, onClose, onSubmit, product, isLoa
   const [condition,   setCondition]   = useState<'A' | 'B' | 'C'>('A');
   const [category,    setCategory]    = useState<'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet'>('celular');
   const [imageUrls,   setImageUrls]   = useState('');
+  const [stockReason, setStockReason] = useState('');
   const [error,       setError]       = useState('');
 
   useEffect(() => {
@@ -72,6 +73,7 @@ export default function ProductModal({ isOpen, onClose, onSubmit, product, isLoa
       setName(''); setDescription(''); setPrice('');
       setStock(''); setCondition('A'); setCategory('celular'); setImageUrls('');
     }
+    setStockReason('');
     setError('');
   }, [product, isOpen]);
 
@@ -95,9 +97,19 @@ export default function ProductModal({ isOpen, onClose, onSubmit, product, isLoa
     if (isNaN(stockNum) || stockNum < 0)    { setError('El stock debe ser 0 o mayor'); return; }
 
     const image_urls = imageUrls.split(',').map(u => u.trim()).filter(Boolean);
+    const stockChanged = Boolean(product) && stockNum !== product?.stock;
 
     try {
-      await onSubmit({ name: name.trim(), description: description.trim() || undefined, price: priceNum, stock: stockNum, condition, category, image_urls });
+      await onSubmit({
+        name: name.trim(),
+        description: description.trim() || undefined,
+        price: priceNum,
+        stock: stockNum,
+        condition,
+        category,
+        image_urls,
+        ...(stockChanged ? { reason: stockReason.trim() || undefined } : {}),
+      });
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Error al guardar producto');
@@ -268,6 +280,22 @@ export default function ProductModal({ isOpen, onClose, onSubmit, product, isLoa
               />
             </div>
           </div>
+
+          {/* Motivo del cambio de stock */}
+          {product && stock !== '' && parseInt(stock) !== product.stock && !isNaN(parseInt(stock)) && (
+            <div>
+              <label style={labelStyle}>Motivo del ajuste de stock</label>
+              <input
+                type="text"
+                value={stockReason}
+                onChange={e => setStockReason(e.target.value)}
+                placeholder="Ej: Reposición de proveedor, corrección de inventario…"
+                style={inputStyle}
+                onFocus={e => { e.target.style.borderColor = 'var(--accent)'; e.target.style.boxShadow = '0 0 0 3px var(--accent-light)'; }}
+                onBlur={e  => { e.target.style.borderColor = 'var(--line)'; e.target.style.boxShadow = 'none'; }}
+              />
+            </div>
+          )}
 
           {/* Condición */}
           <div>

--- a/frontend/src/components/ProductTable.tsx
+++ b/frontend/src/components/ProductTable.tsx
@@ -5,6 +5,7 @@ import type { Product } from '../types/product';
 import type { UpdateProductDTO } from '../services/products.service';
 import { productsService } from '../services/products.service';
 import ProductModal from './ProductModal';
+import InventoryHistoryModal from './InventoryHistoryModal';
 import type { CreateProductDTO } from '../services/products.service';
 
 const ProductStats: React.FC<{ products: Product[] | undefined }> = ({ products }) => {
@@ -161,6 +162,7 @@ export default function ProductTable() {
   const queryClient = useQueryClient();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const [historyProduct, setHistoryProduct] = useState<Product | null>(null);
 
   const { data: products, isLoading } = useQuery<Product[]>({
     queryKey: ['admin-products'],
@@ -299,6 +301,21 @@ export default function ProductTable() {
                 <td className="actions">
                   <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
                     <button
+                      onClick={() => setHistoryProduct(product)}
+                      title="Historial de inventario"
+                      style={{
+                        background: 'transparent',
+                        border: 'none',
+                        cursor: 'pointer',
+                        color: 'var(--ink2)',
+                        padding: '4px',
+                      }}
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" style={{ width: 18, height: 18 }}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                    </button>
+                    <button
                       onClick={() => handleOpenEdit(product)}
                       title="Editar"
                       style={{
@@ -349,6 +366,12 @@ export default function ProductTable() {
         onSubmit={handleSubmit}
         product={selectedProduct}
         isLoading={createMutation.isPending || updateMutation.isPending}
+      />
+
+      <InventoryHistoryModal
+        productId={historyProduct?._id ?? null}
+        productName={historyProduct?.name}
+        onClose={() => setHistoryProduct(null)}
       />
     </>
   );

--- a/frontend/src/services/products.service.ts
+++ b/frontend/src/services/products.service.ts
@@ -20,6 +20,20 @@ export interface UpdateProductDTO {
   condition?: 'A' | 'B' | 'C';
   category?: 'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet';
   image_urls?: string[];
+  // Motivo del ajuste de stock (HU-36), para el historial de movimientos de inventario.
+  reason?: string;
+}
+
+export interface InventoryMovement {
+  _id: string;
+  productId: string;
+  type: 'restock' | 'manual_adjustment' | 'sale';
+  quantityChange: number;
+  previousStock: number;
+  newStock: number;
+  reason: string;
+  performedBy: string;
+  createdAt: string;
 }
 
 export interface ProductFilters {
@@ -103,6 +117,18 @@ export const productsService = {
     }
     const result = await response.json();
     return { threshold: result.threshold, data: result.data || [] };
+  },
+
+  async getInventoryMovements(id: string, token: string): Promise<InventoryMovement[]> {
+    const response = await fetch(`${API_URL}/products/${id}/inventory-movements`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) {
+      const result = await response.json().catch(() => ({}));
+      throw new Error(result?.message || result?.errors?.[0]?.message || 'Failed to fetch inventory movements');
+    }
+    const result = await response.json();
+    return result.data || [];
   },
 
   async getById(id: string, token?: string): Promise<Product> {


### PR DESCRIPTION
## Summary
- Nuevo modelo `InventoryMovement` que registra cada cambio de stock: alta de producto (`restock`), ajuste manual desde el admin (`manual_adjustment`) y venta confirmada (`sale`), guardando stock anterior/nuevo, motivo, usuario responsable y fecha.
- Nuevo endpoint `GET /api/products/:id/inventory-movements` (solo admin) para consultar el historial por producto.
- El registro de venta se integra dentro de la misma transaccion de `finalizePaidOrder`, sin afectar el flujo de pago si el registro fallara.
- En el admin: boton de historial (icono de reloj) en la tabla de productos que abre un modal con el listado de movimientos, y un campo de "motivo del ajuste" en el formulario de edicion que aparece solo cuando el stock cambia.

## Test plan
- [x] `e2e/inventory-movements.spec.ts` (9 tests): 403 no-admin, 404 producto inexistente, alta registra movimiento `restock`, alta sin stock inicial no registra nada, ajuste manual con motivo/usuario/fecha, motivo por defecto si no se envia, sin movimiento si el stock no cambia, venta automatica al confirmar compra, aislamiento de historial por producto.
- [x] Suite completa de Playwright: 86/86 tests pasando (sin regresiones).
- [x] Verificacion manual en navegador: edicion de stock con motivo personalizado desde el modal de admin, confirmando que el historial muestra el motivo correcto, el delta de stock y el usuario que realizo el cambio.

Closes #145