### PR TITLE
feat(mcp): exponer tool get_product para el issue #189

### DIFF
--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -1,4 +1,5 @@
 import { Context } from 'hono';
+import mongoose from 'mongoose';
 import { Product } from '../models/Product';
 import { InventoryMovement } from '../models/InventoryMovement';
 import { recordInventoryMovement } from '../services/inventory.service';
@@ -60,6 +61,10 @@ export const getProducts = async (c: Context) => {
 export const getProductById = async (c: Context) => {
   try {
     const id = c.req.param('id');
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return c.json({ success: false, message: 'ID de producto invalido' }, 400);
+    }
+
     const product = await Product.findById(id);
     
     if (!product) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       - ./backend/.env:/app/.env
     environment:
       - PORT=3000
-      - MONGODB_URI=mongodb://mongodb:27017/safetech
       - NODE_ENV=development
     depends_on:
       mongodb:

--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -3,6 +3,7 @@ import type { AuthInfo } from '@modelcontextprotocol/server';
 import type { AppEnv } from './config/env.js';
 import type { BackendApiClient } from './services/backend-api.js';
 import { registerSearchProductsTool } from './tools/public/search-products.tool.js';
+import { registerGetProductTool } from './tools/public/get-product.tool.js';
 import type { Logger } from './utils/logger.js';
 
 interface ServerDependencies {
@@ -20,6 +21,7 @@ export function buildServer({ env, logger, backendApi, authInfo }: ServerDepende
   });
 
   registerSearchProductsTool(server, { env, logger, backendApi });
+  registerGetProductTool(server, { env, logger, backendApi });
 
   return server;
 }

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -35,6 +35,9 @@ class FakeAuthenticator implements Authenticator {
 
 class FakeBackendApi extends BackendApiClient {
   shouldFailProducts = false;
+  shouldFailGetProduct = false;
+  shouldNotFindProduct = false;
+  shouldRejectProductId = false;
 
   constructor() {
     super('http://backend.test/api');
@@ -80,6 +83,43 @@ class FakeBackendApi extends BackendApiClient {
 
     return {
       data: filters.name ? data.filter((product) => product.name.includes(filters.name!)) : data,
+    };
+  }
+
+  override async getProduct(productId: string) {
+    if (this.shouldRejectProductId) {
+      throw new BackendApiError('Invalid product id', 400, {
+        success: false,
+        message: 'ID de producto invalido',
+      });
+    }
+
+    if (this.shouldNotFindProduct) {
+      throw new BackendApiError('Product not found', 404, {
+        success: false,
+        message: 'Producto no encontrado',
+      });
+    }
+
+    if (this.shouldFailGetProduct) {
+      throw new BackendApiError('Unexpected backend error', 500, {
+        success: false,
+        message: 'Unexpected error',
+      });
+    }
+
+    return {
+      data: {
+        id: productId,
+        name: 'iPhone 13 Reacondicionado',
+        description: '128GB',
+        price: 699,
+        stock: 4,
+        condition: 'A' as const,
+        category: 'celular' as const,
+        primaryImageUrl: 'https://cdn.test/iphone.jpg',
+        imageUrls: ['https://cdn.test/iphone.jpg', 'https://cdn.test/iphone-back.jpg'],
+      },
     };
   }
 }
@@ -179,8 +219,11 @@ test('mcp handshake works and exposes search_products tool', async () => {
   assert.equal(serverVersion?.name, 'SafeTech MCP Server');
 
   const tools = await client.listTools();
-  assert.equal(tools.tools.length, 1);
-  assert.equal(tools.tools[0]?.name, 'search_products');
+  assert.equal(tools.tools.length, 2);
+  assert.deepEqual(
+    tools.tools.map((tool) => tool.name).sort(),
+    ['get_product', 'search_products'],
+  );
 
   const result = await client.callTool({
     name: 'search_products',
@@ -209,6 +252,179 @@ test('mcp handshake works and exposes search_products tool', async () => {
       name: 'iPhone',
       limit: 5,
     },
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('get_product returns normalized product detail', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'get_product',
+    arguments: {
+      id: '507f1f77bcf86cd799439011',
+    },
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.deepEqual(result.structuredContent, {
+    id: '507f1f77bcf86cd799439011',
+    name: 'iPhone 13 Reacondicionado',
+    description: '128GB',
+    price: 699,
+    stock: 4,
+    condition: 'A',
+    category: 'celular',
+    primaryImageUrl: 'https://cdn.test/iphone.jpg',
+    imageUrls: ['https://cdn.test/iphone.jpg', 'https://cdn.test/iphone-back.jpg'],
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('get_product normalizes not found errors', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldNotFindProduct = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'get_product',
+    arguments: {
+      id: '507f1f77bcf86cd799439099',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'PRODUCT_NOT_FOUND',
+    message: 'No se encontro un producto con el identificador indicado.',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('get_product normalizes invalid id errors', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectProductId = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'get_product',
+    arguments: {
+      id: 'bad-id',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'INVALID_PRODUCT_ID',
+    message: 'El identificador del producto no es valido.',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('get_product normalizes backend failures', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldFailGetProduct = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'get_product',
+    arguments: {
+      id: '507f1f77bcf86cd799439011',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'BACKEND_500',
+    message: 'No fue posible obtener el detalle del producto en este momento.',
   });
 
   await transport.terminateSession();

--- a/mcp-server/src/services/backend-api.ts
+++ b/mcp-server/src/services/backend-api.ts
@@ -1,4 +1,10 @@
-import type { BackendHealth, ProductListResponse, ProductSummary } from '../types.js';
+import type {
+  BackendHealth,
+  ProductDetail,
+  ProductDetailResponse,
+  ProductListResponse,
+  ProductSummary,
+} from '../types.js';
 
 export class BackendApiError extends Error {
   constructor(
@@ -55,6 +61,29 @@ export class BackendApiClient {
         category: product.category,
         primaryImageUrl: product.image_urls?.[0],
       })),
+    };
+  }
+
+  async getProduct(productId: string, requestId: string): Promise<{ data: ProductDetail }> {
+    const response = await this.request<ProductDetailResponse>(`/products/${productId}`, {
+      method: 'GET',
+      headers: {
+        'x-request-id': requestId,
+      },
+    });
+
+    return {
+      data: {
+        id: response.data._id,
+        name: response.data.name,
+        description: response.data.description,
+        price: response.data.price,
+        stock: response.data.stock,
+        condition: response.data.condition,
+        category: response.data.category,
+        primaryImageUrl: response.data.image_urls?.[0],
+        imageUrls: response.data.image_urls ?? [],
+      },
     };
   }
 

--- a/mcp-server/src/tools/public/get-product.tool.ts
+++ b/mcp-server/src/tools/public/get-product.tool.ts
@@ -1,0 +1,145 @@
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+import { logAuditEvent } from '../../services/audit-log.js';
+import { BackendApiError, type BackendApiClient } from '../../services/backend-api.js';
+import type { AppEnv } from '../../config/env.js';
+import type { ProductDetail } from '../../types.js';
+import type { Logger } from '../../utils/logger.js';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { buildToolMeta } from '../access-control.js';
+
+const getProductInputSchema = z.object({
+  id: z.string().trim().min(1).max(100),
+});
+
+const productDetailSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  price: z.number(),
+  stock: z.number().int(),
+  condition: z.enum(['A', 'B', 'C']),
+  category: z.enum(['celular', 'laptop', 'pc', 'auriculares', 'tablet']),
+  primaryImageUrl: z.string().url().optional(),
+  imageUrls: z.array(z.string().url()),
+});
+
+interface RegisterGetProductToolDependencies {
+  env: AppEnv;
+  logger: Logger;
+  backendApi: BackendApiClient;
+}
+
+export function registerGetProductTool(
+  server: McpServer,
+  { env, logger, backendApi }: RegisterGetProductToolDependencies,
+) {
+  server.registerTool(
+    'get_product',
+    {
+      title: 'Get Product',
+      description: 'Obtiene el detalle de un producto del catalogo de SafeTech por su identificador.',
+      inputSchema: getProductInputSchema,
+      outputSchema: productDetailSchema,
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
+      _meta: {
+        ...buildToolMeta('user', {
+          issue: '#189',
+          source: `${env.BACKEND_API_URL}/products/:id`,
+        }),
+      },
+    },
+    async (input, ctx) => {
+      const auditRequestId = randomUUID();
+      const startedAt = Date.now();
+      const actor = ctx.http?.authInfo?.clientId ?? 'anonymous';
+
+      try {
+        const response = await backendApi.getProduct(input.id, auditRequestId);
+        const output = normalizeProduct(response.data);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role: extractRole(ctx),
+          action: 'tool.get_product',
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output) }],
+          structuredContent: output,
+        };
+      } catch (error) {
+        const normalizedError = normalizeToolError(error);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role: extractRole(ctx),
+          action: 'tool.get_product',
+          outcome: 'error',
+          durationMs: Date.now() - startedAt,
+          errorCode: normalizedError.code,
+        });
+
+        return {
+          content: [{ type: 'text', text: normalizedError.message }],
+          structuredContent: normalizedError,
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function normalizeProduct(product: ProductDetail): z.infer<typeof productDetailSchema> {
+  return {
+    id: product.id,
+    name: product.name,
+    ...(product.description ? { description: product.description } : {}),
+    price: product.price,
+    stock: product.stock,
+    condition: product.condition,
+    category: product.category,
+    ...(product.primaryImageUrl ? { primaryImageUrl: product.primaryImageUrl } : {}),
+    imageUrls: product.imageUrls,
+  };
+}
+
+function extractRole(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  const roleScope = ctx.http?.authInfo?.scopes?.find((scope) => scope.startsWith('role:'));
+  return roleScope?.replace('role:', '') ?? 'unknown';
+}
+
+function normalizeToolError(error: unknown) {
+  if (error instanceof BackendApiError) {
+    if (error.status === 400) {
+      return {
+        code: 'INVALID_PRODUCT_ID',
+        message: 'El identificador del producto no es valido.',
+      };
+    }
+
+    if (error.status === 404) {
+      return {
+        code: 'PRODUCT_NOT_FOUND',
+        message: 'No se encontro un producto con el identificador indicado.',
+      };
+    }
+
+    return {
+      code: `BACKEND_${error.status}`,
+      message: 'No fue posible obtener el detalle del producto en este momento.',
+    };
+  }
+
+  return {
+    code: 'INTERNAL_ERROR',
+    message: 'Ocurrio un error inesperado al obtener el detalle del producto.',
+  };
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -29,6 +29,10 @@ export interface ProductSummary {
   primaryImageUrl?: string;
 }
 
+export interface ProductDetail extends ProductSummary {
+  imageUrls: string[];
+}
+
 export interface ProductListResponse {
   success: boolean;
   data: Array<{
@@ -44,4 +48,21 @@ export interface ProductListResponse {
     updatedAt?: string;
     __v?: number;
   }>;
+}
+
+export interface ProductDetailResponse {
+  success: boolean;
+  data: {
+    _id: string;
+    name: string;
+    description?: string;
+    price: number;
+    stock: number;
+    condition: 'A' | 'B' | 'C';
+    category: 'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet';
+    image_urls?: string[];
+    createdAt?: string;
+    updatedAt?: string;
+    __v?: number;
+  };
 }


### PR DESCRIPTION
## Resumen
Este PR resuelve el issue técnico MCP  exponiendo la tool  sobre la lógica ya existente de .

## Cambios
- agrega la tool MCP 
- registra la tool en el bootstrap del servidor MCP
- extiende el cliente interno del backend y los tipos para detalle de producto
- normaliza la salida del producto para uso por agentes
- normaliza errores para id inválido, producto no encontrado y fallos backend
- valida ids de producto malformados en 
- ajusta  para que el backend use  desde 

## Validaciones
-  en 
- prueba manual MCP con producto existente
- prueba manual MCP con id inválido
- prueba manual MCP con ObjectId válido inexistente

## Riesgos o pendientes
- la mejora de validación de id en backend quedó validada de forma end-to-end; no se agregó una prueba backend aislada

## Issue relacionado
Closes #189