### PR TITLE
HU-59: validacion uniforme con Zod en todas las rutas

### DIFF
--- a/backend/src/routes/checkout.routes.ts
+++ b/backend/src/routes/checkout.routes.ts
@@ -1,14 +1,19 @@
 import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
 import { createPaymentIntentController } from '../controllers/checkout.controller';
 import { clerkAuthMiddleware } from '../middlewares/auth.middleware';
+import { checkoutSchema } from '../validators/checkout.validator';
 
 const checkoutRoutes = new Hono();
 
-// Embedded Stripe Payment Element flow — returns { clientSecret, orderId, amount }.
-// Reuses an existing pending Order + PaymentIntent for the same cart on retry.
 checkoutRoutes.post(
   '/',
   clerkAuthMiddleware,
+  zValidator('json', checkoutSchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
   createPaymentIntentController,
 );
 

--- a/backend/src/routes/order.routes.ts
+++ b/backend/src/routes/order.routes.ts
@@ -3,15 +3,17 @@ import { zValidator } from '@hono/zod-validator';
 import { getMyOrders, getOrderBySession, getAllOrders, confirmOrderPayment, updateShippingInfo } from '../controllers/order.controller';
 import { clerkAuthMiddleware, adminAuthMiddleware } from '../middlewares/auth.middleware';
 import { updateShippingSchema } from '../validators/order.validator';
+import { confirmPaymentSchema } from '../validators/technician.validator';
 
 const orderRouter = new Hono();
 
 orderRouter.get('/mine', clerkAuthMiddleware, getMyOrders);
 orderRouter.get('/by-session/:sessionId', clerkAuthMiddleware, getOrderBySession);
-orderRouter.post('/confirm-payment', clerkAuthMiddleware, confirmOrderPayment);
+orderRouter.post('/confirm-payment', clerkAuthMiddleware, zValidator('json', confirmPaymentSchema, (result, c) => {
+  if (!result.success) return c.json({ success: false, errors: result.error.errors }, 400);
+}), confirmOrderPayment);
 orderRouter.get('/', adminAuthMiddleware, getAllOrders);
 
-// Actualizar info de envio y tracking de una orden (solo admin)
 orderRouter.put(
   '/:id/shipping',
   adminAuthMiddleware,

--- a/backend/src/routes/technician.routes.ts
+++ b/backend/src/routes/technician.routes.ts
@@ -1,11 +1,22 @@
 import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
 import { getTechnicians, createTechnician, deleteTechnician } from '../controllers/technician.controller';
 import { adminAuthMiddleware } from '../middlewares/auth.middleware';
+import { createTechnicianSchema } from '../validators/technician.validator';
 
 const technicianRoutes = new Hono();
 
 technicianRoutes.get('/', adminAuthMiddleware, getTechnicians);
-technicianRoutes.post('/', adminAuthMiddleware, createTechnician);
+technicianRoutes.post(
+  '/',
+  adminAuthMiddleware,
+  zValidator('json', createTechnicianSchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  createTechnician,
+);
 technicianRoutes.delete('/:id', adminAuthMiddleware, deleteTechnician);
 
 export default technicianRoutes;

--- a/backend/src/routes/warranty.routes.ts
+++ b/backend/src/routes/warranty.routes.ts
@@ -3,20 +3,26 @@ import { createWarrantyReport, getMyWarranties, updateWarrantyStatus, getAllWarr
 import { clerkAuthMiddleware, adminAuthMiddleware, technicianAuthMiddleware } from '../middlewares/auth.middleware';
 import { zValidator } from '@hono/zod-validator';
 import { createWarrantySchema, updateStatusSchema } from '../validators/warranty.validator';
+import { assignTechnicianSchema, techUpdateWarrantySchema } from '../validators/technician.validator';
 
 const warrantyRoutes = new Hono();
 
-// Rutas de Usuario
-warrantyRoutes.post('/', clerkAuthMiddleware, zValidator('json', createWarrantySchema), createWarrantyReport);
+warrantyRoutes.post('/', clerkAuthMiddleware, zValidator('json', createWarrantySchema, (result, c) => {
+  if (!result.success) return c.json({ success: false, errors: result.error.errors }, 400);
+}), createWarrantyReport);
 warrantyRoutes.get('/mine', clerkAuthMiddleware, getMyWarranties);
 
-// Rutas de Técnico
 warrantyRoutes.get('/assigned', technicianAuthMiddleware, getAssignedWarranties);
-warrantyRoutes.patch('/:id/tech-update', technicianAuthMiddleware, technicianUpdateWarranty);
+warrantyRoutes.patch('/:id/tech-update', technicianAuthMiddleware, zValidator('json', techUpdateWarrantySchema, (result, c) => {
+  if (!result.success) return c.json({ success: false, errors: result.error.errors }, 400);
+}), technicianUpdateWarranty);
 
-// Rutas de Administrador
 warrantyRoutes.get('/', adminAuthMiddleware, getAllWarranties);
-warrantyRoutes.put('/:id/status', adminAuthMiddleware, zValidator('json', updateStatusSchema), updateWarrantyStatus);
-warrantyRoutes.put('/:id/assign', adminAuthMiddleware, assignTechnician);
+warrantyRoutes.put('/:id/status', adminAuthMiddleware, zValidator('json', updateStatusSchema, (result, c) => {
+  if (!result.success) return c.json({ success: false, errors: result.error.errors }, 400);
+}), updateWarrantyStatus);
+warrantyRoutes.put('/:id/assign', adminAuthMiddleware, zValidator('json', assignTechnicianSchema, (result, c) => {
+  if (!result.success) return c.json({ success: false, errors: result.error.errors }, 400);
+}), assignTechnician);
 
 export default warrantyRoutes;

--- a/backend/src/validators/technician.validator.ts
+++ b/backend/src/validators/technician.validator.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const createTechnicianSchema = z.object({
+  name: z.string().min(1, 'El nombre es requerido'),
+  email: z.string().email('Email inválido'),
+  phone: z.string().min(1, 'El teléfono es requerido').optional(),
+  specialty: z.string().optional(),
+});
+
+export const assignTechnicianSchema = z.object({
+  technicianId: z.string().min(1, 'El ID del técnico es requerido'),
+  technicianName: z.string().min(1, 'El nombre del técnico es requerido'),
+});
+
+export const techUpdateWarrantySchema = z.object({
+  status: z.enum(['review', 'resolved', 'rejected', 'refunded']).optional(),
+  repairNotes: z.string().optional(),
+}).refine((data) => data.status !== undefined || data.repairNotes !== undefined, {
+  message: 'Debe enviar al menos status o repairNotes',
+});
+
+export const confirmPaymentSchema = z.object({
+  paymentIntentId: z.string().min(1, 'paymentIntentId es requerido'),
+});


### PR DESCRIPTION
## HU-59 - Validacion uniforme con Zod en todas las rutas de entrada

Closes #168

### Cambios
- **Nuevo validator** `technician.validator.ts`: schemas para createTechnician, assignTechnician, techUpdateWarranty, confirmPayment
- **Checkout routes**: agrega `zValidator('json', checkoutSchema)` (usando schema existente sin usar)
- **Technician routes**: agrega `zValidator` al POST con `createTechnicianSchema`
- **Warranty routes**: agrega `zValidator` a POST, PATCH tech-update, PUT assign con schemas correspondientes. Corrige callbacks de error para formato consistente
- **Order routes**: agrega `zValidator` a POST confirm-payment con `confirmPaymentSchema`

### Rutas que ahora tienen validación Zod
| Ruta | Antes | Después |
|------|-------|---------|
| POST /checkout | Manual en controller | checkoutSchema |
| POST /technicians | Sin validación | createTechnicianSchema |
| PATCH /warranties/:id/tech-update | Manual enum check | techUpdateWarrantySchema |
| PUT /warranties/:id/assign | Manual field check | assignTechnicianSchema |
| POST /orders/confirm-payment | Manual type check | confirmPaymentSchema |

### Criterios de aceptación
- [x] Todas las rutas de escritura validan su entrada con Zod
- [x] Los errores se devuelven en formato consistente `{ success: false, errors }`
- [x] El sistema no continúa si la validación falla