### PR TITLE
HU-62: metricas tecnicas y de negocio

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,9 @@ import 'dotenv/config';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { connectDB } from './db/connection';
+import { errorHandler, notFoundHandler } from './middlewares/error.middleware';
+import { requestIdMiddleware, requestLogger } from './lib/logger';
+import { metricsMiddleware, metricsHandler } from './lib/metrics';
 import healthRoutes from './routes/health.routes';
 import productRoutes from './routes/product.routes';
 import checkoutRoutes from './routes/checkout.routes';
@@ -16,15 +19,19 @@ import wishlistRoutes from './routes/wishlist.routes';
 import e2eRoutes from './routes/e2e.routes';
 import { isE2ETestMode } from './lib/e2e';
 
-console.log('[DEBUG] CLERK_SECRET_KEY:', process.env.CLERK_SECRET_KEY);
-
 const app = new Hono();
 
 // Global Middlewares
 app.use('/*', cors());
+app.use('/*', requestIdMiddleware);
+app.use('/*', requestLogger);
+app.use('/*', metricsMiddleware);
 
 // Attempt to connect to DB
 connectDB();
+
+// Metrics endpoint
+app.get('/api/metrics', metricsHandler);
 
 // Register routes
 app.route('/api/health', healthRoutes);
@@ -41,6 +48,10 @@ app.route('/api/wishlist', wishlistRoutes);
 if (isE2ETestMode) {
   app.route('/api/e2e', e2eRoutes);
 }
+
+// Global error handler
+app.onError(errorHandler);
+app.notFound(notFoundHandler);
 
 export default {
   port: process.env.PORT || 3000,

--- a/backend/src/lib/metrics.ts
+++ b/backend/src/lib/metrics.ts
@@ -1,0 +1,99 @@
+import { Context, Next } from 'hono';
+
+interface MetricBucket {
+  count: number;
+  totalDuration: number;
+  errors: number;
+  byStatus: Record<number, number>;
+}
+
+interface BusinessMetric {
+  count: number;
+  timestamps: number[];
+}
+
+class MetricsStore {
+  private requests: MetricBucket = { count: 0, totalDuration: 0, errors: 0, byStatus: {} };
+  private routes: Record<string, MetricBucket> = {};
+  private business: Record<string, BusinessMetric> = {};
+  private startedAt = Date.now();
+
+  recordRequest(method: string, path: string, statusCode: number, duration: number) {
+    this.requests.count++;
+    this.requests.totalDuration += duration;
+    if (statusCode >= 400) this.requests.errors++;
+    this.requests.byStatus[statusCode] = (this.requests.byStatus[statusCode] || 0) + 1;
+
+    const key = `${method} ${path}`;
+    if (!this.routes[key]) {
+      this.routes[key] = { count: 0, totalDuration: 0, errors: 0, byStatus: {} };
+    }
+    const route = this.routes[key];
+    route.count++;
+    route.totalDuration += duration;
+    if (statusCode >= 400) route.errors++;
+    route.byStatus[statusCode] = (route.byStatus[statusCode] || 0) + 1;
+  }
+
+  recordBusiness(event: string) {
+    if (!this.business[event]) {
+      this.business[event] = { count: 0, timestamps: [] };
+    }
+    this.business[event].count++;
+    this.business[event].timestamps.push(Date.now());
+    if (this.business[event].timestamps.length > 1000) {
+      this.business[event].timestamps = this.business[event].timestamps.slice(-500);
+    }
+  }
+
+  getSnapshot() {
+    const uptimeMs = Date.now() - this.startedAt;
+    const avgDuration = this.requests.count > 0
+      ? Math.round(this.requests.totalDuration / this.requests.count)
+      : 0;
+
+    const topRoutes = Object.entries(this.routes)
+      .sort((a, b) => b[1].count - a[1].count)
+      .slice(0, 20)
+      .map(([route, data]) => ({
+        route,
+        count: data.count,
+        avgDuration: data.count > 0 ? Math.round(data.totalDuration / data.count) : 0,
+        errors: data.errors,
+        errorRate: data.count > 0 ? Math.round((data.errors / data.count) * 100 * 100) / 100 : 0,
+      }));
+
+    return {
+      uptime: Math.round(uptimeMs / 1000),
+      requests: {
+        total: this.requests.count,
+        errors: this.requests.errors,
+        errorRate: this.requests.count > 0
+          ? Math.round((this.requests.errors / this.requests.count) * 100 * 100) / 100
+          : 0,
+        avgDuration,
+        byStatus: this.requests.byStatus,
+      },
+      topRoutes,
+      business: Object.entries(this.business).map(([event, data]) => ({
+        event,
+        count: data.count,
+        recent: data.timestamps.filter((t) => t > Date.now() - 3600000).length,
+      })),
+    };
+  }
+}
+
+export const metrics = new MetricsStore();
+
+export const metricsMiddleware = async (c: Context, next: Next) => {
+  const start = Date.now();
+  await next();
+  const duration = Date.now() - start;
+  const requestId = c.get('requestId') as string;
+  metrics.recordRequest(c.req.method, c.req.path, c.res.status, duration);
+};
+
+export const metricsHandler = (c: Context) => {
+  return c.json(metrics.getSnapshot());
+};


### PR DESCRIPTION
## HU-62 - Metricas tecnicas y de negocio

Closes #171

### Cambios
- **Nuevo módulo** `lib/metrics.ts`: MetricsStore con contadores en memoria
- **metricsMiddleware**: registra cada request con method, path, statusCode, duration
- **Endpoint** `GET /api/metrics`: retorna snapshot de métricas
- **Métricas técnicas**: total requests, errors, error rate, avg duration, por status code
- **Top 20 rutas**: count, avg duration, errors, error rate
- **Métricas de negocio**: eventos customizables con timestamps

### Respuesta del endpoint `/api/metrics`
```json
{
  "uptime": 3600,
  "requests": { "total": 1500, "errors": 45, "errorRate": 3.0, "avgDuration": 120 },
  "topRoutes": [{ "route": "GET /api/products", "count": 500, "avgDuration": 85, "errors": 0 }],
  "business": [{ "event": "checkout", "count": 120, "recent": 15 }]
}
```

### Criterios de aceptación
- [x] El sistema mide latencia, tasa de error y volumen de requests
- [x] Las métricas se consumen desde `/api/metrics`
- [x] Incluye integración con logger estructurado (HU-61)