### PR TITLE
feat: exponer MCP tool list_my_warranties

### DIFF
--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -5,6 +5,7 @@ import type { BackendApiClient } from './services/backend-api.js';
 import { registerSearchProductsTool } from './tools/public/search-products.tool.js';
 import { registerGetProductTool } from './tools/public/get-product.tool.js';
 import { registerListMyOrdersTool } from './tools/user/list-my-orders.tool.js';
+import { registerListMyWarrantiesTool } from './tools/user/list-my-warranties.tool.js';
 import type { Logger } from './utils/logger.js';
 
 interface ServerDependencies {
@@ -24,6 +25,7 @@ export function buildServer({ env, logger, backendApi, authInfo }: ServerDepende
   registerSearchProductsTool(server, { env, logger, backendApi });
   registerGetProductTool(server, { env, logger, backendApi });
   registerListMyOrdersTool(server, { env, logger, backendApi });
+  registerListMyWarrantiesTool(server, { env, logger, backendApi });
 
   return server;
 }

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -5,7 +5,7 @@ import { createApp } from './server.js';
 import type { Authenticator, AuthContext } from './types.js';
 import { BackendApiClient, BackendApiError } from './services/backend-api.js';
 import { createLogger } from './utils/logger.js';
-import type { OrderSummary } from './types.js';
+import type { OrderSummary, WarrantySummary } from './types.js';
 
 const env = {
   PORT: 3100,
@@ -40,7 +40,9 @@ class FakeBackendApi extends BackendApiClient {
   shouldNotFindProduct = false;
   shouldRejectProductId = false;
   shouldRejectOrdersAuth = false;
+  shouldRejectWarrantiesAuth = false;
   lastOrdersToken?: string;
+  lastWarrantiesToken?: string;
 
   constructor() {
     super('http://backend.test/api');
@@ -187,6 +189,41 @@ class FakeBackendApi extends BackendApiClient {
       ],
     };
   }
+
+  override async getMyWarranties(
+    token: string,
+    _requestId: string,
+  ): Promise<{ data: WarrantySummary[] }> {
+    this.lastWarrantiesToken = token;
+
+    if (this.shouldRejectWarrantiesAuth) {
+      throw new BackendApiError('Unauthorized', 401, {
+        error: 'Unauthorized: User ID not found',
+      });
+    }
+
+    return {
+      data: [
+        {
+          id: 'wr_1',
+          status: 'review',
+          description: '[battery] La bateria se descarga demasiado rapido',
+          evidenceUrls: ['https://cdn.test/warranty-1.jpg'],
+          createdAt: '2026-07-02T09:00:00.000Z',
+          updatedAt: '2026-07-03T12:00:00.000Z',
+          technicianId: 'tech_1',
+          technicianName: 'Maria Gomez',
+          order: {
+            id: 'ord_1',
+            totalAmount: 699,
+            status: 'paid',
+            createdAt: '2026-07-01T10:00:00.000Z',
+            updatedAt: '2026-07-01T10:05:00.000Z',
+          },
+        },
+      ],
+    };
+  }
 }
 
 test('health endpoint reports backend connectivity', async () => {
@@ -284,10 +321,10 @@ test('mcp handshake works and exposes search_products tool', async () => {
   assert.equal(serverVersion?.name, 'SafeTech MCP Server');
 
   const tools = await client.listTools();
-  assert.equal(tools.tools.length, 3);
+  assert.equal(tools.tools.length, 4);
   assert.deepEqual(
     tools.tools.map((tool) => tool.name).sort(),
-    ['get_product', 'list_my_orders', 'search_products'],
+    ['get_product', 'list_my_orders', 'list_my_warranties', 'search_products'],
   );
 
   const result = await client.callTool({
@@ -317,6 +354,103 @@ test('mcp handshake works and exposes search_products tool', async () => {
       name: 'iPhone',
       limit: 5,
     },
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('list_my_warranties returns normalized warranties for the authenticated user', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'list_my_warranties',
+    arguments: {},
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.equal(backendApi.lastWarrantiesToken, 'test-token');
+  assert.deepEqual(result.structuredContent, {
+    warranties: [
+      {
+        id: 'wr_1',
+        status: 'review',
+        description: '[battery] La bateria se descarga demasiado rapido',
+        evidenceUrls: ['https://cdn.test/warranty-1.jpg'],
+        createdAt: '2026-07-02T09:00:00.000Z',
+        updatedAt: '2026-07-03T12:00:00.000Z',
+        technicianId: 'tech_1',
+        technicianName: 'Maria Gomez',
+        order: {
+          id: 'ord_1',
+          totalAmount: 699,
+          status: 'paid',
+          createdAt: '2026-07-01T10:00:00.000Z',
+          updatedAt: '2026-07-01T10:05:00.000Z',
+        },
+      },
+    ],
+    count: 1,
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('list_my_warranties rejects authenticated backend failures in a controlled way', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectWarrantiesAuth = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'list_my_warranties',
+    arguments: {},
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'AUTH_REQUIRED',
+    message: 'La sesion no es valida para consultar garantias.',
   });
 
   await transport.terminateSession();

--- a/mcp-server/src/services/backend-api.ts
+++ b/mcp-server/src/services/backend-api.ts
@@ -1,11 +1,13 @@
 import type {
   BackendOrderResponse,
+  BackendWarrantyResponse,
   BackendHealth,
   OrderSummary,
   ProductDetail,
   ProductDetailResponse,
   ProductListResponse,
   ProductSummary,
+  WarrantySummary,
 } from '../types.js';
 
 export class BackendApiError extends Error {
@@ -135,6 +137,31 @@ export class BackendApiClient {
     };
   }
 
+  async getMyWarranties(token: string, requestId: string): Promise<{ data: WarrantySummary[] }> {
+    const response = await this.request<BackendWarrantyResponse[]>('/warranties/mine', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'x-request-id': requestId,
+      },
+    });
+
+    return {
+      data: response.map((warranty) => ({
+        id: warranty._id,
+        status: warranty.status,
+        description: warranty.description,
+        evidenceUrls: warranty.evidenceUrls ?? [],
+        createdAt: warranty.createdAt,
+        ...(warranty.updatedAt ? { updatedAt: warranty.updatedAt } : {}),
+        ...(warranty.resolvedAt ? { resolvedAt: warranty.resolvedAt } : {}),
+        ...(warranty.technicianId ? { technicianId: warranty.technicianId } : {}),
+        ...(warranty.technicianName ? { technicianName: warranty.technicianName } : {}),
+        order: normalizeWarrantyOrder(warranty.orderId),
+      })),
+    };
+  }
+
   private async request<T>(path: string, init: RequestInit): Promise<T> {
     const response = await fetch(`${this.baseUrl}${path}`, init);
     const text = await response.text();
@@ -154,4 +181,20 @@ function safeJsonParse(value: string): unknown {
   } catch {
     return value;
   }
+}
+
+function normalizeWarrantyOrder(order: BackendWarrantyResponse['orderId']) {
+  if (typeof order === 'string') {
+    return {
+      id: order,
+    };
+  }
+
+  return {
+    id: order._id ?? '',
+    ...(order.total_amount !== undefined ? { totalAmount: order.total_amount } : {}),
+    ...(order.status ? { status: order.status } : {}),
+    ...(order.createdAt ? { createdAt: order.createdAt } : {}),
+    ...(order.updatedAt ? { updatedAt: order.updatedAt } : {}),
+  };
 }

--- a/mcp-server/src/tools/user/list-my-warranties.tool.ts
+++ b/mcp-server/src/tools/user/list-my-warranties.tool.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { z } from 'zod';
+import type { AppEnv } from '../../config/env.js';
+import { logAuditEvent } from '../../services/audit-log.js';
+import { BackendApiError, type BackendApiClient } from '../../services/backend-api.js';
+import type { Logger } from '../../utils/logger.js';
+import { buildToolMeta } from '../access-control.js';
+
+const listMyWarrantiesInputSchema = z.object({}).strict();
+
+const warrantyOrderSchema = z.object({
+  id: z.string().min(1),
+  totalAmount: z.number().optional(),
+  status: z.enum(['pending', 'paid', 'processing', 'shipped', 'delivered', 'failed']).optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+
+const warrantySummarySchema = z.object({
+  id: z.string(),
+  status: z.enum(['pending', 'review', 'resolved', 'rejected', 'refunded']),
+  description: z.string(),
+  evidenceUrls: z.array(z.string().url()),
+  createdAt: z.string(),
+  updatedAt: z.string().optional(),
+  resolvedAt: z.string().optional(),
+  technicianId: z.string().optional(),
+  technicianName: z.string().optional(),
+  order: warrantyOrderSchema,
+});
+
+const listMyWarrantiesOutputSchema = z.object({
+  warranties: z.array(warrantySummarySchema),
+  count: z.number().int().min(0),
+});
+
+interface RegisterListMyWarrantiesToolDependencies {
+  env: AppEnv;
+  logger: Logger;
+  backendApi: BackendApiClient;
+}
+
+export function registerListMyWarrantiesTool(
+  server: McpServer,
+  { env, logger, backendApi }: RegisterListMyWarrantiesToolDependencies,
+) {
+  server.registerTool(
+    'list_my_warranties',
+    {
+      title: 'List My Warranties',
+      description: 'Devuelve los reclamos de garantia del usuario autenticado con su estado, fechas, orden relacionada y tecnico asignado si existe.',
+      inputSchema: listMyWarrantiesInputSchema,
+      outputSchema: listMyWarrantiesOutputSchema,
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
+      _meta: {
+        ...buildToolMeta('user', {
+          issue: '#191',
+          source: `${env.BACKEND_API_URL}/warranties/mine`,
+        }),
+      },
+    },
+    async (_input, ctx) => {
+      const auditRequestId = randomUUID();
+      const startedAt = Date.now();
+      const authInfo = getAuthInfo(ctx);
+      const actor = authInfo?.clientId ?? 'anonymous';
+      const token = authInfo?.token;
+
+      try {
+        if (!token) {
+          const authError = {
+            code: 'AUTH_REQUIRED',
+            message: 'Se requiere autenticacion para consultar las garantias del usuario.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role: extractRole(ctx),
+            action: 'tool.list_my_warranties',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: authError.code,
+          });
+
+          return {
+            content: [{ type: 'text', text: authError.message }],
+            structuredContent: authError,
+            isError: true,
+          };
+        }
+
+        const response = await backendApi.getMyWarranties(token, auditRequestId);
+        const output = {
+          warranties: response.data,
+          count: response.data.length,
+        };
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role: extractRole(ctx),
+          action: 'tool.list_my_warranties',
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output) }],
+          structuredContent: output,
+        };
+      } catch (error) {
+        const normalizedError = normalizeToolError(error);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role: extractRole(ctx),
+          action: 'tool.list_my_warranties',
+          outcome: 'error',
+          durationMs: Date.now() - startedAt,
+          errorCode: normalizedError.code,
+        });
+
+        return {
+          content: [{ type: 'text', text: normalizedError.message }],
+          structuredContent: normalizedError,
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function extractRole(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  const roleScope = getAuthInfo(ctx)?.scopes?.find((scope: string) => scope.startsWith('role:'));
+  return roleScope?.replace('role:', '') ?? 'unknown';
+}
+
+function getAuthInfo(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  return ctx.http?.authInfo ?? (ctx as { authInfo?: { token?: string; clientId?: string; scopes?: string[] } }).authInfo;
+}
+
+function normalizeToolError(error: unknown) {
+  if (error instanceof BackendApiError) {
+    if (error.status === 401) {
+      return {
+        code: 'AUTH_REQUIRED',
+        message: 'La sesion no es valida para consultar garantias.',
+      };
+    }
+
+    if (error.status === 403) {
+      return {
+        code: 'FORBIDDEN',
+        message: 'No tienes permiso para consultar estas garantias.',
+      };
+    }
+
+    return {
+      code: `BACKEND_${error.status}`,
+      message: 'No fue posible consultar las garantias en este momento.',
+    };
+  }
+
+  return {
+    code: 'INTERNAL_ERROR',
+    message: 'Ocurrio un error inesperado al consultar las garantias.',
+  };
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -138,3 +138,45 @@ export interface BackendOrderResponse {
   shippingAddress?: ShippingAddressSummary;
   items?: BackendOrderItemResponse[];
 }
+
+export interface WarrantyOrderSummary {
+  id: string;
+  totalAmount?: number;
+  status?: 'pending' | 'paid' | 'processing' | 'shipped' | 'delivered' | 'failed';
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface WarrantySummary {
+  id: string;
+  status: 'pending' | 'review' | 'resolved' | 'rejected' | 'refunded';
+  description: string;
+  evidenceUrls: string[];
+  createdAt: string;
+  updatedAt?: string;
+  resolvedAt?: string;
+  technicianId?: string;
+  technicianName?: string;
+  order: WarrantyOrderSummary;
+}
+
+export interface BackendWarrantyResponse {
+  _id: string;
+  status: 'pending' | 'review' | 'resolved' | 'rejected' | 'refunded';
+  description: string;
+  evidenceUrls?: string[];
+  createdAt: string;
+  updatedAt?: string;
+  resolvedAt?: string;
+  technicianId?: string;
+  technicianName?: string;
+  orderId:
+    | string
+    | {
+        _id?: string;
+        total_amount?: number;
+        status?: 'pending' | 'paid' | 'processing' | 'shipped' | 'delivered' | 'failed';
+        createdAt?: string;
+        updatedAt?: string;
+      };
+}


### PR DESCRIPTION
## Resumen
Este PR resuelve el issue técnico MCP `#191`, tomando como base `develop` y limitando el alcance a la exposición del tool `list_my_warranties` para la HU ya implementada `HU-12` (`#121`).

Se implementó únicamente la capa MCP necesaria para reutilizar la capacidad existente del sistema, sin rehacer la lógica funcional de garantías del backend.

## Alcance implementado
- registra el tool MCP `list_my_warranties`
- integra la consulta al backend existente `GET /api/warranties/mine`
- define contrato de entrada y salida del tool
- normaliza la respuesta para uso por agentes
- agrega manejo consistente de errores
- agrega auditoría/logs del tool
- agrega pruebas del tool y su registro en el servidor MCP

## Fuera de alcance
- no crea lógica nueva de garantías
- no modifica la HU funcional original `#121`
- no amplía permisos para consultar garantías de terceros
- no introduce cambios de negocio fuera del issue técnico `#191`

## Validaciones ejecutadas
- `npm test` en `mcp-server`
- `npm run build` en `mcp-server`
- validación remota del tool con usuario autenticado sin garantías
- validación remota del tool con una garantía real no vacía

## Resultado funcional validado
El tool responde correctamente con estructura normalizada y devuelve únicamente datos del usuario autenticado. Se validó un caso real con salida no vacía, incluyendo:
- `id`
- `status`
- `description`
- `createdAt`
- `order`
- campos opcionales solo cuando existen

## Riesgos o notas
- no se modificó la lógica funcional de garantías del backend
- la implementación depende del endpoint backend existente `/api/warranties/mine`
- se mantuvo la doble validación de autenticación entre MCP y backend

## Issue relacionado
Closes #191
Refs #121
