### PR TITLE
HU-64: pruebas unitarias de servicios y validadores

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "module": "src/index.ts",
   "type": "module",
   "scripts": {
-    "dev": "bun run --watch src/index.ts"
+    "dev": "bun run --watch src/index.ts",
+    "test": "bun test"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1035.0",

--- a/backend/src/lib/alerting.test.ts
+++ b/backend/src/lib/alerting.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { alerting } from './alerting';
+
+describe('alerting', () => {
+  beforeEach(() => {
+    alerting.resetForTests();
+  });
+
+  test('reports no active alerts in a healthy, low-traffic state', () => {
+    expect(alerting.getActiveAlerts()).toEqual([]);
+  });
+
+  test('triggers high_error_rate after more than 20 errors in a minute', () => {
+    for (let i = 0; i < 21; i++) {
+      alerting.recordError('/api/products');
+    }
+    const alerts = alerting.getActiveAlerts();
+    expect(alerts.some((a) => a.name === 'high_error_rate')).toBe(true);
+  });
+
+  test('does not trigger high_error_rate at exactly the threshold', () => {
+    for (let i = 0; i < 20; i++) {
+      alerting.recordError('/api/products');
+    }
+    const alerts = alerting.getActiveAlerts();
+    expect(alerts.some((a) => a.name === 'high_error_rate')).toBe(false);
+  });
+
+  test('triggers checkout_failures after more than 5 checkout errors in a minute', () => {
+    for (let i = 0; i < 6; i++) {
+      alerting.recordError('/api/checkout');
+    }
+    const alerts = alerting.getActiveAlerts();
+    expect(alerts.some((a) => a.name === 'checkout_failures')).toBe(true);
+  });
+
+  test('triggers webhook_failures after more than 3 webhook errors in a minute', () => {
+    for (let i = 0; i < 4; i++) {
+      alerting.recordError('/api/webhooks/stripe');
+    }
+    const alerts = alerting.getActiveAlerts();
+    expect(alerts.some((a) => a.name === 'webhook_failures')).toBe(true);
+  });
+
+  test('counts webhook errors towards checkout_failures too, since webhooks match both windows', () => {
+    for (let i = 0; i < 6; i++) {
+      alerting.recordError('/api/webhooks/stripe');
+    }
+    const alerts = alerting.getActiveAlerts();
+    expect(alerts.some((a) => a.name === 'checkout_failures')).toBe(true);
+    expect(alerts.some((a) => a.name === 'webhook_failures')).toBe(true);
+  });
+
+  test('does not count unrelated errors towards checkout or webhook windows', () => {
+    for (let i = 0; i < 10; i++) {
+      alerting.recordError('/api/products');
+    }
+    const alerts = alerting.getActiveAlerts();
+    expect(alerts.some((a) => a.name === 'checkout_failures')).toBe(false);
+    expect(alerts.some((a) => a.name === 'webhook_failures')).toBe(false);
+  });
+
+  test('triggers db_unhealthy when the database connection is marked unhealthy', () => {
+    alerting.setDbHealth(false);
+    const alerts = alerting.getActiveAlerts();
+    expect(alerts.some((a) => a.name === 'db_unhealthy')).toBe(true);
+  });
+
+  test('clears db_unhealthy once the connection recovers', () => {
+    alerting.setDbHealth(false);
+    alerting.setDbHealth(true);
+    const alerts = alerting.getActiveAlerts();
+    expect(alerts.some((a) => a.name === 'db_unhealthy')).toBe(false);
+  });
+});

--- a/backend/src/lib/alerting.ts
+++ b/backend/src/lib/alerting.ts
@@ -27,6 +27,14 @@ export const alerting = {
     dbHealthy = healthy;
   },
 
+  resetForTests() {
+    dbHealthy = true;
+    errorWindow = [];
+    checkoutErrorWindow = [];
+    webhookErrorWindow = [];
+    state.lastTriggered = {};
+  },
+
   recordError(path: string) {
     const now = Date.now();
     errorWindow.push(now);

--- a/backend/src/lib/metrics.test.ts
+++ b/backend/src/lib/metrics.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+import { MetricsStore } from './metrics';
+
+describe('MetricsStore', () => {
+  test('starts with an empty snapshot', () => {
+    const store = new MetricsStore();
+    const snapshot = store.getSnapshot();
+    expect(snapshot.requests.total).toBe(0);
+    expect(snapshot.requests.errors).toBe(0);
+    expect(snapshot.requests.avgDuration).toBe(0);
+    expect(snapshot.topRoutes).toEqual([]);
+    expect(snapshot.business).toEqual([]);
+  });
+
+  test('aggregates request counts, durations and status codes', () => {
+    const store = new MetricsStore();
+    store.recordRequest('GET', '/api/products', 200, 100);
+    store.recordRequest('GET', '/api/products', 200, 300);
+
+    const snapshot = store.getSnapshot();
+    expect(snapshot.requests.total).toBe(2);
+    expect(snapshot.requests.avgDuration).toBe(200);
+    expect(snapshot.requests.byStatus[200]).toBe(2);
+    expect(snapshot.requests.errors).toBe(0);
+  });
+
+  test('counts responses with status >= 400 as errors', () => {
+    const store = new MetricsStore();
+    store.recordRequest('POST', '/api/checkout', 500, 50);
+    store.recordRequest('GET', '/api/products', 200, 50);
+
+    const snapshot = store.getSnapshot();
+    expect(snapshot.requests.errors).toBe(1);
+    expect(snapshot.requests.errorRate).toBe(50);
+  });
+
+  test('tracks per-route stats independently of the global total', () => {
+    const store = new MetricsStore();
+    store.recordRequest('GET', '/api/products', 200, 100);
+    store.recordRequest('GET', '/api/orders', 404, 20);
+
+    const snapshot = store.getSnapshot();
+    const routes = snapshot.topRoutes.map((r) => r.route);
+    expect(routes).toContain('GET /api/products');
+    expect(routes).toContain('GET /api/orders');
+
+    const ordersRoute = snapshot.topRoutes.find((r) => r.route === 'GET /api/orders');
+    expect(ordersRoute?.errors).toBe(1);
+    expect(ordersRoute?.errorRate).toBe(100);
+  });
+
+  test('records a business event and includes it in recent counts', () => {
+    const store = new MetricsStore();
+    store.recordBusiness('order_paid');
+    store.recordBusiness('order_paid');
+
+    const snapshot = store.getSnapshot();
+    const event = snapshot.business.find((b) => b.event === 'order_paid');
+    expect(event?.count).toBe(2);
+    expect(event?.recent).toBe(2);
+  });
+
+  test('orders topRoutes by descending request count', () => {
+    const store = new MetricsStore();
+    store.recordRequest('GET', '/api/low-traffic', 200, 10);
+    for (let i = 0; i < 3; i++) {
+      store.recordRequest('GET', '/api/high-traffic', 200, 10);
+    }
+
+    const snapshot = store.getSnapshot();
+    expect(snapshot.topRoutes[0].route).toBe('GET /api/high-traffic');
+  });
+});

--- a/backend/src/lib/metrics.ts
+++ b/backend/src/lib/metrics.ts
@@ -12,7 +12,7 @@ interface BusinessMetric {
   timestamps: number[];
 }
 
-class MetricsStore {
+export class MetricsStore {
   private requests: MetricBucket = { count: 0, totalDuration: 0, errors: 0, byStatus: {} };
   private routes: Record<string, MetricBucket> = {};
   private business: Record<string, BusinessMetric> = {};

--- a/backend/src/validators/address.validator.test.ts
+++ b/backend/src/validators/address.validator.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test';
+import { createAddressSchema, updateAddressSchema } from './address.validator';
+
+const validAddress = {
+  recipientName: 'Ana Perez',
+  phone: '099123456',
+  street: 'Av. Siempre Viva 123',
+  city: 'Asuncion',
+  state: 'Central',
+  zipCode: '1000',
+  country: 'Paraguay',
+};
+
+describe('createAddressSchema', () => {
+  test('accepts a fully populated address', () => {
+    const result = createAddressSchema.safeParse(validAddress);
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts isDefault as an optional boolean', () => {
+    const result = createAddressSchema.safeParse({ ...validAddress, isDefault: true });
+    expect(result.success).toBe(true);
+  });
+
+  test.each(Object.keys(validAddress) as Array<keyof typeof validAddress>)(
+    'rejects a missing required field: %s',
+    (field) => {
+      const incomplete: Record<string, unknown> = { ...validAddress };
+      delete incomplete[field];
+      const result = createAddressSchema.safeParse(incomplete);
+      expect(result.success).toBe(false);
+    },
+  );
+
+  test('rejects an empty string field', () => {
+    const result = createAddressSchema.safeParse({ ...validAddress, city: '' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('updateAddressSchema', () => {
+  test('accepts a partial update with a single field', () => {
+    const result = updateAddressSchema.safeParse({ city: 'Encarnacion' });
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts an empty object since all fields are optional', () => {
+    const result = updateAddressSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects an empty string on a provided field', () => {
+    const result = updateAddressSchema.safeParse({ street: '' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/src/validators/checkout.validator.test.ts
+++ b/backend/src/validators/checkout.validator.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test';
+import mongoose from 'mongoose';
+import { checkoutSchema } from './checkout.validator';
+
+const validId = () => new mongoose.Types.ObjectId().toString();
+
+describe('checkoutSchema', () => {
+  test('accepts a cart with one or more valid items', () => {
+    const result = checkoutSchema.safeParse({
+      items: [
+        { productId: validId(), quantity: 1 },
+        { productId: validId(), quantity: 3 },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects an empty items array', () => {
+    const result = checkoutSchema.safeParse({ items: [] });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects an invalid productId format', () => {
+    const result = checkoutSchema.safeParse({
+      items: [{ productId: 'not-a-valid-object-id', quantity: 1 }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a quantity of zero or less', () => {
+    const result = checkoutSchema.safeParse({
+      items: [{ productId: validId(), quantity: 0 }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a non-integer quantity', () => {
+    const result = checkoutSchema.safeParse({
+      items: [{ productId: validId(), quantity: 1.5 }],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/src/validators/order.validator.test.ts
+++ b/backend/src/validators/order.validator.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+import { updateShippingSchema } from './order.validator';
+
+describe('updateShippingSchema', () => {
+  test('accepts a status-only update', () => {
+    const result = updateShippingSchema.safeParse({ status: 'shipped' });
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts a carrier and trackingNumber update', () => {
+    const result = updateShippingSchema.safeParse({ carrier: 'DHL', trackingNumber: 'ABC123' });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects an empty object with no fields set', () => {
+    const result = updateShippingSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects an invalid status value', () => {
+    const result = updateShippingSchema.safeParse({ status: 'in_transit' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects an empty carrier string', () => {
+    const result = updateShippingSchema.safeParse({ carrier: '' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/src/validators/product.validator.test.ts
+++ b/backend/src/validators/product.validator.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  bestSellersQuerySchema,
+  createProductSchema,
+  lowStockQuerySchema,
+  productFilterSchema,
+  updateProductSchema,
+} from './product.validator';
+
+const validProduct = {
+  name: 'iPhone 12',
+  price: 350,
+  condition: 'A' as const,
+  category: 'celular' as const,
+};
+
+describe('createProductSchema', () => {
+  test('accepts a valid product and defaults stock to 0', () => {
+    const result = createProductSchema.safeParse(validProduct);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.stock).toBe(0);
+    }
+  });
+
+  test('accepts an explicit stock value', () => {
+    const result = createProductSchema.safeParse({ ...validProduct, stock: 5 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.stock).toBe(5);
+    }
+  });
+
+  test('rejects a negative price', () => {
+    const result = createProductSchema.safeParse({ ...validProduct, price: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects an invalid condition', () => {
+    const result = createProductSchema.safeParse({ ...validProduct, condition: 'D' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects an invalid category', () => {
+    const result = createProductSchema.safeParse({ ...validProduct, category: 'consola' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a non-url image', () => {
+    const result = createProductSchema.safeParse({ ...validProduct, image_urls: ['not-a-url'] });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('updateProductSchema', () => {
+  test('accepts a partial update without resetting stock to 0', () => {
+    const result = updateProductSchema.safeParse({ price: 400 });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.stock).toBeUndefined();
+    }
+  });
+
+  test('accepts an optional reason for stock adjustment', () => {
+    const result = updateProductSchema.safeParse({ stock: 10, reason: 'Reposicion' });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects an empty reason string', () => {
+    const result = updateProductSchema.safeParse({ reason: '' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('productFilterSchema', () => {
+  test('accepts an empty filter', () => {
+    const result = productFilterSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test('coerces numeric query params from strings', () => {
+    const result = productFilterSchema.safeParse({ minPrice: '10', maxPrice: '100', limit: '20', page: '2' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.minPrice).toBe(10);
+      expect(result.data.limit).toBe(20);
+    }
+  });
+
+  test('rejects minPrice greater than maxPrice', () => {
+    const result = productFilterSchema.safeParse({ minPrice: '100', maxPrice: '10' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a limit above the max allowed', () => {
+    const result = productFilterSchema.safeParse({ limit: '51' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('lowStockQuerySchema', () => {
+  test('accepts a missing threshold', () => {
+    const result = lowStockQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects a negative threshold', () => {
+    const result = lowStockQuerySchema.safeParse({ threshold: '-1' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('bestSellersQuerySchema', () => {
+  test('accepts a limit within range', () => {
+    const result = bestSellersQuerySchema.safeParse({ limit: '5' });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects a limit above 12', () => {
+    const result = bestSellersQuerySchema.safeParse({ limit: '13' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/src/validators/technician.validator.test.ts
+++ b/backend/src/validators/technician.validator.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  assignTechnicianSchema,
+  confirmPaymentSchema,
+  createTechnicianSchema,
+  techUpdateWarrantySchema,
+} from './technician.validator';
+
+describe('createTechnicianSchema', () => {
+  test('accepts a technician with a valid email', () => {
+    const result = createTechnicianSchema.safeParse({ name: 'Juan', email: 'juan@safetech.com' });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects an invalid email', () => {
+    const result = createTechnicianSchema.safeParse({ name: 'Juan', email: 'not-an-email' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a missing name', () => {
+    const result = createTechnicianSchema.safeParse({ email: 'juan@safetech.com' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('assignTechnicianSchema', () => {
+  test('accepts a valid technician assignment', () => {
+    const result = assignTechnicianSchema.safeParse({ technicianId: 'tech_1', technicianName: 'Juan' });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects a missing technicianId', () => {
+    const result = assignTechnicianSchema.safeParse({ technicianName: 'Juan' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('techUpdateWarrantySchema', () => {
+  test('accepts a status-only update', () => {
+    const result = techUpdateWarrantySchema.safeParse({ status: 'resolved' });
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts a repairNotes-only update', () => {
+    const result = techUpdateWarrantySchema.safeParse({ repairNotes: 'Se reemplazo la pantalla' });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects an empty object', () => {
+    const result = techUpdateWarrantySchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects an invalid status', () => {
+    const result = techUpdateWarrantySchema.safeParse({ status: 'pending' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('confirmPaymentSchema', () => {
+  test('accepts a valid paymentIntentId', () => {
+    const result = confirmPaymentSchema.safeParse({ paymentIntentId: 'pi_123' });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects an empty paymentIntentId', () => {
+    const result = confirmPaymentSchema.safeParse({ paymentIntentId: '' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/src/validators/warranty.validator.test.ts
+++ b/backend/src/validators/warranty.validator.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+import { createWarrantySchema, updateStatusSchema } from './warranty.validator';
+
+const validOrderId = '507f1f77bcf86cd799439011';
+
+describe('createWarrantySchema', () => {
+  test('accepts a valid warranty claim', () => {
+    const result = createWarrantySchema.safeParse({
+      orderId: validOrderId,
+      reason: 'Producto defectuoso',
+      description: 'La pantalla dejo de encender al segundo dia de uso',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test('defaults evidenceUrls to an empty array', () => {
+    const result = createWarrantySchema.safeParse({
+      orderId: validOrderId,
+      reason: 'Producto defectuoso',
+      description: 'La pantalla dejo de encender al segundo dia de uso',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.evidenceUrls).toEqual([]);
+    }
+  });
+
+  test('rejects an invalid orderId format', () => {
+    const result = createWarrantySchema.safeParse({
+      orderId: 'not-an-object-id',
+      reason: 'Producto defectuoso',
+      description: 'La pantalla dejo de encender al segundo dia de uso',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a description shorter than 10 characters', () => {
+    const result = createWarrantySchema.safeParse({
+      orderId: validOrderId,
+      reason: 'Producto defectuoso',
+      description: 'Muy corta',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a missing reason', () => {
+    const result = createWarrantySchema.safeParse({
+      orderId: validOrderId,
+      description: 'La pantalla dejo de encender al segundo dia de uso',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('updateStatusSchema', () => {
+  test('accepts a valid status', () => {
+    const result = updateStatusSchema.safeParse({ status: 'resolved' });
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts repairNotes alongside status', () => {
+    const result = updateStatusSchema.safeParse({ status: 'refunded', repairNotes: 'Reembolso procesado' });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects an invalid status', () => {
+    const result = updateStatusSchema.safeParse({ status: 'unknown' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a missing status', () => {
+    const result = updateStatusSchema.safeParse({ repairNotes: 'Reembolso procesado' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/src/validators/wishlist.validator.test.ts
+++ b/backend/src/validators/wishlist.validator.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { addToWishlistSchema, updateNoteSchema } from './wishlist.validator';
+
+describe('addToWishlistSchema', () => {
+  test('accepts a valid productId', () => {
+    const result = addToWishlistSchema.safeParse({ productId: 'prod_1' });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects an empty productId', () => {
+    const result = addToWishlistSchema.safeParse({ productId: '' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a missing productId', () => {
+    const result = addToWishlistSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('updateNoteSchema', () => {
+  test('accepts a valid note', () => {
+    const result = updateNoteSchema.safeParse({ note: 'Esperar oferta de fin de mes' });
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts an empty note string', () => {
+    const result = updateNoteSchema.safeParse({ note: '' });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects a note longer than 500 characters', () => {
+    const result = updateNoteSchema.safeParse({ note: 'a'.repeat(501) });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## HU-64 - Pruebas unitarias de servicios y validadores

Closes #173

### Cambios
- **Suite de pruebas unitarias** con `bun test` (runner nativo de Bun, sin dependencias nuevas).
- **Cobertura**: los 7 modulos de `validators/*.ts` (Zod, casos validos/invalidos, defaults, coerciones) y la logica de negocio pura en `lib/` sin dependencias externas: `alerting.ts` (reglas de alerta de HU-63) y `metrics.ts` (agregacion de metricas de HU-62).
- **Script**: se agrega `"test": "bun test"` a `backend/package.json`.

### Alcance y decision consciente sobre `services/`
`order.service.ts` e `inventory.service.ts` estan acoplados a Mongoose (transacciones, sesiones) y no tienen logica pura extraible sin refactor. Mockear Mongo para "unitario" los volveria pruebas fragiles y no reproducibles. Esa logica (incluido el decremento de stock critico en `finalizePaidOrder`) ya se ejercita end-to-end via la suite Playwright en `e2e/` (transaction.spec.ts) y se reforzara en HU-65 con los flujos criticos restantes (consulta de pedidos, garantia).

### Cambios menores en codigo de produccion (para permitir tests aislados)
- `lib/metrics.ts`: se exporta la clase `MetricsStore` (antes solo el singleton) para poder instanciarla limpia en cada test, sin estado compartido entre casos.
- `lib/alerting.ts`: se agrega `alerting.resetForTests()` para resetear el estado interno del singleton (ventanas de errores, cooldowns) entre tests. No se usa en runtime de produccion.

### Verificacion
```
cd backend && bun test
# 81 pass, 0 fail, 101 expect() calls, 9 files
```

### Criterios de aceptacion
- [x] El proyecto incluye suite automatizada de pruebas unitarias (`bun test`).
- [x] Las reglas de negocio criticas con logica pura tienen cobertura (validators + alerting + metrics).
- [x] Las pruebas se ejecutan de forma reproducible (`bun test`, sin servicios externos ni DB).