### PR TITLE
HU-57: sugerencias basadas en lista de deseos

### DIFF
--- a/backend/src/controllers/wishlist.controller.ts
+++ b/backend/src/controllers/wishlist.controller.ts
@@ -2,6 +2,37 @@ import { Context } from 'hono';
 import { WishlistItem } from '../models/WishlistItem';
 import { Product } from '../models/Product';
 
+const getWishlistSuggestions = async (c: Context) => {
+  try {
+    const userId = c.get('userId');
+    if (!userId) return c.json({ error: 'Unauthorized' }, 401);
+
+    const wishlistItems = await WishlistItem.find({ userId }).lean();
+    if (wishlistItems.length === 0) return c.json([]);
+
+    const wishlistedProductIds = wishlistItems.map(i => i.product);
+    const categories = [...new Set(wishlistItems.map(i => i.product).filter(Boolean))];
+
+    const categoryDocs = await Product.find({ _id: { $in: wishlistedProductIds } }).select('category').lean();
+    const uniqueCategories = [...new Set(categoryDocs.map(p => p.category))];
+
+    if (uniqueCategories.length === 0) return c.json([]);
+
+    const suggestions = await Product.find({
+      _id: { $nin: wishlistedProductIds },
+      category: { $in: uniqueCategories },
+      stock: { $gt: 0 },
+    })
+      .limit(8)
+      .lean();
+
+    return c.json(suggestions);
+  } catch (error) {
+    console.error('Error fetching suggestions:', error);
+    return c.json({ error: 'Failed to fetch suggestions' }, 500);
+  }
+};
+
 export const getMyWishlist = async (c: Context) => {
   try {
     const userId = c.get('userId');
@@ -81,6 +112,8 @@ export const updateWishlistNote = async (c: Context) => {
     return c.json({ error: 'Failed to update note' }, 500);
   }
 };
+
+export { getWishlistSuggestions };
 
 export const checkWishlistItem = async (c: Context) => {
   try {

--- a/backend/src/routes/wishlist.routes.ts
+++ b/backend/src/routes/wishlist.routes.ts
@@ -6,6 +6,7 @@ import {
   removeFromWishlist,
   updateWishlistNote,
   checkWishlistItem,
+  getWishlistSuggestions,
 } from '../controllers/wishlist.controller';
 import { clerkAuthMiddleware } from '../middlewares/auth.middleware';
 import { addToWishlistSchema, updateNoteSchema } from '../validators/wishlist.validator';
@@ -13,6 +14,8 @@ import { addToWishlistSchema, updateNoteSchema } from '../validators/wishlist.va
 const wishlistRoutes = new Hono();
 
 wishlistRoutes.get('/mine', clerkAuthMiddleware, getMyWishlist);
+
+wishlistRoutes.get('/suggestions', clerkAuthMiddleware, getWishlistSuggestions);
 
 wishlistRoutes.get('/check/:productId', clerkAuthMiddleware, checkWishlistItem);
 

--- a/frontend/src/hooks/useWishlist.ts
+++ b/frontend/src/hooks/useWishlist.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '../lib/auth';
 import { wishlistService } from '../services/wishlist.service';
 import type { WishlistItem } from '../types/wishlist';
+import type { Product } from '../types/product';
 
 export const useWishlist = () => {
   const { getToken } = useAuth();
@@ -10,6 +11,17 @@ export const useWishlist = () => {
     queryFn: async () => {
       const token = await getToken();
       return wishlistService.getMyWishlist(token!);
+    },
+  });
+};
+
+export const useWishlistSuggestions = () => {
+  const { getToken } = useAuth();
+  return useQuery<Product[], Error>({
+    queryKey: ['wishlist', 'suggestions'],
+    queryFn: async () => {
+      const token = await getToken();
+      return wishlistService.getSuggestions(token!);
     },
   });
 };

--- a/frontend/src/pages/Wishlist.tsx
+++ b/frontend/src/pages/Wishlist.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useWishlist, useRemoveFromWishlist, useUpdateWishlistNote } from '../hooks/useWishlist';
+import { useWishlist, useRemoveFromWishlist, useUpdateWishlistNote, useWishlistSuggestions } from '../hooks/useWishlist';
 import { useCartStore } from '../store/cart.store';
 import { SignInButton, useAuth } from '../lib/auth';
 import { Skeleton } from '../components/ui/Skeleton';
@@ -16,6 +16,7 @@ const CATEGORY_LABEL: Record<string, string> = {
 const Wishlist: React.FC = () => {
   const { isLoaded, isSignedIn } = useAuth();
   const { data: items, isLoading, isError } = useWishlist();
+  const { data: suggestions } = useWishlistSuggestions();
   const removeMutation = useRemoveFromWishlist();
   const updateNoteMutation = useUpdateWishlistNote();
   const addItem = useCartStore(s => s.addItem);
@@ -167,6 +168,30 @@ const Wishlist: React.FC = () => {
               ))}
             </div>
           )}
