### PR TITLE
HU-65: pruebas e2e de flujos criticos

### DIFF
--- a/e2e/order-history.spec.ts
+++ b/e2e/order-history.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+import { resetE2EState, signInAs } from './helpers';
+
+test.beforeEach(async ({ request }) => {
+  await resetE2EState(request);
+});
+
+test('a signed-in shopper sees their order history with item detail', async ({ page }) => {
+  await signInAs(page, 'user');
+  await page.goto('/orders');
+
+  await expect(page.getByRole('heading', { name: /pedidos/i })).toBeVisible();
+  await expect(page.getByText('Pagado')).toBeVisible();
+  const orderHeadline = page.getByRole('heading', { name: 'iPhone 13 Reacondicionado' });
+  await expect(orderHeadline).toBeVisible();
+
+  await orderHeadline.click();
+
+  await expect(page.getByText('Artículos del pedido')).toBeVisible();
+  await expect(page.getByText(/Cantidad: 1/)).toBeVisible();
+  await expect(page.getByText('Registrar garantía →')).toBeVisible();
+});
+
+test('redirects a signed-out visitor to the sign-in prompt instead of showing order history', async ({ page }) => {
+  await page.goto('/orders');
+  await expect(page.getByRole('heading', { name: 'Debes iniciar sesión para ver tus pedidos' })).toBeVisible();
+});

--- a/e2e/warranty-claim.spec.ts
+++ b/e2e/warranty-claim.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from '@playwright/test';
+import { resetE2EState, signInAs } from './helpers';
+
+const API_URL = 'http://127.0.0.1:3001/api';
+const USER_AUTH = { Authorization: 'Bearer mock:user:e2e-user' };
+
+test.beforeEach(async ({ request }) => {
+  await resetE2EState(request);
+});
+
+test('a shopper files a warranty claim on a fresh purchase and sees it listed as pending', async ({ page }) => {
+  await signInAs(page, 'user');
+  await page.goto('/home');
+
+  await page.getByRole('button', { name: 'Añadir al carrito' }).first().click();
+  await page.getByRole('button', { name: 'Ir a pagar' }).click();
+  await expect(page).toHaveURL(/\/checkout$/);
+  await page.getByTestId('test-payment-button').click();
+  await expect(page).toHaveURL(/\/success\?payment_intent=e2e_pi_/);
+
+  await page.goto('/orders');
+  const newOrderCard = page.locator('.oc-card').first();
+  await newOrderCard.click();
+  await newOrderCard.getByText('Registrar garantía →').click();
+
+  await expect(page).toHaveURL(/\/warranties\/new\?orderId=/);
+  await expect(page.getByRole('heading', { name: 'Reportar garantía' })).toBeVisible();
+
+  await page.getByRole('combobox').selectOption('Falla de fábrica');
+  await page.getByRole('button', { name: 'Continuar' }).click();
+
+  await page
+    .getByPlaceholder('Describe detalladamente qué sucede con el producto...')
+    .fill('El producto llego con la pantalla rota desde la caja original.');
+  await page.getByRole('button', { name: 'Continuar' }).click();
+
+  await page.getByRole('button', { name: 'Enviar ticket' }).click();
+
+  await expect(page).toHaveURL(/\/warranties\/success$/);
+  await expect(page.getByRole('heading', { name: 'Ticket creado' })).toBeVisible();
+
+  await page.goto('/mis-garantias');
+  await expect(page.getByRole('heading', { name: /garantías/i })).toBeVisible();
+
+  // The seeded account already has one pre-existing warranty claim (from
+  // resetE2EState), so scope the assertion to the card for the claim just
+  // filed instead of asserting "Pendiente" globally.
+  const newClaimCard = page
+    .locator('.wc-card')
+    .filter({ hasText: 'El producto llego con la pantalla rota desde la caja original.' });
+  await expect(newClaimCard).toBeVisible();
+  await expect(newClaimCard.getByText('Pendiente')).toBeVisible();
+});
+
+test('an account with no warranty claims sees the empty state on mis-garantias', async ({ page }) => {
+  // The seeded warranty belongs to e2e-user, so e2e-admin has none of its own.
+  await signInAs(page, 'admin');
+  await page.goto('/mis-garantias');
+  await expect(page.getByRole('heading', { name: 'No tienes garantías registradas' })).toBeVisible();
+});
+
+test('rejects a second warranty claim for an order that already has one', async ({ request }) => {
+  const ordersRes = await request.get(`${API_URL}/orders/mine`, { headers: USER_AUTH });
+  const orders = await ordersRes.json();
+  const seededOrderId = orders[0]._id as string;
+
+  const response = await request.post(`${API_URL}/warranties`, {
+    headers: USER_AUTH,
+    data: {
+      orderId: seededOrderId,
+      reason: 'Falla de fábrica',
+      description: 'Otro intento de reclamo sobre la misma orden ya reportada.',
+    },
+  });
+
+  expect(response.status()).toBe(409);
+});
+
+test('rejects a warranty claim for an order that does not belong to the caller', async ({ request }) => {
+  const ordersRes = await request.get(`${API_URL}/orders/mine`, { headers: USER_AUTH });
+  const orders = await ordersRes.json();
+  const seededOrderId = orders[0]._id as string;
+
+  const response = await request.post(`${API_URL}/warranties`, {
+    headers: { Authorization: 'Bearer mock:admin:e2e-admin' },
+    data: {
+      orderId: seededOrderId,
+      reason: 'Falla de fábrica',
+      description: 'Reclamo intentado por un usuario que no es el dueno de la orden.',
+    },
+  });
+
+  expect(response.status()).toBe(403);
+});


