### PR TITLE
feat(mcp): exponer delete_product y devolver el producto eliminado

### DIFF
--- a/backend/src/controllers/product.controller.test.ts
+++ b/backend/src/controllers/product.controller.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { deleteProduct } from './product.controller';
+import { Product } from '../models/Product';
+
+function createContext(id = 'prod_1') {
+  let statusCode = 200;
+  let payload: unknown;
+
+  const context = {
+    req: {
+      param: () => id,
+    },
+    json: (value: unknown, status?: number) => {
+      payload = value;
+      statusCode = status ?? 200;
+      return { payload: value, status: statusCode };
+    },
+  };
+
+  return {
+    context,
+    get statusCode() {
+      return statusCode;
+    },
+    get payload() {
+      return payload;
+    },
+  };
+}
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe('deleteProduct controller', () => {
+  test('returns deleted product data when the product exists', async () => {
+    const deletedProduct = {
+      _id: 'prod_1',
+      name: 'iPhone 13 Reacondicionado',
+      description: '128GB',
+      price: 699,
+      stock: 4,
+      condition: 'A',
+      category: 'celular',
+      image_urls: ['https://cdn.test/iphone.jpg'],
+    };
+
+    const deleteById = mock(() => Promise.resolve(deletedProduct));
+    Product.findByIdAndDelete = deleteById as typeof Product.findByIdAndDelete;
+
+    const harness = createContext('prod_1');
+
+    await deleteProduct(harness.context as never);
+
+    expect(deleteById).toHaveBeenCalledWith('prod_1');
+    expect(harness.statusCode).toBe(200);
+    expect(harness.payload).toEqual({
+      success: true,
+      message: 'Producto eliminado correctamente',
+      data: deletedProduct,
+    });
+  });
+
+  test('returns 404 when the product does not exist', async () => {
+    const deleteById = mock(() => Promise.resolve(null));
+    Product.findByIdAndDelete = deleteById as typeof Product.findByIdAndDelete;
+
+    const harness = createContext('missing_product');
+
+    await deleteProduct(harness.context as never);
+
+    expect(harness.statusCode).toBe(404);
+    expect(harness.payload).toEqual({
+      success: false,
+      message: 'Producto no encontrado',
+    });
+  });
+});

--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -235,7 +235,11 @@ export const deleteProduct = async (c: Context) => {
       return c.json({ success: false, message: 'Producto no encontrado' }, 404);
     }
     
-    return c.json({ success: true, message: 'Producto eliminado correctamente' });
+    return c.json({
+      success: true,
+      message: 'Producto eliminado correctamente',
+      data: deletedProduct,
+    });
   } catch (error: any) {
     return c.json({ success: false, message: error.message }, 500);
   }

--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -11,6 +11,7 @@ import { registerUpdateWarrantyStatusTool } from './tools/admin/update-warranty-
 import { registerAssignTechnicianTool } from './tools/admin/assign-technician.tool.js';
 import { registerCreateProductTool } from './tools/admin/create-product.tool.js';
 import { registerUpdateProductTool } from './tools/admin/update-product.tool.js';
