### PR TITLE
feat: exponer update_product en MCP

### DIFF
--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -10,6 +10,7 @@ import { registerCreateWarrantyClaimTool } from './tools/user/create-warranty-cl
 import { registerUpdateWarrantyStatusTool } from './tools/admin/update-warranty-status.tool.js';
 import { registerAssignTechnicianTool } from './tools/admin/assign-technician.tool.js';
 import { registerCreateProductTool } from './tools/admin/create-product.tool.js';
+import { registerUpdateProductTool } from './tools/admin/update-product.tool.js';
 import type { Logger } from './utils/logger.js';
 
 interface ServerDependencies {
@@ -34,6 +35,7 @@ export function buildServer({ env, logger, backendApi, authInfo }: ServerDepende
   registerUpdateWarrantyStatusTool(server, { env, logger, backendApi });
   registerAssignTechnicianTool(server, { env, logger, backendApi });
   registerCreateProductTool(server, { env, logger, backendApi });
+  registerUpdateProductTool(server, { env, logger, backendApi });
 
   return server;
 }

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -13,6 +13,8 @@ import type {
   CreateWarrantyClaimInput,
   CreateWarrantyClaimResult,
   OrderSummary,
+  UpdateProductInput,
+  UpdateProductResult,
   UpdateWarrantyStatusInput,
   UpdateWarrantyStatusResult,
   WarrantySummary,
@@ -72,12 +74,19 @@ class FakeBackendApi extends BackendApiClient {
   shouldRejectCreateProductAuth = false;
   shouldRejectCreateProductForbidden = false;
   shouldRejectCreateProductInvalid = false;
+  shouldRejectUpdateProductAuth = false;
+  shouldRejectUpdateProductForbidden = false;
+  shouldRejectUpdateProductInvalid = false;
+  shouldRejectUpdateProductNotFound = false;
   lastOrdersToken?: string;
   lastWarrantiesToken?: string;
   lastCreateWarrantyToken?: string;
   lastCreateWarrantyInput?: CreateWarrantyClaimInput;
   lastCreateProductToken?: string;
   lastCreateProductInput?: CreateProductInput;
+  lastUpdateProductToken?: string;
+  lastUpdateProductId?: string;
+  lastUpdateProductInput?: UpdateProductInput;
   lastUpdateWarrantyToken?: string;
   lastUpdateWarrantyId?: string;
   lastUpdateWarrantyInput?: UpdateWarrantyStatusInput;
@@ -207,6 +216,57 @@ class FakeBackendApi extends BackendApiClient {
         category: input.category,
         primaryImageUrl: input.imageUrls?.[0],
         imageUrls: input.imageUrls ?? [],
+      },
+    };
+  }
+
+  override async updateProduct(
+    token: string,
+    productId: string,
+    input: UpdateProductInput,
+    _requestId: string,
+  ): Promise<{ data: UpdateProductResult }> {
+    this.lastUpdateProductToken = token;
+    this.lastUpdateProductId = productId;
+    this.lastUpdateProductInput = input;
+
+    if (this.shouldRejectUpdateProductAuth) {
+      throw new BackendApiError('Unauthorized', 401, {
+        error: 'Unauthorized',
+      });
+    }
+
+    if (this.shouldRejectUpdateProductForbidden) {
+      throw new BackendApiError('Forbidden', 403, {
+        error: 'Forbidden',
+      });
+    }
+
+    if (this.shouldRejectUpdateProductNotFound) {
+      throw new BackendApiError('Not found', 404, {
+        success: false,
+        message: 'Producto no encontrado',
+      });
+    }
+
+    if (this.shouldRejectUpdateProductInvalid) {
+      throw new BackendApiError('Bad request', 400, {
+        success: false,
+        message: 'El precio debe ser un valor positivo',
+      });
+    }
+
+    return {
+      data: {
+        id: productId,
+        name: input.name ?? 'iPhone 13 Reacondicionado',
+        ...(input.description !== undefined ? { description: input.description } : {}),
+        price: input.price ?? 699,
+        stock: input.stock ?? 4,
+        condition: input.condition ?? 'A',
+        category: input.category ?? 'celular',
+        primaryImageUrl: input.imageUrls?.[0] ?? 'https://cdn.test/iphone.jpg',
+        imageUrls: input.imageUrls ?? ['https://cdn.test/iphone.jpg'],
       },
     };
   }
@@ -566,10 +626,10 @@ test('mcp handshake works and exposes search_products tool', async () => {
   assert.equal(serverVersion?.name, 'SafeTech MCP Server');
 
   const tools = await client.listTools();
-  assert.equal(tools.tools.length, 8);
+  assert.equal(tools.tools.length, 9);
   assert.deepEqual(
     tools.tools.map((tool) => tool.name).sort(),
-    ['assign_technician', 'create_product', 'create_warranty_claim', 'get_product', 'list_my_orders', 'list_my_warranties', 'search_products', 'update_warranty_status'],
+    ['assign_technician', 'create_product', 'create_warranty_claim', 'get_product', 'list_my_orders', 'list_my_warranties', 'search_products', 'update_product', 'update_warranty_status'],
   );
 
   const result = await client.callTool({
@@ -726,6 +786,66 @@ test('create_product creates a product for an admin user', async () => {
   await client.close();
 });
 
+test('update_product updates a product for an admin user', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'update_product',
+    arguments: {
+      productId: '6870f1e2a1234567890ab222',
+      updates: {
+        price: 749,
+        stock: 6,
+        imageUrls: ['https://cdn.test/iphone-new.jpg'],
+        reason: 'Reconteo de inventario',
+      },
+    },
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.equal(backendApi.lastUpdateProductToken, 'test-token');
+  assert.equal(backendApi.lastUpdateProductId, '6870f1e2a1234567890ab222');
+  assert.deepEqual(backendApi.lastUpdateProductInput, {
+    price: 749,
+    stock: 6,
+    imageUrls: ['https://cdn.test/iphone-new.jpg'],
+    reason: 'Reconteo de inventario',
+  });
+  assert.deepEqual(result.structuredContent, {
+    id: '6870f1e2a1234567890ab222',
+    name: 'iPhone 13 Reacondicionado',
+    price: 749,
+    stock: 6,
+    condition: 'A',
+    category: 'celular',
+    primaryImageUrl: 'https://cdn.test/iphone-new.jpg',
+    imageUrls: ['https://cdn.test/iphone-new.jpg'],
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
 test('create_product rejects non-admin users before calling the backend', async () => {
   const backendApi = new FakeBackendApi();
   const { app } = createApp({
@@ -764,6 +884,50 @@ test('create_product rejects non-admin users before calling the backend', async 
   assert.deepEqual(result.structuredContent, {
     code: 'FORBIDDEN',
     message: 'Solo un administrador puede crear productos.',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('update_product rejects non-admin users before calling the backend', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('user'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'update_product',
+    arguments: {
+      productId: '6870f1e2a1234567890ab222',
+      updates: {
+        price: 749,
+      },
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.equal(backendApi.lastUpdateProductToken, undefined);
+  assert.deepEqual(result.structuredContent, {
+    code: 'FORBIDDEN',
+    message: 'Solo un administrador puede actualizar productos.',
   });
 
   await transport.terminateSession();
@@ -809,6 +973,96 @@ test('create_product normalizes backend validation failures', async () => {
   assert.deepEqual(result.structuredContent, {
     code: 'INVALID_PRODUCT_INPUT',
     message: 'La categoría es inválida',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('update_product normalizes backend validation failures', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectUpdateProductInvalid = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'update_product',
+    arguments: {
+      productId: '6870f1e2a1234567890ab222',
+      updates: {
+        price: 749,
+      },
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'INVALID_PRODUCT_INPUT',
+    message: 'El precio debe ser un valor positivo',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('update_product normalizes product not found responses', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectUpdateProductNotFound = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'update_product',
+    arguments: {
+      productId: '6870f1e2a1234567890ab999',
+      updates: {
+        stock: 2,
+      },
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'PRODUCT_NOT_FOUND',
+    message: 'Producto no encontrado',
   });
 
   await transport.terminateSession();

--- a/mcp-server/src/services/backend-api.ts
+++ b/mcp-server/src/services/backend-api.ts
@@ -6,6 +6,8 @@ import type {
   CreateWarrantyClaimResult,
   CreateProductInput,
   CreateProductResult,
+  UpdateProductInput,
+  UpdateProductResult,
   BackendOrderResponse,
   BackendWarrantyStatusResponse,
   BackendWarrantyResponse,
@@ -122,6 +124,46 @@ export class BackendApiClient {
         condition: input.condition,
         category: input.category,
         ...(input.imageUrls !== undefined ? { image_urls: input.imageUrls } : {}),
+      }),
+    });
+
+    return {
+      data: {
+        id: response.data._id,
+        name: response.data.name,
+        description: response.data.description,
+        price: response.data.price,
+        stock: response.data.stock,
+        condition: response.data.condition,
+        category: response.data.category,
+        primaryImageUrl: response.data.image_urls?.[0],
+        imageUrls: response.data.image_urls ?? [],
+      },
+    };
+  }
+
+  async updateProduct(
+    token: string,
+    productId: string,
+    input: UpdateProductInput,
+    requestId: string,
+  ): Promise<{ data: UpdateProductResult }> {
+    const response = await this.request<ProductCreateResponse>(`/products/${productId}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'x-request-id': requestId,
+      },
+      body: JSON.stringify({
+        ...(input.name !== undefined ? { name: input.name } : {}),
+        ...(input.description !== undefined ? { description: input.description } : {}),
+        ...(input.price !== undefined ? { price: input.price } : {}),
+        ...(input.stock !== undefined ? { stock: input.stock } : {}),
+        ...(input.condition !== undefined ? { condition: input.condition } : {}),
+        ...(input.category !== undefined ? { category: input.category } : {}),
+        ...(input.imageUrls !== undefined ? { image_urls: input.imageUrls } : {}),
+        ...(input.reason !== undefined ? { reason: input.reason } : {}),
       }),
     });
 

--- a/mcp-server/src/tools/admin/update-product.tool.ts
+++ b/mcp-server/src/tools/admin/update-product.tool.ts
@@ -1,0 +1,274 @@
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { z } from 'zod';
+import type { AppEnv } from '../../config/env.js';
+import { logAuditEvent } from '../../services/audit-log.js';
+import { BackendApiError, type BackendApiClient } from '../../services/backend-api.js';
+import type { Logger } from '../../utils/logger.js';
+import { buildToolMeta } from '../access-control.js';
+
+const productPatchSchema = z
+  .object({
+    name: z.string().trim().min(1).max(200).optional(),
+    description: z.string().trim().min(1).optional(),
+    price: z.number().min(0).optional(),
+    stock: z.number().int().min(0).optional(),
+    condition: z.enum(['A', 'B', 'C']).optional(),
+    category: z.enum(['celular', 'laptop', 'pc', 'auriculares', 'tablet']).optional(),
+    imageUrls: z.array(z.string().url()).optional(),
+    reason: z.string().trim().min(1).optional(),
+  })
+  .refine((input) => Object.keys(input).length > 0, {
+    message: 'Debes enviar al menos un campo para actualizar.',
+  });
+
+const updateProductInputSchema = z.object({
+  productId: z.string().trim().min(1),
+  updates: productPatchSchema,
+});
+
+const updateProductOutputSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  price: z.number(),
+  stock: z.number().int(),
+  condition: z.enum(['A', 'B', 'C']),
+  category: z.enum(['celular', 'laptop', 'pc', 'auriculares', 'tablet']),
+  primaryImageUrl: z.string().url().optional(),
+  imageUrls: z.array(z.string().url()),
+});
+
+interface RegisterUpdateProductToolDependencies {
+  env: AppEnv;
+  logger: Logger;
+  backendApi: BackendApiClient;
+}
+
+export function registerUpdateProductTool(
+  server: McpServer,
+  { env, logger, backendApi }: RegisterUpdateProductToolDependencies,
+) {
+  server.registerTool(
+    'update_product',
+    {
+      title: 'Update Product',
+      description:
+        'Actualiza parcialmente un producto del catalogo de SafeTech y devuelve el registro persistido. Solo disponible para administradores.',
+      inputSchema: updateProductInputSchema,
+      outputSchema: updateProductOutputSchema,
+      annotations: {
+        readOnlyHint: false,
+        openWorldHint: false,
+      },
+      _meta: {
+        ...buildToolMeta('admin', {
+          issue: '#196',
+          source: `${env.BACKEND_API_URL}/products/:id`,
+        }),
+      },
+    },
+    async (input, ctx) => {
+      const auditRequestId = randomUUID();
+      const startedAt = Date.now();
+      const authInfo = getAuthInfo(ctx);
+      const actor = authInfo?.clientId ?? 'anonymous';
+      const role = extractRole(ctx);
+      const token = authInfo?.token;
+      const auditMetadata = {
+        productId: input.productId,
+        updatedFields: Object.keys(input.updates),
+        stockReasonProvided: input.updates.reason !== undefined,
+      };
+
+      try {
+        if (!token) {
+          const authError = {
+            code: 'AUTH_REQUIRED',
+            message: 'Se requiere autenticacion para actualizar productos.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role,
+            action: 'tool.update_product',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: authError.code,
+            metadata: auditMetadata,
+          });
+
+          return {
+            content: [{ type: 'text', text: authError.message }],
+            structuredContent: authError,
+            isError: true,
+          };
+        }
+
+        if (role !== 'admin') {
+          const forbiddenError = {
+            code: 'FORBIDDEN',
+            message: 'Solo un administrador puede actualizar productos.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role,
+            action: 'tool.update_product',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: forbiddenError.code,
+            metadata: auditMetadata,
+          });
+
+          return {
+            content: [{ type: 'text', text: forbiddenError.message }],
+            structuredContent: forbiddenError,
+            isError: true,
+          };
+        }
+
+        const response = await backendApi.updateProduct(
+          token,
+          input.productId,
+          input.updates,
+          auditRequestId,
+        );
+
+        const output = normalizeProduct(response.data);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role,
+          action: 'tool.update_product',
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+          metadata: {
+            ...auditMetadata,
+            productName: output.name,
+            stock: output.stock,
+          },
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output) }],
+          structuredContent: output,
+        };
+      } catch (error) {
+        const normalizedError = normalizeToolError(error);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role,
+          action: 'tool.update_product',
+          outcome: 'error',
+          durationMs: Date.now() - startedAt,
+          errorCode: normalizedError.code,
+          metadata: auditMetadata,
+        });
+
+        return {
+          content: [{ type: 'text', text: normalizedError.message }],
+          structuredContent: normalizedError,
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function normalizeProduct(product: z.infer<typeof updateProductOutputSchema>) {
+  return {
+    id: product.id,
+    name: product.name,
+    ...(product.description ? { description: product.description } : {}),
+    price: product.price,
+    stock: product.stock,
+    condition: product.condition,
+    category: product.category,
+    ...(product.primaryImageUrl ? { primaryImageUrl: product.primaryImageUrl } : {}),
+    imageUrls: product.imageUrls,
+  };
+}
+
+function extractRole(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  const roleScope = getAuthInfo(ctx)?.scopes?.find((scope: string) => scope.startsWith('role:'));
+  return roleScope?.replace('role:', '') ?? 'unknown';
+}
+
+function getAuthInfo(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  return ctx.http?.authInfo ?? (ctx as { authInfo?: { token?: string; clientId?: string; scopes?: string[] } }).authInfo;
+}
+
+function normalizeToolError(error: unknown) {
+  if (error instanceof BackendApiError) {
+    if (error.status === 401) {
+      return {
+        code: 'AUTH_REQUIRED',
+        message: 'La sesion no es valida para actualizar productos.',
+      };
+    }
+
+    if (error.status === 403) {
+      return {
+        code: 'FORBIDDEN',
+        message: 'No tienes permisos para actualizar productos.',
+      };
+    }
+
+    if (error.status === 404) {
+      return {
+        code: 'PRODUCT_NOT_FOUND',
+        message: extractBackendMessage(error.body) ?? 'El producto indicado no existe.',
+      };
+    }
+
+    if (error.status === 400) {
+      return {
+        code: 'INVALID_PRODUCT_INPUT',
+        message:
+          extractBackendMessage(error.body) ??
+          'Los datos enviados para actualizar el producto no son validos.',
+      };
+    }
+
+    return {
+      code: `BACKEND_${error.status}`,
+      message: 'No fue posible actualizar el producto en este momento.',
+    };
+  }
+
+  return {
+    code: 'INTERNAL_ERROR',
+    message: 'Ocurrio un error inesperado al actualizar el producto.',
+  };
+}
+
+function extractBackendMessage(body: unknown) {
+  if (body && typeof body === 'object') {
+    const candidate = body as {
+      message?: unknown;
+      error?: unknown;
+      errors?: Array<{ message?: string }>;
+    };
+
+    if (typeof candidate.message === 'string') {
+      return candidate.message;
+    }
+
+    if (typeof candidate.error === 'string') {
+      return candidate.error;
+    }
+
+    const firstError = candidate.errors?.find((entry) => typeof entry.message === 'string');
+    if (firstError?.message) {
+      return firstError.message;
+    }
+  }
+
+  return null;
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -45,6 +45,19 @@ export interface CreateProductInput {
 
 export interface CreateProductResult extends ProductDetail {}
 
+export interface UpdateProductInput {
+  name?: string;
+  description?: string;
+  price?: number;
+  stock?: number;
+  condition?: 'A' | 'B' | 'C';
+  category?: 'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet';
+  imageUrls?: string[];
+  reason?: string;
+}
+
+export interface UpdateProductResult extends ProductDetail {}
+
 export interface ProductListResponse {
   success: boolean;
   data: Array<{


### PR DESCRIPTION
## Resumen

Este PR implementa el issue técnico `#196` para exponer la capacidad `update_product` en el servidor MCP de SafeTech, reutilizando la lógica backend ya existente de `HU-27` sin reimplementar el CRUD de productos.

## Cambios realizados

- se registra la tool `update_product` en el `mcp-server`
- se agrega la implementación de la tool admin `update_product`
- se extienden los tipos compartidos para soportar actualización parcial de productos
- se extiende el cliente backend para consumir `PUT /api/products/:id`
- se valida autenticación y rol `admin` antes de invocar el backend
- se normaliza la respuesta del producto actualizado para uso por agentes MCP
- se normalizan errores de autorización, validación y producto no encontrado
- se agrega auditoría reforzada para la ejecución de una acción sensible
- se agregan pruebas automatizadas del tool

## Alcance

Incluye únicamente la exposición MCP de `update_product`.

No incluye:
- nueva lógica de productos
- cambios a la HU original `#136`
- reimplementación del CRUD de productos

## Validaciones ejecutadas

### Locales

- `cd mcp-server && npm run build`
- `cd mcp-server && npm test`

Resultado:
- `31` tests OK
- `0` fallos

### Remotas

Con cuenta `non-admin`:
- intento de actualizar precio, stock, categoría, nombre e imágenes
- resultado esperado y observado: rechazo consistente con `Solo un administrador puede actualizar productos.`

Con cuenta `admin`:
- actualización exitosa de precio
- actualización exitosa de stock con `reason`
- actualización exitosa de nombre
- actualización exitosa de descripción
- actualización exitosa de categoría válida
- actualización exitosa de imágenes
- actualización exitosa múltiple (`price`, `stock`, `description`)
- validación de `404` con producto inexistente: `Producto no encontrado`

Validación de schema MCP:
- `price < 0` rechazado por `inputSchema`
- `stock < 0` rechazado por `inputSchema`
- `category` fuera del enum rechazada por `inputSchema`

## Riesgos / notas

- el campo `reason` fue incluido en la tool porque el backend actual ya lo soporta para auditoría de movimientos de inventario
- durante el flujo local, `git pull` sobre `develop` reportó una discrepancia de tracking remoto (`refs/heads/develop` no fue traída), aunque no bloqueó la implementación ni el push de la rama

## Issue relacionado

Closes #196
