### PR TITLE
HU-60: manejo centralizado de errores

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { connectDB } from './db/connection';
+import { errorHandler, notFoundHandler } from './middlewares/error.middleware';
 import healthRoutes from './routes/health.routes';
 import productRoutes from './routes/product.routes';
 import checkoutRoutes from './routes/checkout.routes';
@@ -15,8 +16,6 @@ import addressRoutes from './routes/address.routes';
 import wishlistRoutes from './routes/wishlist.routes';
 import e2eRoutes from './routes/e2e.routes';
 import { isE2ETestMode } from './lib/e2e';
-
-console.log('[DEBUG] CLERK_SECRET_KEY:', process.env.CLERK_SECRET_KEY);
 
 const app = new Hono();
 
@@ -41,6 +40,10 @@ app.route('/api/wishlist', wishlistRoutes);
 if (isE2ETestMode) {
   app.route('/api/e2e', e2eRoutes);
 }
+
+// Global error handler (must be after routes)
+app.onError(errorHandler);
+app.notFound(notFoundHandler);
 
 export default {
   port: process.env.PORT || 3000,

--- a/backend/src/middlewares/error.middleware.ts
+++ b/backend/src/middlewares/error.middleware.ts
@@ -1,0 +1,64 @@
+import { Context } from 'hono';
+import { StatusCode } from 'hono/utils/http-status';
+
+export class AppError extends Error {
+  public statusCode: number;
+  public code: string;
+
+  constructor(message: string, statusCode: number = 500, code: string = 'INTERNAL_ERROR') {
+    super(message);
+    this.statusCode = statusCode;
+    this.code = code;
+  }
+}
+
+export const errorHandler = (err: Error, c: Context) => {
+  console.error(`[Error] ${err.message}`, err.stack);
+
+  if (err instanceof AppError) {
+    return c.json(
+      { success: false, error: { message: err.message, code: err.code } },
+      err.statusCode as StatusCode,
+    );
+  }
+
+  if (err.message.includes('STRIPE_SECRET_KEY')) {
+    return c.json(
+      { success: false, error: { message: 'Payment service not configured', code: 'PAYMENT_CONFIG_ERROR' } },
+      500,
+    );
+  }
+
+  if (err.message.includes('STRIPE')) {
+    return c.json(
+      { success: false, error: { message: 'Payment processing error', code: 'PAYMENT_ERROR' } },
+      502,
+    );
+  }
+
+  if (err.message.includes('E11000') || err.message.includes('duplicate key')) {
+    return c.json(
+      { success: false, error: { message: 'Resource already exists', code: 'DUPLICATE_RESOURCE' } },
+      409,
+    );
+  }
+
+  if (err.name === 'CastError' || err.message.includes('ObjectId')) {
+    return c.json(
+      { success: false, error: { message: 'Invalid resource ID format', code: 'INVALID_ID' } },
+      400,
+    );
+  }
+
+  return c.json(
+    { success: false, error: { message: 'Internal server error', code: 'INTERNAL_ERROR' } },
+    500,
+  );
+};
+
+export const notFoundHandler = (c: Context) => {
+  return c.json(
+    { success: false, error: { message: `Route ${c.req.method} ${c.req.path} not found`, code: 'NOT_FOUND' } },
+    404,
+  );
+};


### PR DESCRIPTION
## HU-60 - Manejo centralizado de errores

Closes #169

### Cambios
- **Nuevo middleware** `error.middleware.ts`: `AppError` class, `errorHandler`, `notFoundHandler`
- **app.onError()**: captura errores no controlados con formato consistente `{ success, error: { message, code } }`
- **app.notFound()**: retorna 404 para rutas inexistentes
- **Clasificación automática**: Stripe errors → 502, duplicate key → 409, CastError → 400, config errors → 500
- **Seguridad**: mensajes genéricos al cliente, detalles en server logs
- **Removido** `console.log` que imprimía `CLERK_SECRET_KEY` en stdout

### Formato de respuesta de error
```json
{ "success": false, "error": { "message": "...", "code": "ERROR_CODE" } }
```

### Criterios de aceptación
- [x] Los errores no controlados se capturan en un middleware global
- [x] La API devuelve códigos HTTP coherentes
- [x] Los mensajes no filtran información sensible