### PR TITLE
feat: exponer assign_technician en MCP y robustecer asignacion de tecnicos

### DIFF
--- a/backend/src/controllers/warranty.controller.test.ts
+++ b/backend/src/controllers/warranty.controller.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { assignTechnician } from './warranty.controller';
+import { Technician } from '../models/Technician';
+import { WarrantyReport } from '../models/WarrantyReport';
+
+function createContext(body: Record<string, unknown>, id = 'wr_1') {
+  let statusCode = 200;
+  let payload: unknown;
+
+  const context = {
+    req: {
+      param: () => ({ id }),
+      json: async () => body,
+    },
+    json: (value: unknown, status?: number) => {
+      payload = value;
+      statusCode = status ?? 200;
+      return { payload: value, status: statusCode };
+    },
+  };
+
+  return {
+    context,
+    get statusCode() {
+      return statusCode;
+    },
+    get payload() {
+      return payload;
+    },
+  };
+}
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe('assignTechnician controller', () => {
+  test('resolves technician name from technicianId and updates the report', async () => {
+    const technicianLookup = mock(() =>
+      Promise.resolve({ _id: 'tech_1', name: 'Maria Gomez', active: true }),
+    );
+    const previousLookup = mock(() =>
+      Promise.resolve({ _id: 'wr_1', status: 'review' }),
+    );
+    const updateReport = mock(() =>
+      Promise.resolve({
+        _id: 'wr_1',
+        orderId: 'ord_1',
+        userId: 'user_1',
+        status: 'review',
+        description: 'Falla de bateria',
+        technicianId: 'tech_1',
+        technicianName: 'Maria Gomez',
+      }),
+    );
+
+    Technician.findById = technicianLookup as typeof Technician.findById;
+    WarrantyReport.findById = previousLookup as typeof WarrantyReport.findById;
+    WarrantyReport.findByIdAndUpdate = updateReport as typeof WarrantyReport.findByIdAndUpdate;
+
+    const harness = createContext({ technicianId: 'tech_1' });
+
+    await assignTechnician(harness.context as never);
+
+    expect(technicianLookup).toHaveBeenCalledWith('tech_1');
+    expect(updateReport).toHaveBeenCalledWith(
+      'wr_1',
+      expect.objectContaining({
+        technicianId: 'tech_1',
+        technicianName: 'Maria Gomez',
+        status: 'review',
+      }),
+      { new: true },
+    );
+    expect(harness.statusCode).toBe(200);
+  });
+
+  test('returns 409 when the technician exists but is inactive', async () => {
+    const technicianLookup = mock(() =>
+      Promise.resolve({ _id: 'tech_1', name: 'Maria Gomez', active: false }),
+    );
+
+    Technician.findById = technicianLookup as typeof Technician.findById;
+
+    const harness = createContext({ technicianId: 'tech_1' });
+
+    await assignTechnician(harness.context as never);
+
+    expect(harness.statusCode).toBe(409);
+    expect(harness.payload).toEqual({ error: 'Technician is inactive' });
+  });
+});

--- a/backend/src/controllers/warranty.controller.ts
+++ b/backend/src/controllers/warranty.controller.ts
@@ -2,6 +2,7 @@ import { Context } from 'hono';
 import { WarrantyReport } from '../models/WarrantyReport';
 import { Order } from '../models/Order';
 import { User } from '../models/User';