### PR DESCRIPTION
## HU-65 - Pruebas E2E de flujos criticos

Closes #174

### Cambios
Se agregan dos especificaciones Playwright nuevas, siguiendo el estilo y helpers ya existentes en `e2e/` (`resetE2EState`, `signInAs`):

- **`e2e/order-history.spec.ts`**: un shopper autenticado ve su historial de pedidos y el detalle de un pedido pagado (articulos, cantidad, acceso a "Registrar garantia"); un visitante no autenticado ve el gate de inicio de sesion.
- **`e2e/warranty-claim.spec.ts`**: flujo completo de UI - compra -> registrar garantia (wizard de 3 pasos) -> pantalla de exito -> aparece listada como "Pendiente" en `/mis-garantias`. Ademas, casos de API para las reglas de negocio: 409 al reclamar dos veces sobre la misma orden, 403 al reclamar sobre una orden ajena, y el estado vacio de "Mis garantias" para una cuenta sin reclamos.

Login y compra ya estaban cubiertos por `auth.spec.ts` y `transaction.spec.ts`; con esto los 4 flujos criticos que pide la HU (login, compra, consulta de pedidos, garantia) quedan cubiertos.

### Alcance y decision consciente sobre el criterio de "el pipeline debe marcar fallo"
El criterio de aceptacion "el pipeline debe marcar fallo cuando las pruebas criticas no pasen" se resuelve en **HU-66** (#175, pipeline CI/CD), no en esta PR. Esta PR entrega las especificaciones E2E y su ejecutabilidad reproducible en un entorno aislado (Playwright + `E2E_TEST_MODE` + mock auth + reset seeding); HU-66 se encarga de correrlas en CI con gate de fallo.

### Verificacion
Corrida la suite completa contra un Mongo aislado:
```
npx playwright test
# 92 passed (34.0s)
```
Incluye los specs nuevos (6 tests) y los 86 preexistentes, todos en verde.

### Criterios de aceptacion
- [x] Se cubren al menos login, compra, consulta de pedidos y garantia.
- [x] Las pruebas son ejecutables en entorno aislado (Playwright + `E2E_TEST_MODE`, sin dependencias externas reales).
- [ ] El pipeline debe marcar fallo cuando las pruebas criticas no pasen -> se resuelve en HU-66.