### PR TITLE
feat: exponer create_warranty_claim en MCP y corregir base URL del checkout

### DIFF
--- a/frontend/src/services/checkout.service.ts
+++ b/frontend/src/services/checkout.service.ts
@@ -1,4 +1,4 @@
-const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000';
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
 
 export interface CreatePaymentIntentResponse {
   clientSecret: string;
@@ -13,7 +13,7 @@ export const checkoutService = {
     token: string,
     addressId?: string,
   ): Promise<CreatePaymentIntentResponse> => {
-    const response = await fetch(`${BACKEND_URL}/api/checkout`, {
+    const response = await fetch(`${API_URL}/checkout`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -6,6 +6,7 @@ import { registerSearchProductsTool } from './tools/public/search-products.tool.
 import { registerGetProductTool } from './tools/public/get-product.tool.js';
 import { registerListMyOrdersTool } from './tools/user/list-my-orders.tool.js';
 import { registerListMyWarrantiesTool } from './tools/user/list-my-warranties.tool.js';
+import { registerCreateWarrantyClaimTool } from './tools/user/create-warranty-claim.tool.js';
 import type { Logger } from './utils/logger.js';
 
 interface ServerDependencies {
@@ -26,6 +27,7 @@ export function buildServer({ env, logger, backendApi, authInfo }: ServerDepende
   registerGetProductTool(server, { env, logger, backendApi });
   registerListMyOrdersTool(server, { env, logger, backendApi });
   registerListMyWarrantiesTool(server, { env, logger, backendApi });
+  registerCreateWarrantyClaimTool(server, { env, logger, backendApi });
 
   return server;
 }

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -5,7 +5,12 @@ import { createApp } from './server.js';
 import type { Authenticator, AuthContext } from './types.js';
 import { BackendApiClient, BackendApiError } from './services/backend-api.js';
 import { createLogger } from './utils/logger.js';
-import type { OrderSummary, WarrantySummary } from './types.js';
+import type {
+  CreateWarrantyClaimInput,
+  CreateWarrantyClaimResult,
+  OrderSummary,
+  WarrantySummary,
+} from './types.js';
 
 const env = {
   PORT: 3100,
@@ -41,8 +46,15 @@ class FakeBackendApi extends BackendApiClient {
   shouldRejectProductId = false;
   shouldRejectOrdersAuth = false;
   shouldRejectWarrantiesAuth = false;
+  shouldRejectCreateWarrantyAuth = false;
+  shouldRejectCreateWarrantyForbidden = false;
+  shouldRejectCreateWarrantyNotFound = false;
+  shouldRejectCreateWarrantyConflict = false;
+  shouldRejectCreateWarrantyInvalid = false;
   lastOrdersToken?: string;
   lastWarrantiesToken?: string;
+  lastCreateWarrantyToken?: string;
+  lastCreateWarrantyInput?: CreateWarrantyClaimInput;
 
   constructor() {
     super('http://backend.test/api');
@@ -224,6 +236,52 @@ class FakeBackendApi extends BackendApiClient {
       ],
     };
   }
+
+  override async createWarrantyClaim(
+    token: string,
+    input: CreateWarrantyClaimInput,
+    _requestId: string,
+  ): Promise<{ data: CreateWarrantyClaimResult }> {
+    this.lastCreateWarrantyToken = token;
+    this.lastCreateWarrantyInput = input;
+
+    if (this.shouldRejectCreateWarrantyAuth) {
+      throw new BackendApiError('Unauthorized', 401, {
+        error: 'Unauthorized: User ID not found',
+      });
+    }
+
+    if (this.shouldRejectCreateWarrantyForbidden) {
+      throw new BackendApiError('Forbidden', 403, {
+        error: 'No autorizado: La orden no pertenece a este usuario',
+      });
+    }
+
+    if (this.shouldRejectCreateWarrantyNotFound) {
+      throw new BackendApiError('Not found', 404, {
+        error: 'Orden no encontrada',
+      });
+    }
+
+    if (this.shouldRejectCreateWarrantyConflict) {
+      throw new BackendApiError('Conflict', 409, {
+        error: 'Ya registraste una garantia para esta orden',
+      });
+    }
+
+    if (this.shouldRejectCreateWarrantyInvalid) {
+      throw new BackendApiError('Bad request', 400, {
+        error: 'Garantía Expirada. Plazo Legal agotado',
+      });
+    }
+
+    return {
+      data: {
+        ticketId: 'wr_new_1',
+        status: 'pending',
+      },
+    };
+  }
 }
 
 test('health endpoint reports backend connectivity', async () => {
@@ -321,10 +379,10 @@ test('mcp handshake works and exposes search_products tool', async () => {
   assert.equal(serverVersion?.name, 'SafeTech MCP Server');
 
   const tools = await client.listTools();
-  assert.equal(tools.tools.length, 4);
+  assert.equal(tools.tools.length, 5);
   assert.deepEqual(
     tools.tools.map((tool) => tool.name).sort(),
-    ['get_product', 'list_my_orders', 'list_my_warranties', 'search_products'],
+    ['create_warranty_claim', 'get_product', 'list_my_orders', 'list_my_warranties', 'search_products'],
   );
 
   const result = await client.callTool({
@@ -451,6 +509,146 @@ test('list_my_warranties rejects authenticated backend failures in a controlled 
   assert.deepEqual(result.structuredContent, {
     code: 'AUTH_REQUIRED',
     message: 'La sesion no es valida para consultar garantias.',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('create_warranty_claim creates a warranty claim for the authenticated user', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'create_warranty_claim',
+    arguments: {
+      orderId: '507f191e810c19729de860ea',
+      reason: 'battery',
+      description: 'La bateria se descarga demasiado rapido.',
+      evidenceUrls: ['https://cdn.test/warranty-new-1.jpg'],
+    },
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.equal(backendApi.lastCreateWarrantyToken, 'test-token');
+  assert.deepEqual(backendApi.lastCreateWarrantyInput, {
+    orderId: '507f191e810c19729de860ea',
+    reason: 'battery',
+    description: 'La bateria se descarga demasiado rapido.',
+    evidenceUrls: ['https://cdn.test/warranty-new-1.jpg'],
+  });
+  assert.deepEqual(result.structuredContent, {
+    ticketId: 'wr_new_1',
+    status: 'pending',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('create_warranty_claim rejects warranty claims for third-party orders in a controlled way', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectCreateWarrantyForbidden = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'create_warranty_claim',
+    arguments: {
+      orderId: '507f191e810c19729de860ea',
+      reason: 'battery',
+      description: 'La bateria se descarga demasiado rapido.',
+      evidenceUrls: ['https://cdn.test/warranty-new-1.jpg'],
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'FORBIDDEN',
+    message: 'No puedes crear un reclamo sobre una orden que no te pertenece.',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('create_warranty_claim normalizes backend validation failures in a controlled way', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectCreateWarrantyInvalid = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'create_warranty_claim',
+    arguments: {
+      orderId: '507f191e810c19729de860ea',
+      reason: 'battery',
+      description: 'La bateria se descarga demasiado rapido.',
+      evidenceUrls: ['https://cdn.test/warranty-new-1.jpg'],
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'INVALID_WARRANTY_CLAIM',
+    message: 'Garantía Expirada. Plazo Legal agotado',
   });
 
   await transport.terminateSession();

--- a/mcp-server/src/services/backend-api.ts
+++ b/mcp-server/src/services/backend-api.ts
@@ -1,4 +1,6 @@
 import type {
+  CreateWarrantyClaimInput,
+  CreateWarrantyClaimResult,
   BackendOrderResponse,
   BackendWarrantyResponse,
   BackendHealth,
@@ -159,6 +161,29 @@ export class BackendApiClient {
         ...(warranty.technicianName ? { technicianName: warranty.technicianName } : {}),
         order: normalizeWarrantyOrder(warranty.orderId),
       })),
+    };
+  }
+
+  async createWarrantyClaim(
+    token: string,
+    input: CreateWarrantyClaimInput,
+    requestId: string,
+  ): Promise<{ data: CreateWarrantyClaimResult }> {
+    const response = await this.request<CreateWarrantyClaimResult>('/warranties', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'x-request-id': requestId,
+      },
+      body: JSON.stringify(input),
+    });
+
+    return {
+      data: {
+        ticketId: response.ticketId,
+        status: response.status,
+      },
     };
   }
 

--- a/mcp-server/src/tools/user/create-warranty-claim.tool.ts
+++ b/mcp-server/src/tools/user/create-warranty-claim.tool.ts
@@ -1,0 +1,195 @@
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { z } from 'zod';
+import type { AppEnv } from '../../config/env.js';
+import { logAuditEvent } from '../../services/audit-log.js';
+import { BackendApiError, type BackendApiClient } from '../../services/backend-api.js';
+import type { Logger } from '../../utils/logger.js';
+import { buildToolMeta } from '../access-control.js';
+
+const createWarrantyClaimInputSchema = z.object({
+  orderId: z.string().regex(/^[0-9a-fA-F]{24}$/, 'Invalid Order ID format'),
+  reason: z.string().trim().min(1),
+  description: z.string().trim().min(10),
+  evidenceUrls: z.array(z.string().url()).optional().default([]),
+});
+
+const createWarrantyClaimOutputSchema = z.object({
+  ticketId: z.string(),
+  status: z.enum(['pending', 'review', 'resolved', 'rejected', 'refunded']),
+});
+
+interface RegisterCreateWarrantyClaimToolDependencies {
+  env: AppEnv;
+  logger: Logger;
+  backendApi: BackendApiClient;
+}
+
+export function registerCreateWarrantyClaimTool(
+  server: McpServer,
+  { env, logger, backendApi }: RegisterCreateWarrantyClaimToolDependencies,
+) {
+  server.registerTool(
+    'create_warranty_claim',
+    {
+      title: 'Create Warranty Claim',
+      description:
+        'Crea un reclamo de garantia para una orden del usuario autenticado y devuelve el identificador del caso creado.',
+      inputSchema: createWarrantyClaimInputSchema,
+      outputSchema: createWarrantyClaimOutputSchema,
+      annotations: {
+        readOnlyHint: false,
+        openWorldHint: false,
+      },
+      _meta: {
+        ...buildToolMeta('user', {
+          issue: '#192',
+          source: `${env.BACKEND_API_URL}/warranties`,
+        }),
+      },
+    },
+    async (input, ctx) => {
+      const auditRequestId = randomUUID();
+      const startedAt = Date.now();
+      const authInfo = getAuthInfo(ctx);
+      const actor = authInfo?.clientId ?? 'anonymous';
+      const token = authInfo?.token;
+
+      try {
+        if (!token) {
+          const authError = {
+            code: 'AUTH_REQUIRED',
+            message: 'Se requiere autenticacion para crear un reclamo de garantia.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role: extractRole(ctx),
+            action: 'tool.create_warranty_claim',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: authError.code,
+          });
+
+          return {
+            content: [{ type: 'text', text: authError.message }],
+            structuredContent: authError,
+            isError: true,
+          };
+        }
+
+        const response = await backendApi.createWarrantyClaim(
+          token,
+          {
+            orderId: input.orderId,
+            reason: input.reason,
+            description: input.description,
+            evidenceUrls: input.evidenceUrls ?? [],
+          },
+          auditRequestId,
+        );
+
+        const output = response.data;
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role: extractRole(ctx),
+          action: 'tool.create_warranty_claim',
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output) }],
+          structuredContent: output,
+        };
+      } catch (error) {
+        const normalizedError = normalizeToolError(error);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role: extractRole(ctx),
+          action: 'tool.create_warranty_claim',
+          outcome: 'error',
+          durationMs: Date.now() - startedAt,
+          errorCode: normalizedError.code,
+        });
+
+        return {
+          content: [{ type: 'text', text: normalizedError.message }],
+          structuredContent: normalizedError,
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function extractRole(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  const roleScope = getAuthInfo(ctx)?.scopes?.find((scope: string) => scope.startsWith('role:'));
+  return roleScope?.replace('role:', '') ?? 'unknown';
+}
+
+function getAuthInfo(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  return ctx.http?.authInfo ?? (ctx as { authInfo?: { token?: string; clientId?: string; scopes?: string[] } }).authInfo;
+}
+
+function normalizeToolError(error: unknown) {
+  if (error instanceof BackendApiError) {
+    if (error.status === 401) {
+      return {
+        code: 'AUTH_REQUIRED',
+        message: 'La sesion no es valida para crear reclamos de garantia.',
+      };
+    }
+
+    if (error.status === 403) {
+      return {
+        code: 'FORBIDDEN',
+        message: 'No puedes crear un reclamo sobre una orden que no te pertenece.',
+      };
+    }
+
+    if (error.status === 404) {
+      return {
+        code: 'ORDER_NOT_FOUND',
+        message: 'No se encontro la orden indicada para crear el reclamo.',
+      };
+    }
+
+    if (error.status === 409) {
+      return {
+        code: 'WARRANTY_ALREADY_EXISTS',
+        message: 'Ya existe un reclamo de garantia para esta orden.',
+      };
+    }
+
+    if (error.status === 400) {
+      return {
+        code: 'INVALID_WARRANTY_CLAIM',
+        message: extractBackendMessage(error.body) ?? 'Los datos del reclamo de garantia no son validos.',
+      };
+    }
+
+    return {
+      code: `BACKEND_${error.status}`,
+      message: 'No fue posible crear el reclamo de garantia en este momento.',
+    };
+  }
+
+  return {
+    code: 'INTERNAL_ERROR',
+    message: 'Ocurrio un error inesperado al crear el reclamo de garantia.',
+  };
+}
+
+function extractBackendMessage(body: unknown) {
+  if (typeof body === 'object' && body !== null && 'error' in body && typeof body.error === 'string') {
+    return body.error;
+  }
+
+  return null;
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -160,6 +160,18 @@ export interface WarrantySummary {
   order: WarrantyOrderSummary;
 }
 
+export interface CreateWarrantyClaimInput {
+  orderId: string;
+  reason: string;
+  description: string;
+  evidenceUrls?: string[];
+}
+
+export interface CreateWarrantyClaimResult {
+  ticketId: string;
+  status: 'pending' | 'review' | 'resolved' | 'rejected' | 'refunded';
+}
+
 export interface BackendWarrantyResponse {
   _id: string;
   status: 'pending' | 'review' | 'resolved' | 'rejected' | 'refunded';


### PR DESCRIPTION
## Resumen

Este PR incorpora dos cambios realizados en la rama:

1. Exposición del tool MCP `create_warranty_claim` para la HU-13, reutilizando la lógica backend existente.
2. Corrección del servicio de checkout del frontend para unificar la URL base de la API y evitar llamadas a `localhost` en despliegues.

## Qué cambia

- agrega el tool MCP `create_warranty_claim`
- registra el tool en el servidor MCP
- integra la llamada autenticada al backend `POST /api/warranties`
- define `inputSchema` y `outputSchema` para el tool
- normaliza errores para uso por agentes
- agrega auditoría consistente del tool
- agrega pruebas MCP para éxito y rechazos controlados
- corrige `frontend/src/services/checkout.service.ts` para usar `VITE_API_URL`
- evita que el checkout en despliegues apunte a `http://localhost:3000`

## Validaciones ejecutadas

- `cd mcp-server && npm test`
- `cd mcp-server && npm run build`
- `cd frontend && npm run build`

## Pruebas funcionales realizadas

En ChatGPT con el MCP conectado se validó que:

- se puede listar la orden más reciente del usuario
- se puede crear un reclamo de garantía válido sobre una orden propia
- el tool devuelve `ticketId` y `status`
- el reclamo aparece luego en `list_my_warranties`
- un reclamo duplicado para la misma orden se rechaza con `WARRANTY_ALREADY_EXISTS`

En frontend desplegado se validó que:

- el flujo de compra ya no intenta llamar `localhost`
- se pudo completar una compra correctamente después de corregir la base URL del checkout

## Riesgos / pendientes

- no existe una tool MCP para adjuntar evidencias a un reclamo ya creado
- los warnings de Clerk con development keys corresponden a configuración del entorno
- los warnings informativos de Stripe no bloquean el flujo validado en este PR

## Commits incluidos

- `f82d7be` feat(mcp): exponer tool create_warranty_claim para HU-13
- `f565c58` fix(frontend): unificar la URL base del checkout

## Issue relacionado

Closes #192