+import { registerDeleteProductTool } from './tools/admin/delete-product.tool.js';
 import type { Logger } from './utils/logger.js';
 
 interface ServerDependencies {
@@ -36,6 +37,7 @@ export function buildServer({ env, logger, backendApi, authInfo }: ServerDepende
   registerAssignTechnicianTool(server, { env, logger, backendApi });
   registerCreateProductTool(server, { env, logger, backendApi });
   registerUpdateProductTool(server, { env, logger, backendApi });
+  registerDeleteProductTool(server, { env, logger, backendApi });
 
   return server;
 }

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -12,6 +12,7 @@ import type {
   CreateProductResult,
   CreateWarrantyClaimInput,
   CreateWarrantyClaimResult,
+  DeleteProductResult,
   OrderSummary,
   UpdateProductInput,
   UpdateProductResult,
@@ -78,6 +79,10 @@ class FakeBackendApi extends BackendApiClient {
   shouldRejectUpdateProductForbidden = false;
   shouldRejectUpdateProductInvalid = false;
   shouldRejectUpdateProductNotFound = false;
+  shouldRejectDeleteProductAuth = false;
+  shouldRejectDeleteProductForbidden = false;
+  shouldRejectDeleteProductNotFound = false;
+  shouldRejectDeleteProductBackend = false;
   lastOrdersToken?: string;
   lastWarrantiesToken?: string;
   lastCreateWarrantyToken?: string;
@@ -87,6 +92,8 @@ class FakeBackendApi extends BackendApiClient {
   lastUpdateProductToken?: string;
   lastUpdateProductId?: string;
   lastUpdateProductInput?: UpdateProductInput;
+  lastDeleteProductToken?: string;
+  lastDeleteProductId?: string;
   lastUpdateWarrantyToken?: string;
   lastUpdateWarrantyId?: string;
   lastUpdateWarrantyInput?: UpdateWarrantyStatusInput;
@@ -529,6 +536,59 @@ class FakeBackendApi extends BackendApiClient {
       },
     };
   }
+
+  override async deleteProduct(
+    token: string,
+    productId: string,
+    _requestId: string,
+  ): Promise<{ data: DeleteProductResult }> {
+    this.lastDeleteProductToken = token;
+    this.lastDeleteProductId = productId;
+
+    if (this.shouldRejectDeleteProductAuth) {
+      throw new BackendApiError('Unauthorized', 401, {
+        error: 'Unauthorized',
+      });
+    }
+
+    if (this.shouldRejectDeleteProductForbidden) {
+      throw new BackendApiError('Forbidden', 403, {
+        error: 'Forbidden',
+      });
+    }
+
+    if (this.shouldRejectDeleteProductNotFound) {
+      throw new BackendApiError('Not found', 404, {
+        success: false,
+        message: 'Producto no encontrado',
+      });
+    }
+
+    if (this.shouldRejectDeleteProductBackend) {
+      throw new BackendApiError('Internal error', 500, {
+        success: false,
+        message: 'Unexpected error',
+      });
+    }
+
+    return {
+      data: {
+        success: true,
+        message: 'Producto eliminado correctamente',
+        data: {
+          id: productId,
+          name: 'iPhone 13 Reacondicionado',
+          description: '128GB',
+          price: 699,
+          stock: 4,
+          condition: 'A',
+          category: 'celular',
+          primaryImageUrl: 'https://cdn.test/iphone.jpg',
+          imageUrls: ['https://cdn.test/iphone.jpg', 'https://cdn.test/iphone-back.jpg'],
+        },
+      },
+    };
+  }
 }
 
 test('health endpoint reports backend connectivity', async () => {
@@ -626,10 +686,10 @@ test('mcp handshake works and exposes search_products tool', async () => {
   assert.equal(serverVersion?.name, 'SafeTech MCP Server');
 
   const tools = await client.listTools();
-  assert.equal(tools.tools.length, 9);
+  assert.equal(tools.tools.length, 10);
   assert.deepEqual(
     tools.tools.map((tool) => tool.name).sort(),
-    ['assign_technician', 'create_product', 'create_warranty_claim', 'get_product', 'list_my_orders', 'list_my_warranties', 'search_products', 'update_product', 'update_warranty_status'],
+    ['assign_technician', 'create_product', 'create_warranty_claim', 'delete_product', 'get_product', 'list_my_orders', 'list_my_warranties', 'search_products', 'update_product', 'update_warranty_status'],
   );
 
   const result = await client.callTool({
@@ -1063,6 +1123,185 @@ test('update_product normalizes product not found responses', async () => {
   assert.deepEqual(result.structuredContent, {
     code: 'PRODUCT_NOT_FOUND',
     message: 'Producto no encontrado',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('delete_product deletes a product for an admin user', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'delete_product',
+    arguments: {
+      productId: '6870f1e2a1234567890ab222',
+      reason: 'Producto retirado del catalogo',
+    },
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.equal(backendApi.lastDeleteProductToken, 'test-token');
+  assert.equal(backendApi.lastDeleteProductId, '6870f1e2a1234567890ab222');
+  assert.deepEqual(result.structuredContent, {
+    success: true,
+    message: 'Producto eliminado correctamente',
+    data: {
+      id: '6870f1e2a1234567890ab222',
+      name: 'iPhone 13 Reacondicionado',
+      description: '128GB',
+      price: 699,
+      stock: 4,
+      condition: 'A',
+      category: 'celular',
+      primaryImageUrl: 'https://cdn.test/iphone.jpg',
+      imageUrls: ['https://cdn.test/iphone.jpg', 'https://cdn.test/iphone-back.jpg'],
+    },
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('delete_product rejects non-admin users before calling the backend', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('user'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'delete_product',
+    arguments: {
+      productId: '6870f1e2a1234567890ab222',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.equal(backendApi.lastDeleteProductToken, undefined);
+  assert.deepEqual(result.structuredContent, {
+    code: 'FORBIDDEN',
+    message: 'Solo un administrador puede eliminar productos.',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('delete_product normalizes product not found responses', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectDeleteProductNotFound = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'delete_product',
+    arguments: {
+      productId: '6870f1e2a1234567890ab999',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'PRODUCT_NOT_FOUND',
+    message: 'Producto no encontrado',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('delete_product normalizes unexpected backend failures', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectDeleteProductBackend = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'delete_product',
+    arguments: {
+      productId: '6870f1e2a1234567890ab222',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'BACKEND_500',
+    message: 'No fue posible eliminar el producto en este momento.',
   });
 
   await transport.terminateSession();

--- a/mcp-server/src/services/backend-api.ts
+++ b/mcp-server/src/services/backend-api.ts
@@ -4,6 +4,7 @@ import type {
   BackendAssignTechnicianResponse,
   CreateWarrantyClaimInput,
   CreateWarrantyClaimResult,
+  DeleteProductResult,
   CreateProductInput,
   CreateProductResult,
   UpdateProductInput,
@@ -13,6 +14,7 @@ import type {
   BackendWarrantyResponse,
   BackendHealth,
   ProductCreateResponse,
+  ProductDeleteResponse,
   OrderSummary,
   ProductDetail,
   ProductDetailResponse,
@@ -178,6 +180,38 @@ export class BackendApiClient {
         category: response.data.category,
         primaryImageUrl: response.data.image_urls?.[0],
         imageUrls: response.data.image_urls ?? [],
+      },
+    };
+  }
+
+  async deleteProduct(
+    token: string,
+    productId: string,
+    requestId: string,
+  ): Promise<{ data: DeleteProductResult }> {
+    const response = await this.request<ProductDeleteResponse>(`/products/${productId}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'x-request-id': requestId,
+      },
+    });
+
+    return {
+      data: {
+        success: response.success,
+        message: response.message,
+        data: {
+          id: response.data._id,
+          name: response.data.name,
+          description: response.data.description,
+          price: response.data.price,
+          stock: response.data.stock,
+          condition: response.data.condition,
+          category: response.data.category,
+          primaryImageUrl: response.data.image_urls?.[0],
+          imageUrls: response.data.image_urls ?? [],
+        },
       },
     };
   }

--- a/mcp-server/src/tools/admin/delete-product.tool.ts
+++ b/mcp-server/src/tools/admin/delete-product.tool.ts
@@ -1,0 +1,255 @@
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { z } from 'zod';
+import type { AppEnv } from '../../config/env.js';
+import { logAuditEvent } from '../../services/audit-log.js';
+import { BackendApiError, type BackendApiClient } from '../../services/backend-api.js';
+import type { Logger } from '../../utils/logger.js';
+import { buildToolMeta } from '../access-control.js';
+
+const deleteProductInputSchema = z.object({
+  productId: z.string().trim().min(1),
+  reason: z.string().trim().min(1).max(500).optional(),
+});
+
+const deleteProductOutputSchema = z.object({
+  success: z.literal(true),
+  message: z.string(),
+  data: z.object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string().optional(),
+    price: z.number(),
+    stock: z.number().int(),
+    condition: z.enum(['A', 'B', 'C']),
+    category: z.enum(['celular', 'laptop', 'pc', 'auriculares', 'tablet']),
+    primaryImageUrl: z.string().url().optional(),
+    imageUrls: z.array(z.string().url()),
+  }),
+});
+
+interface RegisterDeleteProductToolDependencies {
+  env: AppEnv;
+  logger: Logger;
+  backendApi: BackendApiClient;
+}
+
+export function registerDeleteProductTool(
+  server: McpServer,
+  { env, logger, backendApi }: RegisterDeleteProductToolDependencies,
+) {
+  server.registerTool(
+    'delete_product',
+    {
+      title: 'Delete Product',
+      description:
+        'Elimina un producto del catalogo de SafeTech. Solo disponible para administradores.',
+      inputSchema: deleteProductInputSchema,
+      outputSchema: deleteProductOutputSchema,
+      annotations: {
+        readOnlyHint: false,
+        openWorldHint: false,
+        destructiveHint: true,
+      },
+      _meta: {
+        ...buildToolMeta('admin', {
+          issue: '#197',
+          source: `${env.BACKEND_API_URL}/products/:id`,
+        }),
+      },
+    },
+    async (input, ctx) => {
+      const auditRequestId = randomUUID();
+      const startedAt = Date.now();
+      const authInfo = getAuthInfo(ctx);
+      const actor = authInfo?.clientId ?? 'anonymous';
+      const role = extractRole(ctx);
+      const token = authInfo?.token;
+      const auditMetadata = {
+        productId: input.productId,
+        destructive: true,
+        ...(input.reason !== undefined ? { reason: input.reason } : {}),
+      };
+
+      try {
+        if (!token) {
+          const authError = {
+            code: 'AUTH_REQUIRED',
+            message: 'Se requiere autenticacion para eliminar productos.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role,
+            action: 'tool.delete_product',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: authError.code,
+            metadata: auditMetadata,
+          });
+
+          return {
+            content: [{ type: 'text', text: authError.message }],
+            structuredContent: authError,
+            isError: true,
+          };
+        }
+
+        if (role !== 'admin') {
+          const forbiddenError = {
+            code: 'FORBIDDEN',
+            message: 'Solo un administrador puede eliminar productos.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role,
+            action: 'tool.delete_product',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: forbiddenError.code,
+            metadata: auditMetadata,
+          });
+
+          return {
+            content: [{ type: 'text', text: forbiddenError.message }],
+            structuredContent: forbiddenError,
+            isError: true,
+          };
+        }
+
+        const response = await backendApi.deleteProduct(token, input.productId, auditRequestId);
+        const output = {
+          success: true as const,
+          message: response.data.message,
+          data: normalizeDeletedProduct(response.data.data),
+        };
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role,
+          action: 'tool.delete_product',
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+          metadata: auditMetadata,
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output) }],
+          structuredContent: output,
+        };
+      } catch (error) {
+        const normalizedError = normalizeToolError(error);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role,
+          action: 'tool.delete_product',
+          outcome: 'error',
+          durationMs: Date.now() - startedAt,
+          errorCode: normalizedError.code,
+          metadata: auditMetadata,
+        });
+
+        return {
+          content: [{ type: 'text', text: normalizedError.message }],
+          structuredContent: normalizedError,
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function normalizeDeletedProduct(
+  product: {
+    id: string;
+    name: string;
+    description?: string;
+    price: number;
+    stock: number;
+    condition: 'A' | 'B' | 'C';
+    category: 'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet';
+    primaryImageUrl?: string;
+    imageUrls: string[];
+  },
+) {
+  return {
+    id: product.id,
+    name: product.name,
+    ...(product.description ? { description: product.description } : {}),
+    price: product.price,
+    stock: product.stock,
+    condition: product.condition,
+    category: product.category,
+    ...(product.primaryImageUrl ? { primaryImageUrl: product.primaryImageUrl } : {}),
+    imageUrls: product.imageUrls,
+  };
+}
+
+function extractRole(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  const roleScope = getAuthInfo(ctx)?.scopes?.find((scope: string) => scope.startsWith('role:'));
+  return roleScope?.replace('role:', '') ?? 'unknown';
+}
+
+function getAuthInfo(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  return ctx.http?.authInfo ?? (ctx as { authInfo?: { token?: string; clientId?: string; scopes?: string[] } }).authInfo;
+}
+
+function normalizeToolError(error: unknown) {
+  if (error instanceof BackendApiError) {
+    if (error.status === 401) {
+      return {
+        code: 'AUTH_REQUIRED',
+        message: 'La sesion no es valida para eliminar productos.',
+      };
+    }
+
+    if (error.status === 403) {
+      return {
+        code: 'FORBIDDEN',
+        message: 'No tienes permisos para eliminar productos.',
+      };
+    }
+
+    if (error.status === 404) {
+      return {
+        code: 'PRODUCT_NOT_FOUND',
+        message: extractBackendMessage(error.body) ?? 'El producto indicado no existe.',
+      };
+    }
+
+    return {
+      code: `BACKEND_${error.status}`,
+      message: 'No fue posible eliminar el producto en este momento.',
+    };
+  }
+
+  return {
+    code: 'INTERNAL_ERROR',
+    message: 'Ocurrio un error inesperado al eliminar el producto.',
+  };
+}
+
+function extractBackendMessage(body: unknown) {
+  if (body && typeof body === 'object') {
+    const candidate = body as {
+      message?: unknown;
+      error?: unknown;
+    };
+
+    if (typeof candidate.message === 'string') {
+      return candidate.message;
+    }
+
+    if (typeof candidate.error === 'string') {
+      return candidate.error;
+    }
+  }
+
+  return null;
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -58,6 +58,16 @@ export interface UpdateProductInput {
 
 export interface UpdateProductResult extends ProductDetail {}
 
+export interface DeleteProductInput {
+  reason?: string;
+}
+
+export interface DeleteProductResult {
+  success: boolean;
+  message: string;
+  data: ProductDetail;
+}
+
 export interface ProductListResponse {
   success: boolean;
   data: Array<{
@@ -94,6 +104,24 @@ export interface ProductDetailResponse {
 
 export interface ProductCreateResponse {
   success: boolean;
+  data: {
+    _id: string;
+    name: string;
+    description?: string;
+    price: number;
+    stock: number;
+    condition: 'A' | 'B' | 'C';
+    category: 'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet';
+    image_urls?: string[];
+    createdAt?: string;
+    updatedAt?: string;
+    __v?: number;
+  };
+}
+
+export interface ProductDeleteResponse {
+  success: boolean;
+  message: string;
   data: {
     _id: string;
     name: string;


### PR DESCRIPTION
## Resumen

Este PR resuelve el issue técnico MCP `#197` exponiendo la tool `delete_product` para administradores en el `mcp-server`, reutilizando la capacidad existente del backend y endureciendo la respuesta para devolver también el producto eliminado.

## Qué cambia

- registra la tool MCP `delete_product`
- restringe su uso a usuarios con rol `admin`
- marca la operación como destructiva con `destructiveHint`
- integra la llamada al backend `DELETE /products/:id`
- normaliza errores MCP para `AUTH_REQUIRED`, `FORBIDDEN`, `PRODUCT_NOT_FOUND` y errores backend
- agrega auditoría para la acción de borrado
- ajusta el backend para que el endpoint de eliminación devuelva el producto eliminado
- enriquece el `outputSchema` del tool con el payload del producto borrado
- agrega pruebas backend del controlador `deleteProduct`
- agrega pruebas MCP para registro, éxito, rechazo por rol y manejo de errores

## Validaciones ejecutadas

- `cd backend && bun test`
- `cd mcp-server && npm test`
- `cd mcp-server && npm run build`

## Pruebas funcionales remotas

Se validó el comportamiento en remoto con:
- cuenta `non-admin`: rechazo consistente con `FORBIDDEN`
- cuenta `admin`: borrado exitoso, payload enriquecido y `PRODUCT_NOT_FOUND` en reintentos o IDs inexistentes

## Riesgos o pendientes

- la confirmación previa a borrado hoy depende del cliente MCP; del lado servidor se dejó `destructiveHint`
- si se quiere una confirmación obligatoria y consistente, habría que endurecer el contrato del tool en un cambio posterior

## Issue relacionado

Closes #197
