### PR TITLE
HU-53: ver una seccion de productos mas vendidos

### DIFF
--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -1,6 +1,7 @@
 import { Context } from 'hono';
 import mongoose from 'mongoose';
 import { Product } from '../models/Product';
+import { Order } from '../models/Order';
 import { InventoryMovement } from '../models/InventoryMovement';
 import { recordInventoryMovement } from '../services/inventory.service';
 
@@ -169,6 +170,57 @@ export const getLowStockProducts = async (c: Context) => {
     const products = await Product.find({ stock: { $lte: effectiveThreshold } }).sort({ stock: 1 });
 
     return c.json({ success: true, threshold: effectiveThreshold, data: products });
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};
+
+export const getBestSellingProducts = async (c: Context) => {
+  try {
+    const { limit } = c.req.valid('query' as any) as { limit?: number };
+    const effectiveLimit = limit ?? 4;
+    const productCollection = Product.collection.name;
+
+    const bestSellers = await Order.aggregate([
+      { $match: { status: 'paid' } },
+      { $unwind: '$items' },
+      {
+        $group: {
+          _id: '$items.product',
+          unitsSold: { $sum: '$items.quantity' },
+          totalRevenue: { $sum: { $multiply: ['$items.price', '$items.quantity'] } },
+        },
+      },
+      { $sort: { unitsSold: -1, totalRevenue: -1 } },
+      { $limit: effectiveLimit },
+      {
+        $lookup: {
+          from: productCollection,
+          localField: '_id',
+          foreignField: '_id',
+          as: 'product',
+        },
+      },
+      { $unwind: '$product' },
+      {
+        $project: {
+          _id: '$product._id',
+          name: '$product.name',
+          description: '$product.description',
+          price: '$product.price',
+          stock: '$product.stock',
+          condition: '$product.condition',
+          category: '$product.category',
+          image_urls: '$product.image_urls',
+          createdAt: '$product.createdAt',
+          updatedAt: '$product.updatedAt',
+          unitsSold: 1,
+          totalRevenue: 1,
+        },
+      },
+    ]);
+
+    return c.json({ success: true, data: bestSellers });
   } catch (error: any) {
     return c.json({ success: false, message: error.message }, 500);
   }

--- a/backend/src/routes/product.routes.ts
+++ b/backend/src/routes/product.routes.ts
@@ -3,6 +3,7 @@ import { zValidator } from '@hono/zod-validator';
 import {
   createProduct,
   deleteProduct,
+  getBestSellingProducts,
   getLowStockProducts,
   getProductById,
   getProductInventoryMovements,
@@ -11,6 +12,7 @@ import {
 } from '../controllers/product.controller';
 import {
   createProductSchema,
+  bestSellersQuerySchema,
   lowStockQuerySchema,
   productFilterSchema,
   updateProductSchema,
@@ -42,6 +44,16 @@ productRoutes.get(
     }
   }),
   getLowStockProducts
+);
+
+productRoutes.get(
+  '/best-sellers',
+  zValidator('query', bestSellersQuerySchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  getBestSellingProducts
 );
 
 // Obtener un producto por ID

--- a/backend/src/validators/product.validator.ts
+++ b/backend/src/validators/product.validator.ts
@@ -47,3 +47,7 @@ export const productFilterSchema = z
 export const lowStockQuerySchema = z.object({
   threshold: z.coerce.number().int().min(0, 'threshold debe ser 0 o un entero positivo').optional(),
 });
+
+export const bestSellersQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1, 'limit debe ser al menos 1').max(12, 'limit no puede superar 12').optional(),
+});