+import { Technician } from '../models/Technician';
 import { sendWarrantyCreatedEmail, sendWarrantyStatusChangedEmail } from '../services/email.service';
 
 export const createWarrantyReport = async (c: Context) => {
@@ -138,9 +139,21 @@ export const assignTechnician = async (c: Context) => {
     const { id } = c.req.param();
     const { technicianId, technicianName } = await c.req.json();
 
-    if (!technicianId || !technicianName) {
-      return c.json({ error: 'Missing technicianId or technicianName' }, 400);
+    if (!technicianId) {
+      return c.json({ error: 'Missing technicianId' }, 400);
     }
+
+    const technician = await Technician.findById(technicianId);
+
+    if (!technician) {
+      return c.json({ error: 'Technician not found' }, 404);
+    }
+
+    if (technician.active !== true) {
+      return c.json({ error: 'Technician is inactive' }, 409);
+    }
+
+    const resolvedTechnicianName = technician.name || technicianName;
 
     const previous = await WarrantyReport.findById(id);
     if (!previous) return c.json({ error: 'Report not found' }, 404);
@@ -150,7 +163,7 @@ export const assignTechnician = async (c: Context) => {
       id,
       {
         technicianId,
-        technicianName,
+        technicianName: resolvedTechnicianName,
         status: 'review',
         resolvedAt: undefined
       },

--- a/backend/src/routes/e2e.routes.ts
+++ b/backend/src/routes/e2e.routes.ts
@@ -99,6 +99,9 @@ e2eRoutes.post('/reset', async (c) => {
       phone: phone._id,
       laptop: laptop._id,
     },
+    technicianIds: {
+      primary: technician._id,
+    },
   });
 });
 

--- a/backend/src/validators/technician.validator.test.ts
+++ b/backend/src/validators/technician.validator.test.ts
@@ -29,6 +29,11 @@ describe('assignTechnicianSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  test('accepts a technician assignment with only technicianId', () => {
+    const result = assignTechnicianSchema.safeParse({ technicianId: 'tech_1' });
+    expect(result.success).toBe(true);
+  });
+
   test('rejects a missing technicianId', () => {
     const result = assignTechnicianSchema.safeParse({ technicianName: 'Juan' });
     expect(result.success).toBe(false);

--- a/backend/src/validators/technician.validator.ts
+++ b/backend/src/validators/technician.validator.ts
@@ -9,7 +9,7 @@ export const createTechnicianSchema = z.object({
 
 export const assignTechnicianSchema = z.object({
   technicianId: z.string().min(1, 'El ID del técnico es requerido'),
-  technicianName: z.string().min(1, 'El nombre del técnico es requerido'),
+  technicianName: z.string().min(1, 'El nombre del técnico es requerido').optional(),
 });
 
 export const techUpdateWarrantySchema = z.object({

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -5,6 +5,17 @@ export async function resetE2EState(request: APIRequestContext) {
   if (!response.ok()) {
     throw new Error(`Unable to reset e2e state: ${response.status()} ${await response.text()}`);
   }
+
+  return response.json() as Promise<{
+    ok: boolean;
+    productIds: {
+      phone: string;
+      laptop: string;
+    };
+    technicianIds: {
+      primary: string;
+    };
+  }>;
 }
 
 export async function signInAs(page: Page, role: 'user' | 'admin') {

--- a/e2e/transactional-emails.spec.ts
+++ b/e2e/transactional-emails.spec.ts
@@ -6,6 +6,7 @@ const USER_AUTH = { Authorization: 'Bearer mock:user:e2e-user' };
 const ADMIN_AUTH = { Authorization: 'Bearer mock:admin:e2e-admin' };
 
 const SHOPPER_EMAIL = 'shopper@safetech.test';
+let seededTechnicianId = '';
 
 async function getEmails(request: import('@playwright/test').APIRequestContext) {
   const response = await request.get(`${API_URL}/e2e/emails`);
@@ -25,7 +26,8 @@ async function getSeededWarrantyId(request: import('@playwright/test').APIReques
 }
 
 test.beforeEach(async ({ request }) => {
-  await resetE2EState(request);
+  const seed = await resetE2EState(request);
+  seededTechnicianId = seed.technicianIds.primary;
 });
 
 test('no hay correos pendientes justo despues del reset', async ({ request }) => {
@@ -151,7 +153,7 @@ test('envia un correo cuando un admin asigna un tecnico (pending -> review)', as
 
   const response = await request.put(`${API_URL}/warranties/${warrantyId}/assign`, {
     headers: ADMIN_AUTH,
-    data: { technicianId: 'tech-1', technicianName: 'Tecnico de Prueba' },
+    data: { technicianId: seededTechnicianId },
   });
   expect(response.status()).toBe(200);
   expect((await response.json()).status).toBe('review');

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -260,10 +260,10 @@ export default function AdminDashboard() {
   });
 
   const assignTechMutation = useMutation({
-    mutationFn: async ({ id, technicianId, technicianName }: { id: string; technicianId: string; technicianName: string }) => {
+    mutationFn: async ({ id, technicianId }: { id: string; technicianId: string }) => {
       const token = await getToken();
       if (!token) throw new Error('No token');
-      return warrantyService.assignTechnician(id, technicianId, technicianName, token);
+      return warrantyService.assignTechnician(id, technicianId, token);
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['admin-warranties'] }),
   });
@@ -546,7 +546,7 @@ export default function AdminDashboard() {
                                 value={w.technicianId || ''}
                                 onChange={(e) => {
                                   const tech = technicians?.find((t) => t._id === e.target.value);
-                                  if (tech) assignTechMutation.mutate({ id: w._id, technicianId: tech._id, technicianName: tech.name });
+                                  if (tech) assignTechMutation.mutate({ id: w._id, technicianId: tech._id });
                                 }}
                                 disabled={assignTechMutation.isPending || w.status !== 'pending'}
                                 style={{ minWidth: 140 }}

--- a/frontend/src/services/warranty.service.ts
+++ b/frontend/src/services/warranty.service.ts
@@ -79,14 +79,14 @@ export const warrantyService = {
     return response.json();
   },
 
-  async assignTechnician(id: string, technicianId: string, technicianName: string, token: string): Promise<IWarranty> {
+  async assignTechnician(id: string, technicianId: string, token: string): Promise<IWarranty> {
     const response = await fetch(`${API_URL}/warranties/${id}/assign`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`
       },
-      body: JSON.stringify({ technicianId, technicianName }),
+      body: JSON.stringify({ technicianId }),
     });
 
     if (!response.ok) throw new Error('Failed to assign technician');

--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -8,6 +8,7 @@ import { registerListMyOrdersTool } from './tools/user/list-my-orders.tool.js';
 import { registerListMyWarrantiesTool } from './tools/user/list-my-warranties.tool.js';
 import { registerCreateWarrantyClaimTool } from './tools/user/create-warranty-claim.tool.js';
 import { registerUpdateWarrantyStatusTool } from './tools/admin/update-warranty-status.tool.js';
+import { registerAssignTechnicianTool } from './tools/admin/assign-technician.tool.js';
 import type { Logger } from './utils/logger.js';
 
 interface ServerDependencies {
@@ -30,6 +31,7 @@ export function buildServer({ env, logger, backendApi, authInfo }: ServerDepende
   registerListMyWarrantiesTool(server, { env, logger, backendApi });
   registerCreateWarrantyClaimTool(server, { env, logger, backendApi });
   registerUpdateWarrantyStatusTool(server, { env, logger, backendApi });
+  registerAssignTechnicianTool(server, { env, logger, backendApi });
 
   return server;
 }

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -6,6 +6,8 @@ import type { Authenticator, AuthContext } from './types.js';
 import { BackendApiClient, BackendApiError } from './services/backend-api.js';
 import { createLogger } from './utils/logger.js';
 import type {
+  AssignTechnicianInput,
+  AssignTechnicianResult,
   CreateWarrantyClaimInput,
   CreateWarrantyClaimResult,
   OrderSummary,
@@ -59,6 +61,12 @@ class FakeBackendApi extends BackendApiClient {
   shouldRejectUpdateWarrantyForbidden = false;
   shouldRejectUpdateWarrantyNotFound = false;
   shouldRejectUpdateWarrantyInvalid = false;
+  shouldRejectAssignTechnicianAuth = false;
+  shouldRejectAssignTechnicianForbidden = false;
+  shouldRejectAssignTechnicianNotFound = false;
+  shouldRejectAssignTechnicianTechnicianNotFound = false;
+  shouldRejectAssignTechnicianTechnicianInactive = false;
+  shouldRejectAssignTechnicianInvalid = false;
   lastOrdersToken?: string;
   lastWarrantiesToken?: string;
   lastCreateWarrantyToken?: string;
@@ -66,6 +74,9 @@ class FakeBackendApi extends BackendApiClient {
   lastUpdateWarrantyToken?: string;
   lastUpdateWarrantyId?: string;
   lastUpdateWarrantyInput?: UpdateWarrantyStatusInput;
+  lastAssignTechnicianToken?: string;
+  lastAssignTechnicianId?: string;
+  lastAssignTechnicianInput?: AssignTechnicianInput;
 
   constructor() {
     super('http://backend.test/api');
@@ -347,6 +358,68 @@ class FakeBackendApi extends BackendApiClient {
       },
     };
   }
+
+  override async assignTechnician(
+    token: string,
+    warrantyId: string,
+    input: AssignTechnicianInput,
+    _requestId: string,
+  ): Promise<{ data: AssignTechnicianResult }> {
+    this.lastAssignTechnicianToken = token;
+    this.lastAssignTechnicianId = warrantyId;
+    this.lastAssignTechnicianInput = input;
+
+    if (this.shouldRejectAssignTechnicianAuth) {
+      throw new BackendApiError('Unauthorized', 401, {
+        error: 'Unauthorized: Token verification failed',
+      });
+    }
+
+    if (this.shouldRejectAssignTechnicianForbidden) {
+      throw new BackendApiError('Forbidden', 403, {
+        error: 'Forbidden: Insufficient privileges',
+      });
+    }
+
+    if (this.shouldRejectAssignTechnicianTechnicianNotFound) {
+      throw new BackendApiError('Not found', 404, {
+        error: 'Technician not found',
+      });
+    }
+
+    if (this.shouldRejectAssignTechnicianTechnicianInactive) {
+      throw new BackendApiError('Conflict', 409, {
+        error: 'Technician is inactive',
+      });
+    }
+
+    if (this.shouldRejectAssignTechnicianNotFound) {
+      throw new BackendApiError('Not found', 404, {
+        error: 'Report not found',
+      });
+    }
+
+    if (this.shouldRejectAssignTechnicianInvalid) {
+      throw new BackendApiError('Bad request', 400, {
+        error: 'Missing technicianId',
+      });
+    }
+
+    return {
+      data: {
+        id: warrantyId,
+        orderId: '6870f1e2a1234567890abcde',
+        userId: 'user_owner_1',
+        status: 'review',
+        description: '[battery] La bateria no carga correctamente',
+        evidenceUrls: ['https://cdn.test/evidence-1.jpg'],
+        technicianId: input.technicianId,
+        technicianName: 'Maria Gomez',
+        createdAt: '2026-07-02T09:00:00.000Z',
+        updatedAt: '2026-07-03T12:00:00.000Z',
+      },
+    };
+  }
 }
 
 test('health endpoint reports backend connectivity', async () => {
@@ -444,10 +517,10 @@ test('mcp handshake works and exposes search_products tool', async () => {
   assert.equal(serverVersion?.name, 'SafeTech MCP Server');
 
   const tools = await client.listTools();
-  assert.equal(tools.tools.length, 6);
+  assert.equal(tools.tools.length, 7);
   assert.deepEqual(
     tools.tools.map((tool) => tool.name).sort(),
-    ['create_warranty_claim', 'get_product', 'list_my_orders', 'list_my_warranties', 'search_products', 'update_warranty_status'],
+    ['assign_technician', 'create_warranty_claim', 'get_product', 'list_my_orders', 'list_my_warranties', 'search_products', 'update_warranty_status'],
   );
 
   const result = await client.callTool({
@@ -620,6 +693,231 @@ test('update_warranty_status normalizes backend validation failures', async () =
   assert.deepEqual(result.structuredContent, {
     code: 'INVALID_WARRANTY_UPDATE',
     message: 'Invalid status transition',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('assign_technician assigns a technician for an admin user', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'assign_technician',
+    arguments: {
+      warrantyId: '6870f1e2a1234567890abcdf',
+      technicianId: '6870f1e2a1234567890ab111',
+    },
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.equal(backendApi.lastAssignTechnicianToken, 'test-token');
+  assert.equal(backendApi.lastAssignTechnicianId, '6870f1e2a1234567890abcdf');
+  assert.deepEqual(backendApi.lastAssignTechnicianInput, {
+    technicianId: '6870f1e2a1234567890ab111',
+  });
+  assert.deepEqual(result.structuredContent, {
+    id: '6870f1e2a1234567890abcdf',
+    orderId: '6870f1e2a1234567890abcde',
+    userId: 'user_owner_1',
+    status: 'review',
+    description: '[battery] La bateria no carga correctamente',
+    evidenceUrls: ['https://cdn.test/evidence-1.jpg'],
+    technicianId: '6870f1e2a1234567890ab111',
+    technicianName: 'Maria Gomez',
+    createdAt: '2026-07-02T09:00:00.000Z',
+    updatedAt: '2026-07-03T12:00:00.000Z',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('assign_technician rejects non-admin users before calling the backend', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('user'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'assign_technician',
+    arguments: {
+      warrantyId: '6870f1e2a1234567890abcdf',
+      technicianId: '6870f1e2a1234567890ab111',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.equal(backendApi.lastAssignTechnicianToken, undefined);
+  assert.deepEqual(result.structuredContent, {
+    code: 'FORBIDDEN',
+    message: 'Solo un administrador puede asignar tecnicos a garantias.',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('assign_technician normalizes a missing technician backend failure', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectAssignTechnicianTechnicianNotFound = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'assign_technician',
+    arguments: {
+      warrantyId: '6870f1e2a1234567890abcdf',
+      technicianId: '6870f1e2a1234567890ab111',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'TECHNICIAN_NOT_FOUND',
+    message: 'No se encontro el tecnico indicado.',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('assign_technician normalizes an inactive technician backend failure', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectAssignTechnicianTechnicianInactive = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'assign_technician',
+    arguments: {
+      warrantyId: '6870f1e2a1234567890abcdf',
+      technicianId: '6870f1e2a1234567890ab111',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'TECHNICIAN_INACTIVE',
+    message: 'El tecnico indicado existe, pero esta inactivo.',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('assign_technician normalizes a missing warranty backend failure', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectAssignTechnicianNotFound = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'assign_technician',
+    arguments: {
+      warrantyId: '6870f1e2a1234567890abcdf',
+      technicianId: '6870f1e2a1234567890ab111',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'WARRANTY_NOT_FOUND',
+    message: 'No se encontro la garantia indicada.',
   });
 
   await transport.terminateSession();

--- a/mcp-server/src/services/backend-api.ts
+++ b/mcp-server/src/services/backend-api.ts
@@ -1,4 +1,7 @@
 import type {
+  AssignTechnicianInput,
+  AssignTechnicianResult,
+  BackendAssignTechnicianResponse,
   CreateWarrantyClaimInput,
   CreateWarrantyClaimResult,
   BackendOrderResponse,
@@ -198,6 +201,43 @@ export class BackendApiClient {
   ): Promise<{ data: UpdateWarrantyStatusResult }> {
     const response = await this.request<BackendWarrantyStatusResponse>(
       `/warranties/${warrantyId}/status`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+          'x-request-id': requestId,
+        },
+        body: JSON.stringify(input),
+      },
+    );
+
+    return {
+      data: {
+        id: response._id,
+        orderId: response.orderId,
+        userId: response.userId,
+        status: response.status,
+        description: response.description,
+        evidenceUrls: response.evidenceUrls ?? [],
+        ...(response.repairNotes !== undefined ? { repairNotes: response.repairNotes } : {}),
+        ...(response.technicianId ? { technicianId: response.technicianId } : {}),
+        ...(response.technicianName ? { technicianName: response.technicianName } : {}),
+        createdAt: response.createdAt,
+        ...(response.updatedAt ? { updatedAt: response.updatedAt } : {}),
+        ...(response.resolvedAt ? { resolvedAt: response.resolvedAt } : {}),
+      },
+    };
+  }
+
+  async assignTechnician(
+    token: string,
+    warrantyId: string,
+    input: AssignTechnicianInput,
+    requestId: string,
+  ): Promise<{ data: AssignTechnicianResult }> {
+    const response = await this.request<BackendAssignTechnicianResponse>(
+      `/warranties/${warrantyId}/assign`,
       {
         method: 'PUT',
         headers: {

--- a/mcp-server/src/tools/admin/assign-technician.tool.ts
+++ b/mcp-server/src/tools/admin/assign-technician.tool.ts
@@ -1,0 +1,248 @@
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { z } from 'zod';
+import type { AppEnv } from '../../config/env.js';
+import { logAuditEvent } from '../../services/audit-log.js';
+import { BackendApiError, type BackendApiClient } from '../../services/backend-api.js';
+import type { Logger } from '../../utils/logger.js';
+import { buildToolMeta } from '../access-control.js';
+
+const assignTechnicianInputSchema = z.object({
+  warrantyId: z.string().regex(/^[0-9a-fA-F]{24}$/, 'Invalid warranty ID format'),
+  technicianId: z.string().regex(/^[0-9a-fA-F]{24}$/, 'Invalid technician ID format'),
+});
+
+const assignTechnicianOutputSchema = z.object({
+  id: z.string(),
+  orderId: z.string(),
+  userId: z.string(),
+  status: z.enum(['pending', 'review', 'resolved', 'rejected', 'refunded']),
+  description: z.string(),
+  evidenceUrls: z.array(z.string().url()),
+  repairNotes: z.string().optional(),
+  technicianId: z.string().optional(),
+  technicianName: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string().optional(),
+  resolvedAt: z.string().optional(),
+});
+
+interface RegisterAssignTechnicianToolDependencies {
+  env: AppEnv;
+  logger: Logger;
+  backendApi: BackendApiClient;
+}
+
+export function registerAssignTechnicianTool(
+  server: McpServer,
+  { env, logger, backendApi }: RegisterAssignTechnicianToolDependencies,
+) {
+  server.registerTool(
+    'assign_technician',
+    {
+      title: 'Assign Technician',
+      description:
+        'Asigna un tecnico a un reclamo de garantia y devuelve el estado persistido del caso. Solo disponible para administradores.',
+      inputSchema: assignTechnicianInputSchema,
+      outputSchema: assignTechnicianOutputSchema,
+      annotations: {
+        readOnlyHint: false,
+        openWorldHint: false,
+      },
+      _meta: {
+        ...buildToolMeta('admin', {
+          issue: '#194',
+          source: `${env.BACKEND_API_URL}/warranties/:id/assign`,
+        }),
+      },
+    },
+    async (input, ctx) => {
+      const auditRequestId = randomUUID();
+      const startedAt = Date.now();
+      const authInfo = getAuthInfo(ctx);
+      const actor = authInfo?.clientId ?? 'anonymous';
+      const role = extractRole(ctx);
+      const token = authInfo?.token;
+      const auditMetadata = {
+        warrantyId: input.warrantyId,
+        technicianId: input.technicianId,
+      };
+
+      try {
+        if (!token) {
+          const authError = {
+            code: 'AUTH_REQUIRED',
+            message: 'Se requiere autenticacion para asignar tecnicos.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role,
+            action: 'tool.assign_technician',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: authError.code,
+            metadata: auditMetadata,
+          });
+
+          return {
+            content: [{ type: 'text', text: authError.message }],
+            structuredContent: authError,
+            isError: true,
+          };
+        }
+
+        if (role !== 'admin') {
+          const forbiddenError = {
+            code: 'FORBIDDEN',
+            message: 'Solo un administrador puede asignar tecnicos a garantias.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role,
+            action: 'tool.assign_technician',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: forbiddenError.code,
+            metadata: auditMetadata,
+          });
+
+          return {
+            content: [{ type: 'text', text: forbiddenError.message }],
+            structuredContent: forbiddenError,
+            isError: true,
+          };
+        }
+
+        const response = await backendApi.assignTechnician(
+          token,
+          input.warrantyId,
+          {
+            technicianId: input.technicianId,
+          },
+          auditRequestId,
+        );
+
+        const output = response.data;
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role,
+          action: 'tool.assign_technician',
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+          metadata: {
+            ...auditMetadata,
+            persistedStatus: output.status,
+            technicianName: output.technicianName,
+          },
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output) }],
+          structuredContent: output,
+        };
+      } catch (error) {
+        const normalizedError = normalizeToolError(error);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role,
+          action: 'tool.assign_technician',
+          outcome: 'error',
+          durationMs: Date.now() - startedAt,
+          errorCode: normalizedError.code,
+          metadata: auditMetadata,
+        });
+
+        return {
+          content: [{ type: 'text', text: normalizedError.message }],
+          structuredContent: normalizedError,
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function extractRole(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  const roleScope = getAuthInfo(ctx)?.scopes?.find((scope: string) => scope.startsWith('role:'));
+  return roleScope?.replace('role:', '') ?? 'unknown';
+}
+
+function getAuthInfo(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  return ctx.http?.authInfo ?? (ctx as { authInfo?: { token?: string; clientId?: string; scopes?: string[] } }).authInfo;
+}
+
+function normalizeToolError(error: unknown) {
+  if (error instanceof BackendApiError) {
+    if (error.status === 401) {
+      return {
+        code: 'AUTH_REQUIRED',
+        message: 'La sesion no es valida para asignar tecnicos.',
+      };
+    }
+
+    if (error.status === 403) {
+      return {
+        code: 'FORBIDDEN',
+        message: 'No tienes permisos para asignar tecnicos a esta garantia.',
+      };
+    }
+
+    if (error.status === 404) {
+      const backendMessage = extractBackendMessage(error.body);
+
+      if (backendMessage === 'Technician not found') {
+        return {
+          code: 'TECHNICIAN_NOT_FOUND',
+          message: 'No se encontro el tecnico indicado.',
+        };
+      }
+
+      return {
+        code: 'WARRANTY_NOT_FOUND',
+        message: 'No se encontro la garantia indicada.',
+      };
+    }
+
+    if (error.status === 409) {
+      return {
+        code: 'TECHNICIAN_INACTIVE',
+        message: 'El tecnico indicado existe, pero esta inactivo.',
+      };
+    }
+
+    if (error.status === 400) {
+      return {
+        code: 'INVALID_TECHNICIAN_ASSIGNMENT',
+        message:
+          extractBackendMessage(error.body) ??
+          'Los datos enviados para asignar el tecnico no son validos.',
+      };
+    }
+
+    return {
+      code: `BACKEND_${error.status}`,
+      message: 'No fue posible asignar el tecnico en este momento.',
+    };
+  }
+
+  return {
+    code: 'INTERNAL_ERROR',
+    message: 'Ocurrio un error inesperado al asignar el tecnico.',
+  };
+}
+
+function extractBackendMessage(body: unknown) {
+  if (typeof body === 'object' && body !== null && 'error' in body && typeof body.error === 'string') {
+    return body.error;
+  }
+
+  return null;
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -177,7 +177,26 @@ export interface UpdateWarrantyStatusInput {
   repairNotes?: string;
 }
 
+export interface AssignTechnicianInput {
+  technicianId: string;
+}
+
 export interface UpdateWarrantyStatusResult {
+  id: string;
+  orderId: string;
+  userId: string;
+  status: 'pending' | 'review' | 'resolved' | 'rejected' | 'refunded';
+  description: string;
+  evidenceUrls: string[];
+  repairNotes?: string;
+  technicianId?: string;
+  technicianName?: string;
+  createdAt: string;
+  updatedAt?: string;
+  resolvedAt?: string;
+}
+
+export interface AssignTechnicianResult {
   id: string;
   orderId: string;
   userId: string;
@@ -214,6 +233,21 @@ export interface BackendWarrantyResponse {
 }
 
 export interface BackendWarrantyStatusResponse {
+  _id: string;
+  orderId: string;
+  userId: string;
+  status: 'pending' | 'review' | 'resolved' | 'rejected' | 'refunded';
+  description: string;
+  evidenceUrls?: string[];
+  repairNotes?: string;
+  technicianId?: string;
+  technicianName?: string;
+  createdAt: string;
+  updatedAt?: string;
+  resolvedAt?: string;
+}
+
+export interface BackendAssignTechnicianResponse {
   _id: string;
   orderId: string;
   userId: string;


### PR DESCRIPTION
## Resumen

Este PR cierra el issue técnico MCP `#194` exponiendo la tool `assign_technician` para administradores y reforzando el flujo de asignación de técnicos en SafeTech.

Además de registrar la tool en `mcp-server`, se mejoró el contrato backend para que la asignación dependa de `technicianId` como fuente de verdad, resolviendo internamente el `technicianName` y diferenciando técnicos inexistentes de técnicos inactivos.

## Cambios principales

- agregar la tool MCP `assign_technician`
- restringir la tool a usuarios con rol `admin`
- integrar la tool con `PUT /api/warranties/:id/assign`
- normalizar respuestas y errores del flujo de asignación
- agregar auditoría para una acción sensible
- resolver en backend el nombre del técnico a partir de `technicianId`
- distinguir entre técnico inexistente y técnico inactivo
- actualizar frontend para enviar solo `technicianId`
- agregar pruebas del controlador backend y de la tool MCP

## Validaciones ejecutadas

- `bun test backend/src/controllers/warranty.controller.test.ts backend/src/validators/technician.validator.test.ts`
- `npm test` en `mcp-server/`
- `npm run build` en `mcp-server/`
- `npm run build` en `frontend/`

## Pruebas funcionales manuales

Probado en ChatGPT con cuenta no `admin`:
- la operación fue rechazada con `FORBIDDEN`
- no se permitió asignar técnicos ni cambiar el estado de la garantía

Probado en ChatGPT con cuenta `admin`:
- asignación exitosa de garantía a técnico existente
- transición de la garantía a estado `review`
- error controlado para técnico inexistente con `TECHNICIAN_NOT_FOUND`
- error controlado para garantía inexistente con `WARRANTY_NOT_FOUND`

## Riesgos o notas

- la prueba backend agregada cubre la lógica real del controlador con mocks de modelos, no una prueba HTTP end-to-end contra app + base de datos real
- el build de frontend sigue mostrando la advertencia existente de Vite sobre tamaño de bundle, sin relación directa con este issue

## Issue relacionado

Closes #194
