### PR TITLE
feat: exponer list_my_orders como tool MCP

### DIFF
--- a/backend/src/middlewares/auth.middleware.ts
+++ b/backend/src/middlewares/auth.middleware.ts
@@ -1,8 +1,45 @@
-import { verifyToken, createClerkClient } from '@clerk/backend';
+import { createClerkClient } from '@clerk/backend';
 import { Context, Next } from 'hono';
 import { User } from '../models/User';
 import { Technician } from '../models/Technician';
 import { getE2EPrincipalFromToken } from '../lib/e2e';
+
+type AuthenticatedRequestContext = {
+  userId: string;
+  tokenType: 'session_token' | 'oauth_token' | string;
+  sessionClaims?: Record<string, unknown>;
+};
+
+const getClerkClient = () =>
+  createClerkClient({
+    secretKey: process.env.CLERK_SECRET_KEY,
+    publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
+  });
+
+const authenticateClerkRequest = async (request: Request): Promise<AuthenticatedRequestContext> => {
+  const clerk = getClerkClient();
+  const authState = await clerk.authenticateRequest(request, {
+    acceptsToken: ['session_token', 'oauth_token'],
+  });
+
+  if (!authState.isAuthenticated) {
+    throw new Error(`Token verification failed: ${authState.reason ?? 'unknown_reason'}`);
+  }
+
+  const authObject = authState.toAuth();
+  const userId = authObject?.userId;
+
+  if (!userId) {
+    throw new Error('Invalid token payload: missing userId');
+  }
+
+  return {
+    userId,
+    tokenType: authState.tokenType,
+    sessionClaims:
+      authState.tokenType === 'session_token' ? ((authObject.sessionClaims as Record<string, unknown> | undefined) ?? undefined) : undefined,
+  };
+};
 
 export const clerkAuthMiddleware = async (c: Context, next: Next) => {
   const authHeader = c.req.header('Authorization');
@@ -22,15 +59,8 @@ export const clerkAuthMiddleware = async (c: Context, next: Next) => {
   }
 
   try {
-    const payload = await verifyToken(token, {
-      secretKey: process.env.CLERK_SECRET_KEY,
-    });
-
-    if (!payload.sub) {
-      return c.json({ error: 'Unauthorized: Invalid token payload' }, 401);
-    }
-
-    c.set('userId', payload.sub);
+    const auth = await authenticateClerkRequest(c.req.raw);
+    c.set('userId', auth.userId);
     await next();
   } catch (error) {
     console.error('[Auth] Clerk Auth Error:', error);
@@ -60,30 +90,34 @@ export const adminAuthMiddleware = async (c: Context, next: Next) => {
   }
   
   try {
-    const payload = await verifyToken(token, {
-      secretKey: process.env.CLERK_SECRET_KEY,
-    });
-    
-    if (!payload.sub) {
-      return c.json({ error: 'Unauthorized: Invalid token payload' }, 401);
-    }
+    const auth = await authenticateClerkRequest(c.req.raw);
 
     // Checking role directly from local MongoDB User document explicitly
-    const userDoc = await User.findOne({ clerk_id: payload.sub });
+    const userDoc = await User.findOne({ clerk_id: auth.userId });
     
     // Check Clerk Metadata directly
-    const clerk = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY });
-    const clerkUser = await clerk.users.getUser(payload.sub).catch(() => null);
+    const clerk = getClerkClient();
+    const clerkUser = await clerk.users.getUser(auth.userId).catch(() => null);
     
     // Fallback checking to Token custom claims if DB is not matching
-    const tokenRole = (payload.metadata?.role as string) || (payload as any).org_role || (payload as any).role;
+    const tokenClaims = auth.sessionClaims as
+      | {
+          metadata?: { role?: unknown };
+          org_role?: unknown;
+          role?: unknown;
+        }
+      | undefined;
+    const tokenRole =
+      (tokenClaims?.metadata?.role as string | undefined) ||
+      (tokenClaims?.org_role as string | undefined) ||
+      (tokenClaims?.role as string | undefined);
     const clerkApiRole = clerkUser?.publicMetadata?.role;
 
     if (userDoc?.role !== 'admin' && tokenRole !== 'admin' && clerkApiRole !== 'admin') {
       return c.json({ error: 'Forbidden: Insufficient privileges' }, 403);
     }
 
-    c.set('userId', payload.sub);
+    c.set('userId', auth.userId);
     await next();
   } catch (error) {
     console.error('[Admin Auth] Error:', error);
@@ -117,23 +151,22 @@ export const technicianAuthMiddleware = async (c: Context, next: Next) => {
   }
 
   try {
-    const payload = await verifyToken(token, { secretKey: process.env.CLERK_SECRET_KEY });
-    if (!payload.sub) return c.json({ error: 'Unauthorized: Invalid token payload' }, 401);
+    const auth = await authenticateClerkRequest(c.req.raw);
 
-    const clerk = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY });
-    const clerkUser = await clerk.users.getUser(payload.sub).catch(() => null);
+    const clerk = getClerkClient();
+    const clerkUser = await clerk.users.getUser(auth.userId).catch(() => null);
     const role = clerkUser?.publicMetadata?.role;
 
     if (role !== 'technician') {
       return c.json({ error: 'Forbidden: Not a technician' }, 403);
     }
 