--- a/frontend/src/components/BestSellersSection.tsx
+++ b/frontend/src/components/BestSellersSection.tsx
@@ -1,0 +1,100 @@
+import { Link } from 'react-router-dom';
+import { SkeletonCard } from './ui/Skeleton';
+import { useBestSellers } from '../hooks/useBestSellers';
+
+function formatUnits(unitsSold: number) {
+  return unitsSold === 1 ? '1 vendido' : `${unitsSold} vendidos`;
+}
+
+export const BestSellersSection = () => {
+  const { data: products, isLoading, isError } = useBestSellers(4);
+  const featured = products ?? [];
+
+  return (
+    <section style={{ padding: '3rem 0 1.5rem', background: 'var(--white)', borderTop: '1px solid var(--line)', borderBottom: '1px solid var(--line)' }}>
+      <div className="page-container">
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end', gap: '1rem', marginBottom: '1.5rem', flexWrap: 'wrap' }}>
+          <div>
+            <p style={{ fontSize: '0.65rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '2.5px', color: 'var(--gray)', marginBottom: '0.75rem', fontFamily: 'var(--font-sans)' }}>
+              Más vendidos
+            </p>
+            <h2 style={{ fontSize: 'clamp(1.5rem, 3vw, 2.2rem)', fontWeight: 600, color: 'var(--ink)', lineHeight: 1.1, fontFamily: 'var(--font-display)' }}>
+              Lo que más compran otros clientes
+            </h2>
+          </div>
+          <p style={{ fontSize: '0.9rem', color: 'var(--ink2)', fontFamily: 'var(--font-sans)', maxWidth: 460, lineHeight: 1.6 }}>
+            Se ordena por volumen de ventas confirmadas, no por heurísticas de frontend.
+          </p>
+        </div>
+
+        {isError ? null : (
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(210px, 1fr))', gap: '1rem' }}>
+            {isLoading
+              ? Array.from({ length: 4 }).map((_, i) => <SkeletonCard key={i} />)
+              : featured.length === 0
+                ? (
+                    <div style={{ gridColumn: '1 / -1', padding: '1rem 0', color: 'var(--ink2)', fontFamily: 'var(--font-sans)', fontSize: '0.9rem' }}>
+                      Todavia no hay suficientes ventas confirmadas para mostrar productos destacados.
+                    </div>
+                  )
+                : featured.map((product, index) => (
+                    <Link
+                      key={product._id}
+                      to={`/product/${product._id}`}
+                      style={{ display: 'block', color: 'inherit', textDecoration: 'none' }}
+                      aria-label={`Ver detalles de ${product.name}`}
+                    >
+                      <article
+                        style={{
+                          height: '100%',
+                          border: '1px solid var(--line)',
+                          borderRadius: 8,
+                          overflow: 'hidden',
+                          background: 'var(--white)',
+                          boxShadow: '0 10px 24px rgba(0,0,0,0.04)',
+                          transition: 'transform 180ms ease, box-shadow 180ms ease',
+                        }}
+                        onMouseEnter={(e) => {
+                          e.currentTarget.style.transform = 'translateY(-2px)';
+                          e.currentTarget.style.boxShadow = '0 16px 32px rgba(0,0,0,0.08)';
+                        }}
+                        onMouseLeave={(e) => {
+                          e.currentTarget.style.transform = 'translateY(0)';
+                          e.currentTarget.style.boxShadow = '0 10px 24px rgba(0,0,0,0.04)';
+                        }}
+                      >
+                        <div style={{ aspectRatio: '1 / 1', background: 'var(--cream)', overflow: 'hidden' }}>
+                          <img
+                            src={product.image_urls?.[0] || `https://picsum.photos/seed/${product._id}/500/500`}
+                            alt={product.name}
+                            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                          />
+                        </div>
+                        <div style={{ padding: '1rem' }}>
+                          <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.75rem', alignItems: 'start', marginBottom: '0.6rem' }}>
+                            <span style={{ fontSize: '0.62rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '1.8px', color: 'var(--gray)', fontFamily: 'var(--font-sans)' }}>
+                              #{index + 1}
+                            </span>
+                            <span style={{ fontSize: '0.72rem', fontWeight: 600, color: 'var(--ink)', fontFamily: 'var(--font-sans)' }}>
+                              {formatUnits(product.unitsSold)}
+                            </span>
+                          </div>
+                          <h3 style={{ fontSize: '1rem', fontWeight: 600, lineHeight: 1.25, marginBottom: '0.4rem', color: 'var(--ink)', fontFamily: 'var(--font-display)' }}>
+                            {product.name}
+                          </h3>
+                          <p style={{ fontSize: '0.9rem', color: 'var(--ink2)', fontFamily: 'var(--font-sans)', marginBottom: '0.85rem' }}>
+                            ${product.price.toFixed(2)}
+                          </p>
+                          <p style={{ fontSize: '0.74rem', color: 'var(--gray)', fontFamily: 'var(--font-sans)', lineHeight: 1.4 }}>
+                            Vendido desde pedidos pagados confirmados.
+                          </p>
+                        </div>
+                      </article>
+                    </Link>
+                  ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+};

--- a/frontend/src/hooks/useBestSellers.ts
+++ b/frontend/src/hooks/useBestSellers.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { productsService } from '../services/products.service';
+
+export const useBestSellers = (limit = 4) => {
+  return useQuery({
+    queryKey: ['best-sellers', limit],
+    queryFn: () => productsService.getBestSellers(limit),
+  });
+};

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import { ProductList } from '../components/ProductList';
+import { BestSellersSection } from '../components/BestSellersSection';
 
 export default function Home() {
   return (
@@ -37,6 +38,8 @@ export default function Home() {
           </p>
         </div>
       </section>
+
+      <BestSellersSection />
 
       {/* Productos */}
       <section style={{ padding: '3rem 0 5rem', background: 'var(--white)' }}>

--- a/frontend/src/services/products.service.ts
+++ b/frontend/src/services/products.service.ts
@@ -1,4 +1,4 @@
-import type { Product } from '../types/product';
+import type { BestSellerProduct, Product } from '../types/product';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
 
@@ -139,6 +139,16 @@ export const productsService = {
     const result = await response.json();
     // Backend returns { success, data: product }; older callers may have relied on raw shape.
     return (result?.data ?? result) as Product;
+  },
+
+  async getBestSellers(limit = 4): Promise<BestSellerProduct[]> {
+    const response = await fetch(`${API_URL}/products/best-sellers?limit=${limit}`);
+    if (!response.ok) {
+      const result = await response.json().catch(() => ({}));
+      throw new Error(result?.message || result?.errors?.[0]?.message || 'Failed to fetch best sellers');
+    }
+    const result = await response.json();
+    return result.data || [];
   },
 
   async create(data: CreateProductDTO, token: string): Promise<Product> {

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -10,3 +10,8 @@ export interface Product {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface BestSellerProduct extends Product {
+  unitsSold: number;
+  totalRevenue?: number;
+}


### PR DESCRIPTION
Agrega una seccion de productos mas vendidos para la home y expone el ranking desde backend.

Cambios:
- nuevo endpoint `GET /api/products/best-sellers`
- agregacion en Mongo sobre ordenes pagadas
- seccion en `Home` con enlaces al detalle de producto
- hook y servicio dedicados para consumir el ranking

Validacion:
- `npm run build` en `frontend`: OK
- validacion puntual de backend: el repo tiene errores preexistentes de `tsconfig`/tipado ajenos a esta HU, por eso no quedó un typecheck limpio completo
