### PR TITLE
feat: exponer tool MCP update_warranty_status

### DIFF
--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -7,6 +7,7 @@ import { registerGetProductTool } from './tools/public/get-product.tool.js';
 import { registerListMyOrdersTool } from './tools/user/list-my-orders.tool.js';
 import { registerListMyWarrantiesTool } from './tools/user/list-my-warranties.tool.js';
 import { registerCreateWarrantyClaimTool } from './tools/user/create-warranty-claim.tool.js';
+import { registerUpdateWarrantyStatusTool } from './tools/admin/update-warranty-status.tool.js';
 import type { Logger } from './utils/logger.js';
 
 interface ServerDependencies {
@@ -28,6 +29,7 @@ export function buildServer({ env, logger, backendApi, authInfo }: ServerDepende
   registerListMyOrdersTool(server, { env, logger, backendApi });
   registerListMyWarrantiesTool(server, { env, logger, backendApi });
   registerCreateWarrantyClaimTool(server, { env, logger, backendApi });
+  registerUpdateWarrantyStatusTool(server, { env, logger, backendApi });
 
   return server;
 }

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -9,6 +9,8 @@ import type {
   CreateWarrantyClaimInput,
   CreateWarrantyClaimResult,
   OrderSummary,
+  UpdateWarrantyStatusInput,
+  UpdateWarrantyStatusResult,
   WarrantySummary,
 } from './types.js';
 
@@ -29,11 +31,13 @@ const env = {
 };
 
 class FakeAuthenticator implements Authenticator {
+  constructor(private readonly role: AuthContext['role'] = 'admin') {}
+
   async authenticate(): Promise<AuthContext> {
     return {
       token: 'test-token',
       userId: 'user_test',
-      role: 'admin',
+      role: this.role,
       expiresAt: Math.floor(Date.now() / 1000) + 60,
     };
   }
@@ -51,10 +55,17 @@ class FakeBackendApi extends BackendApiClient {
   shouldRejectCreateWarrantyNotFound = false;
   shouldRejectCreateWarrantyConflict = false;
   shouldRejectCreateWarrantyInvalid = false;
+  shouldRejectUpdateWarrantyAuth = false;
+  shouldRejectUpdateWarrantyForbidden = false;
+  shouldRejectUpdateWarrantyNotFound = false;
+  shouldRejectUpdateWarrantyInvalid = false;
   lastOrdersToken?: string;
   lastWarrantiesToken?: string;
   lastCreateWarrantyToken?: string;
   lastCreateWarrantyInput?: CreateWarrantyClaimInput;
+  lastUpdateWarrantyToken?: string;
+  lastUpdateWarrantyId?: string;
+  lastUpdateWarrantyInput?: UpdateWarrantyStatusInput;
 
   constructor() {
     super('http://backend.test/api');
@@ -282,6 +293,60 @@ class FakeBackendApi extends BackendApiClient {
       },
     };
   }
+
+  override async updateWarrantyStatus(
+    token: string,
+    warrantyId: string,
+    input: UpdateWarrantyStatusInput,
+    _requestId: string,
+  ): Promise<{ data: UpdateWarrantyStatusResult }> {
+    this.lastUpdateWarrantyToken = token;
+    this.lastUpdateWarrantyId = warrantyId;
+    this.lastUpdateWarrantyInput = input;
+
+    if (this.shouldRejectUpdateWarrantyAuth) {
+      throw new BackendApiError('Unauthorized', 401, {
+        error: 'Unauthorized: Token verification failed',
+      });
+    }
+
+    if (this.shouldRejectUpdateWarrantyForbidden) {
+      throw new BackendApiError('Forbidden', 403, {
+        error: 'Forbidden: Insufficient privileges',
+      });
+    }
+
+    if (this.shouldRejectUpdateWarrantyNotFound) {
+      throw new BackendApiError('Not found', 404, {
+        error: 'Report not found',
+      });
+    }
+
+    if (this.shouldRejectUpdateWarrantyInvalid) {
+      throw new BackendApiError('Bad request', 400, {
+        error: 'Invalid status transition',
+      });
+    }
+
+    return {
+      data: {
+        id: warrantyId,
+        orderId: '6870f1e2a1234567890abcde',
+        userId: 'user_owner_1',
+        status: input.status,
+        description: '[battery] La bateria no carga correctamente',
+        evidenceUrls: ['https://cdn.test/evidence-1.jpg'],
+        ...(input.repairNotes !== undefined ? { repairNotes: input.repairNotes } : {}),
+        technicianId: 'tech_1',
+        technicianName: 'Maria Gomez',
+        createdAt: '2026-07-02T09:00:00.000Z',
+        updatedAt: '2026-07-03T12:00:00.000Z',
+        ...(input.status === 'resolved'
+          ? { resolvedAt: '2026-07-03T12:00:00.000Z' }
+          : {}),
+      },
+    };
+  }
 }
 
 test('health endpoint reports backend connectivity', async () => {
@@ -379,10 +444,10 @@ test('mcp handshake works and exposes search_products tool', async () => {
   assert.equal(serverVersion?.name, 'SafeTech MCP Server');
 
   const tools = await client.listTools();
-  assert.equal(tools.tools.length, 5);
+  assert.equal(tools.tools.length, 6);
   assert.deepEqual(
     tools.tools.map((tool) => tool.name).sort(),
-    ['create_warranty_claim', 'get_product', 'list_my_orders', 'list_my_warranties', 'search_products'],
+    ['create_warranty_claim', 'get_product', 'list_my_orders', 'list_my_warranties', 'search_products', 'update_warranty_status'],
   );
 
   const result = await client.callTool({
@@ -412,6 +477,149 @@ test('mcp handshake works and exposes search_products tool', async () => {
       name: 'iPhone',
       limit: 5,
     },
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('update_warranty_status updates a warranty for an admin user', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'update_warranty_status',
+    arguments: {
+      warrantyId: '6870f1e2a1234567890abcdf',
+      status: 'resolved',
+      repairNotes: 'Battery module replaced',
+    },
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.equal(backendApi.lastUpdateWarrantyToken, 'test-token');
+  assert.equal(backendApi.lastUpdateWarrantyId, '6870f1e2a1234567890abcdf');
+  assert.deepEqual(backendApi.lastUpdateWarrantyInput, {
+    status: 'resolved',
+    repairNotes: 'Battery module replaced',
+  });
+  assert.deepEqual(result.structuredContent, {
+    id: '6870f1e2a1234567890abcdf',
+    orderId: '6870f1e2a1234567890abcde',
+    userId: 'user_owner_1',
+    status: 'resolved',
+    description: '[battery] La bateria no carga correctamente',
+    evidenceUrls: ['https://cdn.test/evidence-1.jpg'],
+    repairNotes: 'Battery module replaced',
+    technicianId: 'tech_1',
+    technicianName: 'Maria Gomez',
+    createdAt: '2026-07-02T09:00:00.000Z',
+    updatedAt: '2026-07-03T12:00:00.000Z',
+    resolvedAt: '2026-07-03T12:00:00.000Z',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('update_warranty_status rejects non-admin users before calling the backend', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('user'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'update_warranty_status',
+    arguments: {
+      warrantyId: '6870f1e2a1234567890abcdf',
+      status: 'review',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.equal(backendApi.lastUpdateWarrantyToken, undefined);
+  assert.deepEqual(result.structuredContent, {
+    code: 'FORBIDDEN',
+    message: 'Solo un administrador puede actualizar el estado de una garantia.',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('update_warranty_status normalizes backend validation failures', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectUpdateWarrantyInvalid = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'update_warranty_status',
+    arguments: {
+      warrantyId: '6870f1e2a1234567890abcdf',
+      status: 'rejected',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'INVALID_WARRANTY_UPDATE',
+    message: 'Invalid status transition',
   });
 
   await transport.terminateSession();

--- a/mcp-server/src/services/audit-log.ts
+++ b/mcp-server/src/services/audit-log.ts
@@ -8,6 +8,7 @@ interface AuditEvent {
   outcome: 'success' | 'error';
   durationMs: number;
   errorCode?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export function logAuditEvent(logger: Logger, event: AuditEvent) {

--- a/mcp-server/src/services/backend-api.ts
+++ b/mcp-server/src/services/backend-api.ts
@@ -2,6 +2,7 @@ import type {
   CreateWarrantyClaimInput,
   CreateWarrantyClaimResult,
   BackendOrderResponse,
+  BackendWarrantyStatusResponse,
   BackendWarrantyResponse,
   BackendHealth,
   OrderSummary,
@@ -9,6 +10,8 @@ import type {
   ProductDetailResponse,
   ProductListResponse,
   ProductSummary,
+  UpdateWarrantyStatusInput,
+  UpdateWarrantyStatusResult,
   WarrantySummary,
 } from '../types.js';
 
@@ -183,6 +186,43 @@ export class BackendApiClient {
       data: {
         ticketId: response.ticketId,
         status: response.status,
+      },
+    };
+  }
+
+  async updateWarrantyStatus(
+    token: string,
+    warrantyId: string,
+    input: UpdateWarrantyStatusInput,
+    requestId: string,
+  ): Promise<{ data: UpdateWarrantyStatusResult }> {
+    const response = await this.request<BackendWarrantyStatusResponse>(
+      `/warranties/${warrantyId}/status`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+          'x-request-id': requestId,
+        },
+        body: JSON.stringify(input),
+      },
+    );
+
+    return {
+      data: {
+        id: response._id,
+        orderId: response.orderId,
+        userId: response.userId,
+        status: response.status,
+        description: response.description,
+        evidenceUrls: response.evidenceUrls ?? [],
+        ...(response.repairNotes !== undefined ? { repairNotes: response.repairNotes } : {}),
+        ...(response.technicianId ? { technicianId: response.technicianId } : {}),
+        ...(response.technicianName ? { technicianName: response.technicianName } : {}),
+        createdAt: response.createdAt,
+        ...(response.updatedAt ? { updatedAt: response.updatedAt } : {}),
+        ...(response.resolvedAt ? { resolvedAt: response.resolvedAt } : {}),
       },
     };
   }

--- a/mcp-server/src/tools/admin/update-warranty-status.tool.ts
+++ b/mcp-server/src/tools/admin/update-warranty-status.tool.ts
@@ -1,0 +1,233 @@
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { z } from 'zod';
+import type { AppEnv } from '../../config/env.js';
+import { logAuditEvent } from '../../services/audit-log.js';
+import { BackendApiError, type BackendApiClient } from '../../services/backend-api.js';
+import type { Logger } from '../../utils/logger.js';
+import { buildToolMeta } from '../access-control.js';
+
+const updateWarrantyStatusInputSchema = z.object({
+  warrantyId: z.string().regex(/^[0-9a-fA-F]{24}$/, 'Invalid warranty ID format'),
+  status: z.enum(['review', 'resolved', 'rejected', 'refunded']),
+  repairNotes: z.string().trim().optional(),
+});
+
+const updateWarrantyStatusOutputSchema = z.object({
+  id: z.string(),
+  orderId: z.string(),
+  userId: z.string(),
+  status: z.enum(['pending', 'review', 'resolved', 'rejected', 'refunded']),
+  description: z.string(),
+  evidenceUrls: z.array(z.string().url()),
+  repairNotes: z.string().optional(),
+  technicianId: z.string().optional(),
+  technicianName: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string().optional(),
+  resolvedAt: z.string().optional(),
+});
+
+interface RegisterUpdateWarrantyStatusToolDependencies {
+  env: AppEnv;
+  logger: Logger;
+  backendApi: BackendApiClient;
+}
+
+export function registerUpdateWarrantyStatusTool(
+  server: McpServer,
+  { env, logger, backendApi }: RegisterUpdateWarrantyStatusToolDependencies,
+) {
+  server.registerTool(
+    'update_warranty_status',
+    {
+      title: 'Update Warranty Status',
+      description:
+        'Actualiza el estado de un reclamo de garantia existente y devuelve el estado persistido. Solo disponible para administradores.',
+      inputSchema: updateWarrantyStatusInputSchema,
+      outputSchema: updateWarrantyStatusOutputSchema,
+      annotations: {
+        readOnlyHint: false,
+        openWorldHint: false,
+      },
+      _meta: {
+        ...buildToolMeta('admin', {
+          issue: '#193',
+          source: `${env.BACKEND_API_URL}/warranties/:id/status`,
+        }),
+      },
+    },
+    async (input, ctx) => {
+      const auditRequestId = randomUUID();
+      const startedAt = Date.now();
+      const authInfo = getAuthInfo(ctx);
+      const actor = authInfo?.clientId ?? 'anonymous';
+      const role = extractRole(ctx);
+      const token = authInfo?.token;
+      const auditMetadata = {
+        warrantyId: input.warrantyId,
+        targetStatus: input.status,
+      };
+
+      try {
+        if (!token) {
+          const authError = {
+            code: 'AUTH_REQUIRED',
+            message: 'Se requiere autenticacion para actualizar garantias.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role,
+            action: 'tool.update_warranty_status',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: authError.code,
+            metadata: auditMetadata,
+          });
+
+          return {
+            content: [{ type: 'text', text: authError.message }],
+            structuredContent: authError,
+            isError: true,
+          };
+        }
+
+        if (role !== 'admin') {
+          const forbiddenError = {
+            code: 'FORBIDDEN',
+            message: 'Solo un administrador puede actualizar el estado de una garantia.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role,
+            action: 'tool.update_warranty_status',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: forbiddenError.code,
+            metadata: auditMetadata,
+          });
+
+          return {
+            content: [{ type: 'text', text: forbiddenError.message }],
+            structuredContent: forbiddenError,
+            isError: true,
+          };
+        }
+
+        const response = await backendApi.updateWarrantyStatus(
+          token,
+          input.warrantyId,
+          {
+            status: input.status,
+            ...(input.repairNotes !== undefined ? { repairNotes: input.repairNotes } : {}),
+          },
+          auditRequestId,
+        );
+
+        const output = response.data;
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role,
+          action: 'tool.update_warranty_status',
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+          metadata: {
+            ...auditMetadata,
+            persistedStatus: output.status,
+          },
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output) }],
+          structuredContent: output,
+        };
+      } catch (error) {
+        const normalizedError = normalizeToolError(error);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role,
+          action: 'tool.update_warranty_status',
+          outcome: 'error',
+          durationMs: Date.now() - startedAt,
+          errorCode: normalizedError.code,
+          metadata: auditMetadata,
+        });
+
+        return {
+          content: [{ type: 'text', text: normalizedError.message }],
+          structuredContent: normalizedError,
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function extractRole(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  const roleScope = getAuthInfo(ctx)?.scopes?.find((scope: string) => scope.startsWith('role:'));
+  return roleScope?.replace('role:', '') ?? 'unknown';
+}
+
+function getAuthInfo(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  return ctx.http?.authInfo ?? (ctx as { authInfo?: { token?: string; clientId?: string; scopes?: string[] } }).authInfo;
+}
+
+function normalizeToolError(error: unknown) {
+  if (error instanceof BackendApiError) {
+    if (error.status === 401) {
+      return {
+        code: 'AUTH_REQUIRED',
+        message: 'La sesion no es valida para actualizar garantias.',
+      };
+    }
+
+    if (error.status === 403) {
+      return {
+        code: 'FORBIDDEN',
+        message: 'No tienes permisos para actualizar el estado de esta garantia.',
+      };
+    }
+
+    if (error.status === 404) {
+      return {
+        code: 'WARRANTY_NOT_FOUND',
+        message: 'No se encontro la garantia indicada.',
+      };
+    }
+
+    if (error.status === 400) {
+      return {
+        code: 'INVALID_WARRANTY_UPDATE',
+        message:
+          extractBackendMessage(error.body) ??
+          'Los datos enviados para actualizar la garantia no son validos.',
+      };
+    }
+
+    return {
+      code: `BACKEND_${error.status}`,
+      message: 'No fue posible actualizar la garantia en este momento.',
+    };
+  }
+
+  return {
+    code: 'INTERNAL_ERROR',
+    message: 'Ocurrio un error inesperado al actualizar la garantia.',
+  };
+}
+
+function extractBackendMessage(body: unknown) {
+  if (typeof body === 'object' && body !== null && 'error' in body && typeof body.error === 'string') {
+    return body.error;
+  }
+
+  return null;
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -172,6 +172,26 @@ export interface CreateWarrantyClaimResult {
   status: 'pending' | 'review' | 'resolved' | 'rejected' | 'refunded';
 }
 
+export interface UpdateWarrantyStatusInput {
+  status: 'review' | 'resolved' | 'rejected' | 'refunded';
+  repairNotes?: string;
+}
+
+export interface UpdateWarrantyStatusResult {
+  id: string;
+  orderId: string;
+  userId: string;
+  status: 'pending' | 'review' | 'resolved' | 'rejected' | 'refunded';
+  description: string;
+  evidenceUrls: string[];
+  repairNotes?: string;
+  technicianId?: string;
+  technicianName?: string;
+  createdAt: string;
+  updatedAt?: string;
+  resolvedAt?: string;
+}
+
 export interface BackendWarrantyResponse {
   _id: string;
   status: 'pending' | 'review' | 'resolved' | 'rejected' | 'refunded';
@@ -191,4 +211,19 @@ export interface BackendWarrantyResponse {
         createdAt?: string;
         updatedAt?: string;
       };
+}
+
+export interface BackendWarrantyStatusResponse {
+  _id: string;
+  orderId: string;
+  userId: string;
+  status: 'pending' | 'review' | 'resolved' | 'rejected' | 'refunded';
+  description: string;
+  evidenceUrls?: string[];
+  repairNotes?: string;
+  technicianId?: string;
+  technicianName?: string;
+  createdAt: string;
+  updatedAt?: string;
+  resolvedAt?: string;
 }


### PR DESCRIPTION
## Resumen

Este PR implementa el issue técnico MCP `#193` para exponer la tool `update_warranty_status`, reutilizando la lógica backend existente de `HU-16` sin rehacer reglas de negocio.

## Cambios realizados

- se agrega la tool admin `update_warranty_status` en `mcp-server`
- se registra la tool en el servidor MCP
- se integra la llamada al endpoint backend existente `PUT /api/warranties/:id/status`
- se normalizan input, output y errores para uso por agentes
- se refuerza la auditoría de la acción sensible con metadata mínima
- se agregan pruebas para listado, autorización admin y manejo de errores

## Validaciones

- `cd mcp-server && npm run test`
- `cd mcp-server && npm run build`

## Pruebas manuales

Se validó manualmente el comportamiento esperado:

- usuario no admin:
  - rechazo consistente con `FORBIDDEN`
- usuario admin con ID incorrecto:
  - respuesta `WARRANTY_NOT_FOUND`
- usuario admin con `warrantyId` real:
  - actualización exitosa a `review`
  - actualización exitosa a `resolved` con `repairNotes`

## Riesgos / notas

- la tool opera sobre el `_id` del documento en `warrantyreports`, no sobre `orderId`
- no se introduce lógica nueva de negocio; se reutiliza el backend existente
- no se implementan mecanismos nuevos de service token remoto, fuera del alcance de `#193`

## Issue relacionado

Closes #193