-    const tech = await Technician.findOne({ clerkId: payload.sub });
+    const tech = await Technician.findOne({ clerkId: auth.userId });
     if (!tech) {
       return c.json({ error: 'Forbidden: Technician record not linked to this Clerk account' }, 403);
     }
 
-    c.set('userId', payload.sub);
+    c.set('userId', auth.userId);
     c.set('technicianDocId', (tech._id as any).toString());
     await next();
   } catch (error) {

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,7 @@
 
 Base tecnica del servidor MCP de SafeTech para el issue `#187`, con transporte HTTP remoto y transporte local por `stdio`.
 
-## Alcance
+## Alcance base
 
 - Servidor MCP remoto independiente.
 - Servidor MCP local por `stdio` para pruebas con clientes MCP.
@@ -12,7 +12,7 @@ Base tecnica del servidor MCP de SafeTech para el issue `#187`, con transporte H
 - Logging y auditoria base.
 - Healthcheck del servicio.
 
-No expone tools de negocio en esta fase.
+La fase inicial del issue `#187` no debia exponer tools de negocio. El estado actual del repositorio ya incluye tools MCP de negocio sobre esa base y debe mantenerse alineado con los issues tecnicos de exposicion.
 
 ## Variables
 

--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -4,6 +4,7 @@ import type { AppEnv } from './config/env.js';
 import type { BackendApiClient } from './services/backend-api.js';
 import { registerSearchProductsTool } from './tools/public/search-products.tool.js';
 import { registerGetProductTool } from './tools/public/get-product.tool.js';
+import { registerListMyOrdersTool } from './tools/user/list-my-orders.tool.js';
 import type { Logger } from './utils/logger.js';
 
 interface ServerDependencies {
@@ -22,6 +23,7 @@ export function buildServer({ env, logger, backendApi, authInfo }: ServerDepende
 
   registerSearchProductsTool(server, { env, logger, backendApi });
   registerGetProductTool(server, { env, logger, backendApi });
+  registerListMyOrdersTool(server, { env, logger, backendApi });
 
   return server;
 }

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -5,6 +5,7 @@ import { createApp } from './server.js';
 import type { Authenticator, AuthContext } from './types.js';
 import { BackendApiClient, BackendApiError } from './services/backend-api.js';
 import { createLogger } from './utils/logger.js';
+import type { OrderSummary } from './types.js';
 
 const env = {
   PORT: 3100,
@@ -38,6 +39,8 @@ class FakeBackendApi extends BackendApiClient {
   shouldFailGetProduct = false;
   shouldNotFindProduct = false;
   shouldRejectProductId = false;
+  shouldRejectOrdersAuth = false;
+  lastOrdersToken?: string;
 
   constructor() {
     super('http://backend.test/api');
@@ -120,6 +123,68 @@ class FakeBackendApi extends BackendApiClient {
         primaryImageUrl: 'https://cdn.test/iphone.jpg',
         imageUrls: ['https://cdn.test/iphone.jpg', 'https://cdn.test/iphone-back.jpg'],
       },
+    };
+  }
+
+  override async getMyOrders(token: string, _requestId: string): Promise<{ data: OrderSummary[] }> {
+    this.lastOrdersToken = token;
+
+    if (this.shouldRejectOrdersAuth) {
+      throw new BackendApiError('Unauthorized', 401, {
+        error: 'Unauthorized: User ID not found',
+      });
+    }
+
+    return {
+      data: [
+        {
+          id: 'ord_1',
+          totalAmount: 1598,
+          status: 'paid',
+          createdAt: '2026-07-01T10:00:00.000Z',
+          updatedAt: '2026-07-01T10:05:00.000Z',
+          stripeSessionId: 'cs_test_123',
+          paymentIntentId: 'pi_test_123',
+          carrier: 'DHL',
+          trackingNumber: 'TRACK123',
+          shippingAddress: {
+            recipientName: 'Derlin Romero',
+            city: 'Panama',
+            country: 'PA',
+          },
+          items: [
+            {
+              id: 'item_1',
+              quantity: 1,
+              price: 699,
+              product: {
+                id: 'prod_1',
+                name: 'iPhone 13 Reacondicionado',
+                description: '128GB',
+                price: 699,
+                stock: 4,
+                condition: 'A' as const,
+                category: 'celular' as const,
+                primaryImageUrl: 'https://cdn.test/iphone.jpg',
+              },
+            },
+            {
+              id: 'item_2',
+              quantity: 1,
+              price: 899,
+              product: {
+                id: 'prod_2',
+                name: 'Laptop ThinkPad X1',
+                price: 899,
+                stock: 0,
+                condition: 'B' as const,
+                category: 'laptop' as const,
+                primaryImageUrl: 'https://cdn.test/thinkpad.jpg',
+              },
+            },
+          ],
+        },
+      ],
     };
   }
 }
@@ -219,10 +284,10 @@ test('mcp handshake works and exposes search_products tool', async () => {
   assert.equal(serverVersion?.name, 'SafeTech MCP Server');
 
   const tools = await client.listTools();
-  assert.equal(tools.tools.length, 2);
+  assert.equal(tools.tools.length, 3);
   assert.deepEqual(
     tools.tools.map((tool) => tool.name).sort(),
-    ['get_product', 'search_products'],
+    ['get_product', 'list_my_orders', 'search_products'],
   );
 
   const result = await client.callTool({
@@ -252,6 +317,133 @@ test('mcp handshake works and exposes search_products tool', async () => {
       name: 'iPhone',
       limit: 5,
     },
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('list_my_orders returns normalized orders for the authenticated user', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'list_my_orders',
+    arguments: {},
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.equal(backendApi.lastOrdersToken, 'test-token');
+  assert.deepEqual(result.structuredContent, {
+    orders: [
+      {
+        id: 'ord_1',
+        totalAmount: 1598,
+        status: 'paid',
+        createdAt: '2026-07-01T10:00:00.000Z',
+        updatedAt: '2026-07-01T10:05:00.000Z',
+        stripeSessionId: 'cs_test_123',
+        paymentIntentId: 'pi_test_123',
+        carrier: 'DHL',
+        trackingNumber: 'TRACK123',
+        shippingAddress: {
+          recipientName: 'Derlin Romero',
+          city: 'Panama',
+          country: 'PA',
+        },
+        items: [
+          {
+            id: 'item_1',
+            quantity: 1,
+            price: 699,
+            product: {
+              id: 'prod_1',
+              name: 'iPhone 13 Reacondicionado',
+              description: '128GB',
+              price: 699,
+              stock: 4,
+              condition: 'A',
+              category: 'celular',
+              primaryImageUrl: 'https://cdn.test/iphone.jpg',
+            },
+          },
+          {
+            id: 'item_2',
+            quantity: 1,
+            price: 899,
+            product: {
+              id: 'prod_2',
+              name: 'Laptop ThinkPad X1',
+              price: 899,
+              stock: 0,
+              condition: 'B',
+              category: 'laptop',
+              primaryImageUrl: 'https://cdn.test/thinkpad.jpg',
+            },
+          },
+        ],
+      },
+    ],
+    count: 1,
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('list_my_orders rejects authenticated backend failures in a controlled way', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectOrdersAuth = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'list_my_orders',
+    arguments: {},
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'AUTH_REQUIRED',
+    message: 'La sesion no es valida para consultar pedidos.',
   });
 
   await transport.terminateSession();

--- a/mcp-server/src/services/backend-api.ts
+++ b/mcp-server/src/services/backend-api.ts
@@ -1,5 +1,7 @@
 import type {
+  BackendOrderResponse,
   BackendHealth,
+  OrderSummary,
   ProductDetail,
   ProductDetailResponse,
   ProductListResponse,
@@ -84,6 +86,52 @@ export class BackendApiClient {
         primaryImageUrl: response.data.image_urls?.[0],
         imageUrls: response.data.image_urls ?? [],
       },
+    };
+  }
+
+  async getMyOrders(token: string, requestId: string): Promise<{ data: OrderSummary[] }> {
+    const response = await this.request<BackendOrderResponse[]>('/orders/mine', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'x-request-id': requestId,
+      },
+    });
+
+    return {
+      data: response.map((order) => ({
+        id: order._id,
+        totalAmount: order.total_amount,
+        status: order.status,
+        createdAt: order.createdAt,
+        updatedAt: order.updatedAt,
+        ...(order.stripe_session_id ? { stripeSessionId: order.stripe_session_id } : {}),
+        ...(order.payment_intent_id ? { paymentIntentId: order.payment_intent_id } : {}),
+        ...(order.carrier ? { carrier: order.carrier } : {}),
+        ...(order.trackingNumber ? { trackingNumber: order.trackingNumber } : {}),
+        ...(order.shippingAddress ? { shippingAddress: order.shippingAddress } : {}),
+        items: (order.items ?? []).map((item) => ({
+          id: item._id,
+          quantity: item.quantity,
+          price: item.price,
+          ...(item.product?._id
+            ? {
+                product: {
+                  id: item.product._id,
+                  ...(item.product.name ? { name: item.product.name } : {}),
+                  ...(item.product.description ? { description: item.product.description } : {}),
+                  ...(item.product.price !== undefined ? { price: item.product.price } : {}),
+                  ...(item.product.stock !== undefined ? { stock: item.product.stock } : {}),
+                  ...(item.product.condition ? { condition: item.product.condition } : {}),
+                  ...(item.product.category ? { category: item.product.category } : {}),
+                  ...(item.product.image_urls?.[0]
+                    ? { primaryImageUrl: item.product.image_urls[0] }
+                    : {}),
+                },
+              }
+            : {}),
+        })),
+      })),
     };
   }
 

--- a/mcp-server/src/tools/user/list-my-orders.tool.ts
+++ b/mcp-server/src/tools/user/list-my-orders.tool.ts
@@ -1,0 +1,195 @@
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { z } from 'zod';
+import type { AppEnv } from '../../config/env.js';
+import { logAuditEvent } from '../../services/audit-log.js';
+import { BackendApiError, type BackendApiClient } from '../../services/backend-api.js';
+import type { Logger } from '../../utils/logger.js';
+import { buildToolMeta } from '../access-control.js';
+
+const listMyOrdersInputSchema = z.object({}).strict();
+
+const orderProductSchema = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  price: z.number().optional(),
+  stock: z.number().int().optional(),
+  condition: z.enum(['A', 'B', 'C']).optional(),
+  category: z.enum(['celular', 'laptop', 'pc', 'auriculares', 'tablet']).optional(),
+  primaryImageUrl: z.string().url().optional(),
+});
+
+const orderItemSchema = z.object({
+  id: z.string(),
+  quantity: z.number().int().min(1),
+  price: z.number(),
+  product: orderProductSchema.optional(),
+});
+
+const shippingAddressSchema = z.object({
+  recipientName: z.string().optional(),
+  phone: z.string().optional(),
+  street: z.string().optional(),
+  city: z.string().optional(),
+  state: z.string().optional(),
+  zipCode: z.string().optional(),
+  country: z.string().optional(),
+});
+
+const orderSummarySchema = z.object({
+  id: z.string(),
+  totalAmount: z.number(),
+  status: z.enum(['pending', 'paid', 'processing', 'shipped', 'delivered', 'failed']),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  stripeSessionId: z.string().optional(),
+  paymentIntentId: z.string().optional(),
+  carrier: z.string().optional(),
+  trackingNumber: z.string().optional(),
+  shippingAddress: shippingAddressSchema.optional(),
+  items: z.array(orderItemSchema),
+});
+
+const listMyOrdersOutputSchema = z.object({
+  orders: z.array(orderSummarySchema),
+  count: z.number().int().min(0),
+});
+
+interface RegisterListMyOrdersToolDependencies {
+  env: AppEnv;
+  logger: Logger;
+  backendApi: BackendApiClient;
+}
+
+export function registerListMyOrdersTool(
+  server: McpServer,
+  { env, logger, backendApi }: RegisterListMyOrdersToolDependencies,
+) {
+  server.registerTool(
+    'list_my_orders',
+    {
+      title: 'List My Orders',
+      description: 'Devuelve los pedidos del usuario autenticado en SafeTech con estado, monto, fechas e items asociados.',
+      inputSchema: listMyOrdersInputSchema,
+      outputSchema: listMyOrdersOutputSchema,
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
+      _meta: {
+        ...buildToolMeta('user', {
+          issue: '#190',
+          source: `${env.BACKEND_API_URL}/orders/mine`,
+        }),
+      },
+    },
+    async (_input, ctx) => {
+      const auditRequestId = randomUUID();
+      const startedAt = Date.now();
+      const authInfo = getAuthInfo(ctx);
+      const actor = authInfo?.clientId ?? 'anonymous';
+      const token = authInfo?.token;
+
+      try {
+        if (!token) {
+          const authError = {
+            code: 'AUTH_REQUIRED',
+            message: 'Se requiere autenticacion para consultar los pedidos del usuario.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role: extractRole(ctx),
+            action: 'tool.list_my_orders',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: authError.code,
+          });
+
+          return {
+            content: [{ type: 'text', text: authError.message }],
+            structuredContent: authError,
+            isError: true,
+          };
+        }
+
+        const response = await backendApi.getMyOrders(token, auditRequestId);
+        const output = {
+          orders: response.data,
+          count: response.data.length,
+        };
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role: extractRole(ctx),
+          action: 'tool.list_my_orders',
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output) }],
+          structuredContent: output,
+        };
+      } catch (error) {
+        const normalizedError = normalizeToolError(error);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role: extractRole(ctx),
+          action: 'tool.list_my_orders',
+          outcome: 'error',
+          durationMs: Date.now() - startedAt,
+          errorCode: normalizedError.code,
+        });
+
+        return {
+          content: [{ type: 'text', text: normalizedError.message }],
+          structuredContent: normalizedError,
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function extractRole(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  const roleScope = getAuthInfo(ctx)?.scopes?.find((scope: string) => scope.startsWith('role:'));
+  return roleScope?.replace('role:', '') ?? 'unknown';
+}
+
+function getAuthInfo(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  return ctx.http?.authInfo ?? (ctx as { authInfo?: { token?: string; clientId?: string; scopes?: string[] } }).authInfo;
+}
+
+function normalizeToolError(error: unknown) {
+  if (error instanceof BackendApiError) {
+    if (error.status === 401) {
+      return {
+        code: 'AUTH_REQUIRED',
+        message: 'La sesion no es valida para consultar pedidos.',
+      };
+    }
+
+    if (error.status === 403) {
+      return {
+        code: 'FORBIDDEN',
+        message: 'No tienes permiso para consultar estos pedidos.',
+      };
+    }
+
+    return {
+      code: `BACKEND_${error.status}`,
+      message: 'No fue posible consultar los pedidos en este momento.',
+    };
+  }
+
+  return {
+    code: 'INTERNAL_ERROR',
+    message: 'Ocurrio un error inesperado al consultar los pedidos.',
+  };
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -66,3 +66,75 @@ export interface ProductDetailResponse {
     __v?: number;
   };
 }
+
+export interface OrderProductSummary {
+  id: string;
+  name?: string;
+  description?: string;
+  price?: number;
+  stock?: number;
+  condition?: 'A' | 'B' | 'C';
+  category?: 'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet';
+  primaryImageUrl?: string;
+}
+
+export interface OrderItemSummary {
+  id: string;
+  quantity: number;
+  price: number;
+  product?: OrderProductSummary;
+}
+
+export interface ShippingAddressSummary {
+  recipientName?: string;
+  phone?: string;
+  street?: string;
+  city?: string;
+  state?: string;
+  zipCode?: string;
+  country?: string;
+}
+
+export interface OrderSummary {
+  id: string;
+  totalAmount: number;
+  status: 'pending' | 'paid' | 'processing' | 'shipped' | 'delivered' | 'failed';
+  createdAt: string;
+  updatedAt: string;
+  stripeSessionId?: string;
+  paymentIntentId?: string;
+  carrier?: string;
+  trackingNumber?: string;
+  shippingAddress?: ShippingAddressSummary;
+  items: OrderItemSummary[];
+}
+
+export interface BackendOrderItemResponse {
+  _id: string;
+  quantity: number;
+  price: number;
+  product?: {
+    _id?: string;
+    name?: string;
+    description?: string;
+    price?: number;
+    stock?: number;
+    condition?: 'A' | 'B' | 'C';
+    category?: 'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet';
+    image_urls?: string[];
+  };
+}
+
+export interface BackendOrderResponse {
+  _id: string;
+  total_amount: number;
+  status: 'pending' | 'paid' | 'processing' | 'shipped' | 'delivered' | 'failed';
+  createdAt: string;
+  updatedAt: string;
+  stripe_session_id?: string;
+  payment_intent_id?: string;
+  carrier?: string;
+  trackingNumber?: string;
+  shippingAddress?: ShippingAddressSummary;
+  items?: BackendOrderItemResponse[];
+}


### PR DESCRIPTION
## Resumen

Este PR expone el tool  en el , reutilizando la lógica existente de  para consultar únicamente los pedidos del usuario autenticado.

Además, ajusta la autenticación del backend para aceptar el token OAuth propagado por el MCP remoto sin romper compatibilidad con el flujo actual del frontend.

## Cambios

- agrega el tool  en 
- integra la llamada autenticada a 
- normaliza la respuesta de pedidos para uso por agentes
- normaliza errores del tool
- agrega auditoría del tool
- agrega pruebas de registro, ejecución feliz y error controlado
- actualiza el README del MCP para reflejar tools de negocio ya expuestos
- actualiza los middlewares protegidos del backend para aceptar  y  de Clerk
- preserva las validaciones de rol existentes para  y 

## Validaciones

-  en 
-  en 
- prueba remota end-to-end de  desde ChatGPT/MCP
- validación de que el tool no acepta  manual
- validación del caso sin pedidos:
  - 

## Resultado funcional verificado

- el tool aparece en el servidor MCP
- el tool consulta solo los pedidos del usuario autenticado
- el tool no permite consultar pedidos de terceros mediante 
- el tool maneja autenticación de forma controlada
- el flujo remoto con Clerk quedó operativo tras ajustar el backend para 

## Commits incluidos

-  
-  

## Riesgos o pendientes

- la validación remota se realizó con una cuenta sin pedidos, por lo que no se verificó con datos reales poblados
- aun así, se verificó correctamente el flujo autenticado, el contrato de salida vacío y la restricción de acceso por identidad

## Issue relacionado

Closes #190