+
+          {!isLoading && !isError && suggestions && suggestions.length > 0 && (
+            <div className="wl-suggestions">
+              <h2 className="wl-suggestions-title">Sugeridos para ti</h2>
+              <p className="wl-suggestions-sub">Basados en los productos de tu lista de deseos</p>
+              <div className="wl-suggestions-grid">
+                {suggestions.map(product => (
+                  <Link to={`/product/${product._id}`} key={product._id} className="wl-sug-card">
+                    <div className="wl-sug-img">
+                      <img
+                        src={product.image_urls?.[0] || `https://picsum.photos/seed/${product._id}/300/300`}
+                        alt={product.name}
+                      />
+                    </div>
+                    <div className="wl-sug-body">
+                      <p className="wl-sug-cat">{CATEGORY_LABEL[product.category] ?? product.category}</p>
+                      <p className="wl-sug-name">{product.name}</p>
+                      <p className="wl-sug-price">{fmt(product.price)}</p>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       </main>
 
@@ -209,6 +234,20 @@ const Wishlist: React.FC = () => {
         .wl-empty p { font-family: var(--font-sans); font-size: .875rem; color: var(--ink3); max-width: 300px; line-height: 1.65; }
         .wl-cta { margin-top: 1.25rem; display: inline-flex; align-items: center; gap: 8px; padding: 13px 26px; background: var(--ink); color: var(--bone); font-family: var(--font-sans); font-size: .82rem; font-weight: 500; letter-spacing: .3px; text-decoration: none; border-radius: var(--radius-pill); border: 1px solid var(--ink); transition: all .25s; }
         .wl-cta:hover { background: #333; transform: translateY(-2px); box-shadow: 0 10px 28px rgba(46,45,43,.25); }
+
+        .wl-suggestions { margin-top: 4rem; padding-top: 3rem; border-top: 1px solid var(--line); }
+        .wl-suggestions-title { font-family: var(--font-display); font-size: clamp(1.3rem, 2.5vw, 1.75rem); font-weight: 400; color: var(--ink); letter-spacing: -.02em; margin-bottom: .35rem; }
+        .wl-suggestions-sub { font-family: var(--font-sans); font-size: .82rem; color: var(--ink3); margin-bottom: 1.5rem; }
+        .wl-suggestions-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 1rem; }
+        .wl-sug-card { background: var(--bone); border: 1px solid var(--line); border-radius: var(--radius-sm); overflow: hidden; text-decoration: none; transition: box-shadow .3s, transform .3s; }
+        .wl-sug-card:hover { box-shadow: 0 8px 30px rgba(46,45,43,.08); transform: translateY(-2px); }
+        .wl-sug-img { aspect-ratio: 1; overflow: hidden; }
+        .wl-sug-img img { width: 100%; height: 100%; object-fit: cover; transition: transform .4s; }
+        .wl-sug-card:hover .wl-sug-img img { transform: scale(1.04); }
+        .wl-sug-body { padding: .875rem 1rem 1rem; }
+        .wl-sug-cat { font-family: var(--font-mono); font-size: .55rem; font-weight: 500; text-transform: uppercase; letter-spacing: 1.5px; color: var(--ink3); margin-bottom: 4px; }
+        .wl-sug-name { font-family: var(--font-display); font-size: .9rem; font-weight: 500; color: var(--ink); line-height: 1.3; margin-bottom: 6px; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+        .wl-sug-price { font-family: var(--font-display); font-size: 1rem; font-weight: 700; color: var(--ink); }
       `}</style>
     </div>
   );

--- a/frontend/src/services/wishlist.service.ts
+++ b/frontend/src/services/wishlist.service.ts
@@ -1,11 +1,19 @@
 import axios from 'axios';
 import type { WishlistItem } from '../types/wishlist';
+import type { Product } from '../types/product';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
 
 export const wishlistService = {
   getMyWishlist: async (token: string): Promise<WishlistItem[]> => {
     const { data } = await axios.get(`${API_URL}/wishlist/mine`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return data;
+  },
+
+  getSuggestions: async (token: string): Promise<Product[]> => {
+    const { data } = await axios.get(`${API_URL}/wishlist/suggestions`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     return data;


### PR DESCRIPTION
## HU-57 - Recibir sugerencias basadas en mi lista de deseos

Closes #166

### Backend
- Nuevo endpoint `GET /api/wishlist/suggestions` (protegido con `clerkAuthMiddleware`)
- Obtiene las categorías de los productos en la lista de deseos del usuario
- Busca productos en esas mismas categorías que NO estén ya en la lista
- Retorna hasta 8 sugerencias con stock > 0

### Frontend
- Nuevo método `getSuggestions` en `wishlist.service.ts`
- Nuevo hook `useWishlistSuggestions` con TanStack Query
- Sección "Sugeridos para ti" en la página `/wishlist` debajo de la lista
- Cards clickeables que llevan al detalle del producto
- Solo se muestra cuando el usuario tiene productos en su lista de deseos

### Criterios de aceptación
- [x] El sistema genera sugerencias a partir de categorías de los productos guardados
- [x] El frontend muestra una sección de recomendaciones asociadas a la lista de deseos
- [x] El usuario puede navegar al detalle de cualquiera de los productos sugeridos