### PR TITLE
feat: exponer tool MCP create_product para administradores

### DIFF
--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -9,6 +9,7 @@ import { registerListMyWarrantiesTool } from './tools/user/list-my-warranties.to
 import { registerCreateWarrantyClaimTool } from './tools/user/create-warranty-claim.tool.js';
 import { registerUpdateWarrantyStatusTool } from './tools/admin/update-warranty-status.tool.js';
 import { registerAssignTechnicianTool } from './tools/admin/assign-technician.tool.js';
+import { registerCreateProductTool } from './tools/admin/create-product.tool.js';
 import type { Logger } from './utils/logger.js';
 
 interface ServerDependencies {
@@ -32,6 +33,7 @@ export function buildServer({ env, logger, backendApi, authInfo }: ServerDepende
   registerCreateWarrantyClaimTool(server, { env, logger, backendApi });
   registerUpdateWarrantyStatusTool(server, { env, logger, backendApi });
   registerAssignTechnicianTool(server, { env, logger, backendApi });
+  registerCreateProductTool(server, { env, logger, backendApi });
 
   return server;
 }

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -8,6 +8,8 @@ import { createLogger } from './utils/logger.js';
 import type {
   AssignTechnicianInput,
   AssignTechnicianResult,
+  CreateProductInput,
+  CreateProductResult,
   CreateWarrantyClaimInput,
   CreateWarrantyClaimResult,
   OrderSummary,
@@ -67,10 +69,15 @@ class FakeBackendApi extends BackendApiClient {
   shouldRejectAssignTechnicianTechnicianNotFound = false;
   shouldRejectAssignTechnicianTechnicianInactive = false;
   shouldRejectAssignTechnicianInvalid = false;
+  shouldRejectCreateProductAuth = false;
+  shouldRejectCreateProductForbidden = false;
+  shouldRejectCreateProductInvalid = false;
   lastOrdersToken?: string;
   lastWarrantiesToken?: string;
   lastCreateWarrantyToken?: string;
   lastCreateWarrantyInput?: CreateWarrantyClaimInput;
+  lastCreateProductToken?: string;
+  lastCreateProductInput?: CreateProductInput;
   lastUpdateWarrantyToken?: string;
   lastUpdateWarrantyId?: string;
   lastUpdateWarrantyInput?: UpdateWarrantyStatusInput;
@@ -158,6 +165,48 @@ class FakeBackendApi extends BackendApiClient {
         category: 'celular' as const,
         primaryImageUrl: 'https://cdn.test/iphone.jpg',
         imageUrls: ['https://cdn.test/iphone.jpg', 'https://cdn.test/iphone-back.jpg'],
+      },
+    };
+  }
+
+  override async createProduct(
+    token: string,
+    input: CreateProductInput,
+    _requestId: string,
+  ): Promise<{ data: CreateProductResult }> {
+    this.lastCreateProductToken = token;
+    this.lastCreateProductInput = input;
+
+    if (this.shouldRejectCreateProductAuth) {
+      throw new BackendApiError('Unauthorized', 401, {
+        error: 'Unauthorized',
+      });
+    }
+
+    if (this.shouldRejectCreateProductForbidden) {
+      throw new BackendApiError('Forbidden', 403, {
+        error: 'Forbidden',
+      });
+    }
+
+    if (this.shouldRejectCreateProductInvalid) {
+      throw new BackendApiError('Bad request', 400, {
+        success: false,
+        message: 'La categoría es inválida',
+      });
+    }
+
+    return {
+      data: {
+        id: '6870f1e2a1234567890ab222',
+        name: input.name,
+        ...(input.description !== undefined ? { description: input.description } : {}),
+        price: input.price,
+        stock: input.stock ?? 0,
+        condition: input.condition,
+        category: input.category,
+        primaryImageUrl: input.imageUrls?.[0],
+        imageUrls: input.imageUrls ?? [],
       },
     };
   }
@@ -517,10 +566,10 @@ test('mcp handshake works and exposes search_products tool', async () => {
   assert.equal(serverVersion?.name, 'SafeTech MCP Server');
 
   const tools = await client.listTools();
-  assert.equal(tools.tools.length, 7);
+  assert.equal(tools.tools.length, 8);
   assert.deepEqual(
     tools.tools.map((tool) => tool.name).sort(),
-    ['assign_technician', 'create_warranty_claim', 'get_product', 'list_my_orders', 'list_my_warranties', 'search_products', 'update_warranty_status'],
+    ['assign_technician', 'create_product', 'create_warranty_claim', 'get_product', 'list_my_orders', 'list_my_warranties', 'search_products', 'update_warranty_status'],
   );
 
   const result = await client.callTool({
@@ -608,6 +657,158 @@ test('update_warranty_status updates a warranty for an admin user', async () => 
     createdAt: '2026-07-02T09:00:00.000Z',
     updatedAt: '2026-07-03T12:00:00.000Z',
     resolvedAt: '2026-07-03T12:00:00.000Z',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('create_product creates a product for an admin user', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'create_product',
+    arguments: {
+      name: 'MacBook Pro 14 Reacondicionado',
+      description: 'M3 Pro, 18GB RAM, 512GB SSD',
+      price: 1899,
+      stock: 3,
+      condition: 'A',
+      category: 'laptop',
+      imageUrls: ['https://cdn.test/macbook-front.jpg', 'https://cdn.test/macbook-side.jpg'],
+    },
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.equal(backendApi.lastCreateProductToken, 'test-token');
+  assert.deepEqual(backendApi.lastCreateProductInput, {
+    name: 'MacBook Pro 14 Reacondicionado',
+    description: 'M3 Pro, 18GB RAM, 512GB SSD',
+    price: 1899,
+    stock: 3,
+    condition: 'A',
+    category: 'laptop',
+    imageUrls: ['https://cdn.test/macbook-front.jpg', 'https://cdn.test/macbook-side.jpg'],
+  });
+  assert.deepEqual(result.structuredContent, {
+    id: '6870f1e2a1234567890ab222',
+    name: 'MacBook Pro 14 Reacondicionado',
+    description: 'M3 Pro, 18GB RAM, 512GB SSD',
+    price: 1899,
+    stock: 3,
+    condition: 'A',
+    category: 'laptop',
+    primaryImageUrl: 'https://cdn.test/macbook-front.jpg',
+    imageUrls: ['https://cdn.test/macbook-front.jpg', 'https://cdn.test/macbook-side.jpg'],
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('create_product rejects non-admin users before calling the backend', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('user'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'create_product',
+    arguments: {
+      name: 'MacBook Pro 14 Reacondicionado',
+      price: 1899,
+      condition: 'A',
+      category: 'laptop',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.equal(backendApi.lastCreateProductToken, undefined);
+  assert.deepEqual(result.structuredContent, {
+    code: 'FORBIDDEN',
+    message: 'Solo un administrador puede crear productos.',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('create_product normalizes backend validation failures', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectCreateProductInvalid = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'create_product',
+    arguments: {
+      name: 'MacBook Pro 14 Reacondicionado',
+      price: 1899,
+      condition: 'A',
+      category: 'laptop',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'INVALID_PRODUCT_INPUT',
+    message: 'La categoría es inválida',
   });
 
   await transport.terminateSession();

--- a/mcp-server/src/services/backend-api.ts
+++ b/mcp-server/src/services/backend-api.ts
@@ -4,10 +4,13 @@ import type {
   BackendAssignTechnicianResponse,
   CreateWarrantyClaimInput,
   CreateWarrantyClaimResult,
+  CreateProductInput,
+  CreateProductResult,
   BackendOrderResponse,
   BackendWarrantyStatusResponse,
   BackendWarrantyResponse,
   BackendHealth,
+  ProductCreateResponse,
   OrderSummary,
   ProductDetail,
   ProductDetailResponse,
@@ -82,6 +85,44 @@ export class BackendApiClient {
       headers: {
         'x-request-id': requestId,
       },
+    });
+
+    return {
+      data: {
+        id: response.data._id,
+        name: response.data.name,
+        description: response.data.description,
+        price: response.data.price,
+        stock: response.data.stock,
+        condition: response.data.condition,
+        category: response.data.category,
+        primaryImageUrl: response.data.image_urls?.[0],
+        imageUrls: response.data.image_urls ?? [],
+      },
+    };
+  }
+
+  async createProduct(
+    token: string,
+    input: CreateProductInput,
+    requestId: string,
+  ): Promise<{ data: CreateProductResult }> {
+    const response = await this.request<ProductCreateResponse>('/products', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'x-request-id': requestId,
+      },
+      body: JSON.stringify({
+        name: input.name,
+        ...(input.description !== undefined ? { description: input.description } : {}),
+        price: input.price,
+        ...(input.stock !== undefined ? { stock: input.stock } : {}),
+        condition: input.condition,
+        category: input.category,
+        ...(input.imageUrls !== undefined ? { image_urls: input.imageUrls } : {}),
+      }),
     });
 
     return {

--- a/mcp-server/src/tools/admin/create-product.tool.ts
+++ b/mcp-server/src/tools/admin/create-product.tool.ts
@@ -1,0 +1,254 @@
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { z } from 'zod';
+import type { AppEnv } from '../../config/env.js';
+import { logAuditEvent } from '../../services/audit-log.js';
+import { BackendApiError, type BackendApiClient } from '../../services/backend-api.js';
+import type { CreateProductInput, CreateProductResult } from '../../types.js';
+import type { Logger } from '../../utils/logger.js';
+import { buildToolMeta } from '../access-control.js';
+
+const createProductInputSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+  description: z.string().trim().min(1).optional(),
+  price: z.number().min(0),
+  stock: z.number().int().min(0).optional(),
+  condition: z.enum(['A', 'B', 'C']),
+  category: z.enum(['celular', 'laptop', 'pc', 'auriculares', 'tablet']),
+  imageUrls: z.array(z.string().url()).optional(),
+});
+
+const createProductOutputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  price: z.number(),
+  stock: z.number().int(),
+  condition: z.enum(['A', 'B', 'C']),
+  category: z.enum(['celular', 'laptop', 'pc', 'auriculares', 'tablet']),
+  primaryImageUrl: z.string().url().optional(),
+  imageUrls: z.array(z.string().url()),
+});
+
+interface RegisterCreateProductToolDependencies {
+  env: AppEnv;
+  logger: Logger;
+  backendApi: BackendApiClient;
+}
+
+export function registerCreateProductTool(
+  server: McpServer,
+  { env, logger, backendApi }: RegisterCreateProductToolDependencies,
+) {
+  server.registerTool(
+    'create_product',
+    {
+      title: 'Create Product',
+      description:
+        'Crea un producto nuevo en el catalogo de SafeTech y devuelve el registro persistido. Solo disponible para administradores.',
+      inputSchema: createProductInputSchema,
+      outputSchema: createProductOutputSchema,
+      annotations: {
+        readOnlyHint: false,
+        openWorldHint: false,
+      },
+      _meta: {
+        ...buildToolMeta('admin', {
+          issue: '#195',
+          source: `${env.BACKEND_API_URL}/products`,
+        }),
+      },
+    },
+    async (input, ctx) => {
+      const auditRequestId = randomUUID();
+      const startedAt = Date.now();
+      const authInfo = getAuthInfo(ctx);
+      const actor = authInfo?.clientId ?? 'anonymous';
+      const role = extractRole(ctx);
+      const token = authInfo?.token;
+      const auditMetadata = {
+        productName: input.name,
+        category: input.category,
+        condition: input.condition,
+      };
+
+      try {
+        if (!token) {
+          const authError = {
+            code: 'AUTH_REQUIRED',
+            message: 'Se requiere autenticacion para crear productos.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role,
+            action: 'tool.create_product',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: authError.code,
+            metadata: auditMetadata,
+          });
+
+          return {
+            content: [{ type: 'text', text: authError.message }],
+            structuredContent: authError,
+            isError: true,
+          };
+        }
+
+        if (role !== 'admin') {
+          const forbiddenError = {
+            code: 'FORBIDDEN',
+            message: 'Solo un administrador puede crear productos.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role,
+            action: 'tool.create_product',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: forbiddenError.code,
+            metadata: auditMetadata,
+          });
+
+          return {
+            content: [{ type: 'text', text: forbiddenError.message }],
+            structuredContent: forbiddenError,
+            isError: true,
+          };
+        }
+
+        const response = await backendApi.createProduct(
+          token,
+          {
+            name: input.name,
+            ...(input.description !== undefined ? { description: input.description } : {}),
+            price: input.price,
+            ...(input.stock !== undefined ? { stock: input.stock } : {}),
+            condition: input.condition,
+            category: input.category,
+            ...(input.imageUrls !== undefined ? { imageUrls: input.imageUrls } : {}),
+          },
+          auditRequestId,
+        );
+
+        const output = normalizeProduct(response.data);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role,
+          action: 'tool.create_product',
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+          metadata: {
+            ...auditMetadata,
+            productId: output.id,
+            stock: output.stock,
+          },
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output) }],
+          structuredContent: output,
+        };
+      } catch (error) {
+        const normalizedError = normalizeToolError(error);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role,
+          action: 'tool.create_product',
+          outcome: 'error',
+          durationMs: Date.now() - startedAt,
+          errorCode: normalizedError.code,
+          metadata: auditMetadata,
+        });
+
+        return {
+          content: [{ type: 'text', text: normalizedError.message }],
+          structuredContent: normalizedError,
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function normalizeProduct(product: CreateProductResult): z.infer<typeof createProductOutputSchema> {
+  return {
+    id: product.id,
+    name: product.name,
+    ...(product.description ? { description: product.description } : {}),
+    price: product.price,
+    stock: product.stock,
+    condition: product.condition,
+    category: product.category,
+    ...(product.primaryImageUrl ? { primaryImageUrl: product.primaryImageUrl } : {}),
+    imageUrls: product.imageUrls,
+  };
+}
+
+function extractRole(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  const roleScope = getAuthInfo(ctx)?.scopes?.find((scope: string) => scope.startsWith('role:'));
+  return roleScope?.replace('role:', '') ?? 'unknown';
+}
+
+function getAuthInfo(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  return ctx.http?.authInfo ?? (ctx as { authInfo?: { token?: string; clientId?: string; scopes?: string[] } }).authInfo;
+}
+
+function normalizeToolError(error: unknown) {
+  if (error instanceof BackendApiError) {
+    if (error.status === 401) {
+      return {
+        code: 'AUTH_REQUIRED',
+        message: 'La sesion no es valida para crear productos.',
+      };
+    }
+
+    if (error.status === 403) {
+      return {
+        code: 'FORBIDDEN',
+        message: 'No tienes permisos para crear productos.',
+      };
+    }
+
+    if (error.status === 400) {
+      return {
+        code: 'INVALID_PRODUCT_INPUT',
+        message:
+          extractBackendMessage(error.body) ??
+          'Los datos enviados para crear el producto no son validos.',
+      };
+    }
+
+    return {
+      code: `BACKEND_${error.status}`,
+      message: 'No fue posible crear el producto en este momento.',
+    };
+  }
+
+  return {
+    code: 'INTERNAL_ERROR',
+    message: 'Ocurrio un error inesperado al crear el producto.',
+  };
+}
+
+function extractBackendMessage(body: unknown) {
+  if (typeof body === 'object' && body !== null) {
+    if ('message' in body && typeof body.message === 'string') {
+      return body.message;
+    }
+
+    if ('error' in body && typeof body.error === 'string') {
+      return body.error;
+    }
+  }
+
+  return null;
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -33,6 +33,18 @@ export interface ProductDetail extends ProductSummary {
   imageUrls: string[];
 }
 
+export interface CreateProductInput {
+  name: string;
+  description?: string;
+  price: number;
+  stock?: number;
+  condition: 'A' | 'B' | 'C';
+  category: 'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet';
+  imageUrls?: string[];
+}
+
+export interface CreateProductResult extends ProductDetail {}
+
 export interface ProductListResponse {
   success: boolean;
   data: Array<{
@@ -51,6 +63,23 @@ export interface ProductListResponse {
 }
 
 export interface ProductDetailResponse {
+  success: boolean;
+  data: {
+    _id: string;
+    name: string;
+    description?: string;
+    price: number;
+    stock: number;
+    condition: 'A' | 'B' | 'C';
+    category: 'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet';
+    image_urls?: string[];
+    createdAt?: string;
+    updatedAt?: string;
+    __v?: number;
+  };
+}
+
+export interface ProductCreateResponse {
   success: boolean;
   data: {
     _id: string;


### PR DESCRIPTION
## Resumen

Este PR expone la herramienta MCP `create_product` sobre la lógica ya existente de productos en SafeTech, sin reimplementar el CRUD ni modificar la HU funcional original.

Se agrega la integración en `mcp-server` para que agentes conectados por MCP puedan crear productos usando el backend actual, con validación de autenticación, control de rol `admin`, respuesta normalizada y auditoría reforzada.

## Cambios realizados

- registrar la tool `create_product` en el `mcp-server`
- extender el cliente backend para consumir `POST /api/products`
- definir contratos `input/output` y tipos para creación de productos
- validar autenticación y rol `admin` antes de invocar el backend
- normalizar la respuesta del backend para uso por agentes MCP
- normalizar errores de autorización y validación
- agregar auditoría reforzada para la ejecución de la tool
- agregar pruebas automáticas del tool en el servidor MCP

## Validaciones ejecutadas

### Automatizadas
- `cd mcp-server && npm test`
- `cd mcp-server && npm run build`

### Manuales en ChatGPT con MCP SafeTech

#### Cuenta no admin
Se probó `_create_product` con múltiples payloads válidos y en todos los casos el resultado fue rechazo por permisos.

Resultado estructurado esperado y observado:

```json
{
  "code": "FORBIDDEN",
  "message": "Solo un administrador puede crear productos."
}
```

También se verificó que, después del intento fallido, el producto no queda persistido en catálogo.

#### Cuenta admin
Se probó `_create_product` con múltiples payloads válidos en distintas categorías:
- `laptop`
- `celular`
- `auriculares`
- `tablet`
- `pc`

Se validó que:
- la tool devuelve `id` real del producto creado
- la respuesta normalizada incluye `name`, `price`, `stock`, `condition`, `category`
- cuando se envían imágenes, devuelve `primaryImageUrl` e `imageUrls`
- el producto queda persistido y puede encontrarse luego por nombre

## Riesgos o pendientes

- No se observaron bloqueos funcionales para `#195`.
- Se detectó un renderizado extraño de `primaryImageUrl` en una respuesta textual de ChatGPT, pero no afecta el valor real devuelto por la tool ni la persistencia en backend.
- El backend actual permite crear múltiples productos con el mismo nombre; este PR no cambia ese comportamiento porque está fuera del alcance del issue técnico MCP.

## Issue relacionado

Closes #195
