### PR TITLE
feat: expose search_products_advanced MCP tool

### DIFF
--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -3,6 +3,7 @@ import type { AuthInfo } from '@modelcontextprotocol/server';
 import type { AppEnv } from './config/env.js';
 import type { BackendApiClient } from './services/backend-api.js';
 import { registerSearchProductsTool } from './tools/public/search-products.tool.js';
+import { registerSearchProductsAdvancedTool } from './tools/public/search-products-advanced.tool.js';
 import { registerGetProductTool } from './tools/public/get-product.tool.js';
 import { registerListMyOrdersTool } from './tools/user/list-my-orders.tool.js';
 import { registerListMyWarrantiesTool } from './tools/user/list-my-warranties.tool.js';
@@ -29,6 +30,7 @@ export function buildServer({ env, logger, backendApi, authInfo }: ServerDepende
   });
 
   registerSearchProductsTool(server, { env, logger, backendApi });
+  registerSearchProductsAdvancedTool(server, { env, logger, backendApi });
   registerGetProductTool(server, { env, logger, backendApi });
   registerListMyOrdersTool(server, { env, logger, backendApi });
   registerListMyWarrantiesTool(server, { env, logger, backendApi });

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -14,6 +14,7 @@ import type {
   CreateWarrantyClaimResult,
   DeleteProductResult,
   OrderSummary,
+  ProductSearchAdvancedInput,
   UpdateProductInput,
   UpdateProductResult,
   UpdateWarrantyStatusInput,
@@ -52,6 +53,7 @@ class FakeAuthenticator implements Authenticator {
 
 class FakeBackendApi extends BackendApiClient {
   shouldFailProducts = false;
+  shouldFailAdvancedProducts = false;
   shouldFailGetProduct = false;
   shouldNotFindProduct = false;
   shouldRejectProductId = false;
@@ -100,6 +102,7 @@ class FakeBackendApi extends BackendApiClient {
   lastAssignTechnicianToken?: string;
   lastAssignTechnicianId?: string;
   lastAssignTechnicianInput?: AssignTechnicianInput;
+  lastAdvancedProductFilters?: ProductSearchAdvancedInput;
 
   constructor() {
     super('http://backend.test/api');
@@ -145,6 +148,83 @@ class FakeBackendApi extends BackendApiClient {
 
     return {
       data: filters.name ? data.filter((product) => product.name.includes(filters.name!)) : data,
+    };
+  }
+
+  override async searchProductsAdvanced(filters: ProductSearchAdvancedInput) {
+    this.lastAdvancedProductFilters = filters;
+
+    if (this.shouldFailAdvancedProducts) {
+      throw new BackendApiError('Bad request', 400, {
+        success: false,
+        errors: [{ message: 'Invalid advanced filters' }],
+      });
+    }
+
+    const data = [
+      {
+        id: 'prod_1',
+        name: 'iPhone 13 Reacondicionado',
+        description: '128GB',
+        price: 699,
+        stock: 4,
+        condition: 'A' as const,
+        category: 'celular' as const,
+        primaryImageUrl: 'https://cdn.test/iphone.jpg',
+      },
+      {
+        id: 'prod_2',
+        name: 'Laptop ThinkPad X1',
+        price: 899,
+        stock: 0,
+        condition: 'B' as const,
+        category: 'laptop' as const,
+        primaryImageUrl: 'https://cdn.test/thinkpad.jpg',
+      },
+      {
+        id: 'prod_3',
+        name: 'Galaxy Tab S8',
+        price: 550,
+        stock: 9,
+        condition: 'A' as const,
+        category: 'tablet' as const,
+      },
+    ];
+
+    const filtered = data.filter((product) => {
+      if (filters.name && !product.name.toLowerCase().includes(filters.name.toLowerCase())) {
+        return false;
+      }
+      if (filters.category && product.category !== filters.category) {
+        return false;
+      }
+      if (filters.condition && product.condition !== filters.condition) {
+        return false;
+      }
+      if (filters.minPrice !== undefined && product.price < filters.minPrice) {
+        return false;
+      }
+      if (filters.maxPrice !== undefined && product.price > filters.maxPrice) {
+        return false;
+      }
+      if (filters.available === true && product.stock <= 0) {
+        return false;
+      }
+      if (filters.available === false && product.stock > 0) {
+        return false;
+      }
+      return true;
+    });
+
+    const limited = filters.limit !== undefined ? filtered.slice(0, filters.limit) : filtered;
+
+    return {
+      data: limited,
+      pagination: {
+        page: 1,
+        limit: filters.limit ?? limited.length,
+        total: filtered.length,
+      },
     };
   }
 
@@ -659,7 +739,7 @@ test('unauthenticated mcp requests advertise oauth discovery', async () => {
   assert.ok(body._meta?.['mcp/www_authenticate']?.[0]?.includes('/.well-known/oauth-protected-resource'));
 });
 
-test('mcp handshake works and exposes search_products tool', async () => {
+test('mcp handshake works and exposes search and catalog tools', async () => {
   const backendApi = new FakeBackendApi();
   const { app } = createApp({
     env,
@@ -686,10 +766,10 @@ test('mcp handshake works and exposes search_products tool', async () => {
   assert.equal(serverVersion?.name, 'SafeTech MCP Server');
 
   const tools = await client.listTools();
-  assert.equal(tools.tools.length, 10);
+  assert.equal(tools.tools.length, 11);
   assert.deepEqual(
     tools.tools.map((tool) => tool.name).sort(),
-    ['assign_technician', 'create_product', 'create_warranty_claim', 'delete_product', 'get_product', 'list_my_orders', 'list_my_warranties', 'search_products', 'update_product', 'update_warranty_status'],
+    ['assign_technician', 'create_product', 'create_warranty_claim', 'delete_product', 'get_product', 'list_my_orders', 'list_my_warranties', 'search_products', 'search_products_advanced', 'update_product', 'update_warranty_status'],
   );
 
   const result = await client.callTool({
@@ -718,6 +798,83 @@ test('mcp handshake works and exposes search_products tool', async () => {
     appliedFilters: {
       name: 'iPhone',
       limit: 5,
+    },
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('search_products_advanced returns filtered normalized products', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'search_products_advanced',
+    arguments: {
+      category: 'celular',
+      condition: 'A',
+      minPrice: 600,
+      maxPrice: 800,
+      available: true,
+      limit: 10,
+    },
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.deepEqual(backendApi.lastAdvancedProductFilters, {
+    category: 'celular',
+    condition: 'A',
+    minPrice: 600,
+    maxPrice: 800,
+    available: true,
+    limit: 10,
+  });
+  assert.deepEqual(result.structuredContent, {
+    products: [
+      {
+        id: 'prod_1',
+        name: 'iPhone 13 Reacondicionado',
+        description: '128GB',
+        price: 699,
+        stock: 4,
+        condition: 'A',
+        category: 'celular',
+        primaryImageUrl: 'https://cdn.test/iphone.jpg',
+      },
+    ],
+    count: 1,
+    appliedFilters: {
+      category: 'celular',
+      condition: 'A',
+      minPrice: 600,
+      maxPrice: 800,
+      available: true,
+      limit: 10,
+    },
+    pagination: {
+      page: 1,
+      limit: 10,
+      total: 1,
     },
   });
 
@@ -2192,6 +2349,93 @@ test('search_products normalizes backend validation errors', async () => {
   assert.deepEqual(result.structuredContent, {
     code: 'INVALID_BACKEND_REQUEST',
     message: 'La busqueda no pudo ejecutarse por parametros invalidos.',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('search_products_advanced rejects invalid price ranges before calling the backend', async () => {
+  const backendApi = new FakeBackendApi();
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'search_products_advanced',
+    arguments: {
+      minPrice: 900,
+      maxPrice: 100,
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.match(
+    String(result.content?.[0] && 'text' in result.content[0] ? result.content[0].text : ''),
+    /minPrice no puede ser mayor que maxPrice/i,
+  );
+  assert.equal(backendApi.lastAdvancedProductFilters, undefined);
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('search_products_advanced normalizes backend validation errors', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldFailAdvancedProducts = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'search_products_advanced',
+    arguments: {
+      category: 'tablet',
+      available: true,
+      limit: 5,
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'INVALID_BACKEND_REQUEST',
+    message: 'La busqueda avanzada no pudo ejecutarse por filtros invalidos.',
   });
 
   await transport.terminateSession();

--- a/mcp-server/src/services/backend-api.ts
+++ b/mcp-server/src/services/backend-api.ts
@@ -7,6 +7,8 @@ import type {
   DeleteProductResult,
   CreateProductInput,
   CreateProductResult,
+  ProductPagination,
+  ProductSearchAdvancedInput,
   UpdateProductInput,
   UpdateProductResult,
   BackendOrderResponse,
@@ -80,6 +82,63 @@ export class BackendApiClient {
         category: product.category,
         primaryImageUrl: product.image_urls?.[0],
       })),
+    };
+  }
+
+  async searchProductsAdvanced(
+    filters: ProductSearchAdvancedInput,
+    requestId: string,
+  ): Promise<{ data: ProductSummary[]; pagination?: ProductPagination }> {
+    const search = new URLSearchParams();
+
+    if (filters.name) {
+      search.set('name', filters.name);
+    }
+
+    if (filters.category) {
+      search.set('category', filters.category);
+    }
+
+    if (filters.condition) {
+      search.set('condition', filters.condition);
+    }
+
+    if (filters.minPrice !== undefined) {
+      search.set('minPrice', String(filters.minPrice));
+    }
+
+    if (filters.maxPrice !== undefined) {
+      search.set('maxPrice', String(filters.maxPrice));
+    }
+
+    if (filters.available !== undefined) {
+      search.set('available', String(filters.available));
+    }
+
+    if (filters.limit !== undefined) {
+      search.set('limit', String(filters.limit));
+    }
+
+    const path = search.size > 0 ? `/products?${search.toString()}` : '/products';
+    const response = await this.request<ProductListResponse>(path, {
+      method: 'GET',
+      headers: {
+        'x-request-id': requestId,
+      },
+    });
+
+    return {
+      data: response.data.map((product) => ({
+        id: product._id,
+        name: product.name,
+        description: product.description,
+        price: product.price,
+        stock: product.stock,
+        condition: product.condition,
+        category: product.category,
+        primaryImageUrl: product.image_urls?.[0],
+      })),
+      ...(response.pagination ? { pagination: response.pagination } : {}),
     };
   }
 

--- a/mcp-server/src/tools/public/search-products-advanced.tool.ts
+++ b/mcp-server/src/tools/public/search-products-advanced.tool.ts
@@ -1,0 +1,195 @@
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+import { logAuditEvent } from '../../services/audit-log.js';
+import { BackendApiError, type BackendApiClient } from '../../services/backend-api.js';
+import type { AppEnv } from '../../config/env.js';
+import type { ProductSearchAdvancedInput, ProductSummary } from '../../types.js';
+import type { Logger } from '../../utils/logger.js';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { buildToolMeta } from '../access-control.js';
+
+const productCategorySchema = z.enum(['celular', 'laptop', 'pc', 'auriculares', 'tablet']);
+const productConditionSchema = z.enum(['A', 'B', 'C']);
+
+const searchProductsAdvancedInputSchema = z
+  .object({
+    name: z.string().trim().min(1).max(100).optional(),
+    category: productCategorySchema.optional(),
+    condition: productConditionSchema.optional(),
+    minPrice: z.number().min(0).optional(),
+    maxPrice: z.number().min(0).optional(),
+    available: z.boolean().optional(),
+    limit: z.number().int().min(1).max(50).optional(),
+  })
+  .refine(
+    (input) =>
+      input.minPrice === undefined ||
+      input.maxPrice === undefined ||
+      input.minPrice <= input.maxPrice,
+    {
+      message: 'minPrice no puede ser mayor que maxPrice.',
+      path: ['minPrice'],
+    },
+  );
+
+const productSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  price: z.number(),
+  stock: z.number().int(),
+  condition: productConditionSchema,
+  category: productCategorySchema,
+  primaryImageUrl: z.string().url().optional(),
+});
+
+const searchProductsAdvancedOutputSchema = z.object({
+  products: z.array(productSummarySchema),
+  count: z.number().int().min(0),
+  appliedFilters: z.object({
+    name: z.string().optional(),
+    category: productCategorySchema.optional(),
+    condition: productConditionSchema.optional(),
+    minPrice: z.number().min(0).optional(),
+    maxPrice: z.number().min(0).optional(),
+    available: z.boolean().optional(),
+    limit: z.number().int().min(1).max(50).optional(),
+  }),
+  pagination: z
+    .object({
+      page: z.number().int().min(1),
+      limit: z.number().int().min(1),
+      total: z.number().int().min(0),
+    })
+    .optional(),
+});
+
+interface RegisterSearchProductsAdvancedToolDependencies {
+  env: AppEnv;
+  logger: Logger;
+  backendApi: BackendApiClient;
+}
+
+export function registerSearchProductsAdvancedTool(
+  server: McpServer,
+  { env, logger, backendApi }: RegisterSearchProductsAdvancedToolDependencies,
+) {
+  server.registerTool(
+    'search_products_advanced',
+    {
+      title: 'Search Products Advanced',
+      description:
+        'Busca productos del catalogo de SafeTech con filtros avanzados por categoria, condicion, precio y disponibilidad.',
+      inputSchema: searchProductsAdvancedInputSchema,
+      outputSchema: searchProductsAdvancedOutputSchema,
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
+      _meta: {
+        ...buildToolMeta('user', {
+          issue: '#198',
+          source: `${env.BACKEND_API_URL}/products`,
+        }),
+      },
+    },
+    async (input, ctx) => {
+      const auditRequestId = randomUUID();
+      const startedAt = Date.now();
+      const actor = ctx.http?.authInfo?.clientId ?? 'anonymous';
+
+      try {
+        const response = await backendApi.searchProductsAdvanced(input, auditRequestId);
+        const output = {
+          products: response.data.map(normalizeProduct),
+          count: response.data.length,
+          appliedFilters: buildAppliedFilters(input),
+          ...(response.pagination ? { pagination: response.pagination } : {}),
+        };
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role: extractRole(ctx),
+          action: 'tool.search_products_advanced',
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output) }],
+          structuredContent: output,
+        };
+      } catch (error) {
+        const normalizedError = normalizeToolError(error);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role: extractRole(ctx),
+          action: 'tool.search_products_advanced',
+          outcome: 'error',
+          durationMs: Date.now() - startedAt,
+          errorCode: normalizedError.code,
+        });
+
+        return {
+          content: [{ type: 'text', text: normalizedError.message }],
+          structuredContent: normalizedError,
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function normalizeProduct(product: ProductSummary): z.infer<typeof productSummarySchema> {
+  return {
+    id: product.id,
+    name: product.name,
+    ...(product.description ? { description: product.description } : {}),
+    price: product.price,
+    stock: product.stock,
+    condition: product.condition,
+    category: product.category,
+    ...(product.primaryImageUrl ? { primaryImageUrl: product.primaryImageUrl } : {}),
+  };
+}
+
+function buildAppliedFilters(input: ProductSearchAdvancedInput) {
+  return {
+    ...(input.name !== undefined ? { name: input.name } : {}),
+    ...(input.category !== undefined ? { category: input.category } : {}),
+    ...(input.condition !== undefined ? { condition: input.condition } : {}),
+    ...(input.minPrice !== undefined ? { minPrice: input.minPrice } : {}),
+    ...(input.maxPrice !== undefined ? { maxPrice: input.maxPrice } : {}),
+    ...(input.available !== undefined ? { available: input.available } : {}),
+    ...(input.limit !== undefined ? { limit: input.limit } : {}),
+  };
+}
+
+function extractRole(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  const roleScope = ctx.http?.authInfo?.scopes?.find((scope) => scope.startsWith('role:'));
+  return roleScope?.replace('role:', '') ?? 'unknown';
+}
+
+function normalizeToolError(error: unknown) {
+  if (error instanceof BackendApiError) {
+    if (error.status === 400) {
+      return {
+        code: 'INVALID_BACKEND_REQUEST',
+        message: 'La busqueda avanzada no pudo ejecutarse por filtros invalidos.',
+      };
+    }
+
+    return {
+      code: `BACKEND_${error.status}`,
+      message: 'No fue posible consultar el catalogo avanzado en este momento.',
+    };
+  }
+
+  return {
+    code: 'INTERNAL_ERROR',
+    message: 'Ocurrio un error inesperado al consultar productos con filtros avanzados.',
+  };
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -29,8 +29,24 @@ export interface ProductSummary {
   primaryImageUrl?: string;
 }
 
+export interface ProductSearchAdvancedInput {
+  name?: string;
+  category?: 'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet';
+  condition?: 'A' | 'B' | 'C';
+  minPrice?: number;
+  maxPrice?: number;
+  available?: boolean;
+  limit?: number;
+}
+
 export interface ProductDetail extends ProductSummary {
   imageUrls: string[];
+}
+
+export interface ProductPagination {
+  page: number;
+  limit: number;
+  total: number;
 }
 
 export interface CreateProductInput {
@@ -83,6 +99,7 @@ export interface ProductListResponse {
     updatedAt?: string;
     __v?: number;
   }>;
+  pagination?: ProductPagination;
 }
 
 export interface ProductDetailResponse {


### PR DESCRIPTION
## Resumen
- registra la tool `search_products_advanced` en el `mcp-server`
- reutiliza el endpoint existente `GET /api/products` con filtros avanzados
- normaliza la salida para agentes y controla errores de validación/backend
- agrega cobertura de pruebas para registro, casos felices y errores

## Cambios principales
- se agrega `mcp-server/src/tools/public/search-products-advanced.tool.ts`
- se extiende `BackendApiClient` para soportar búsqueda avanzada de productos
- se registran tipos de input y paginación usados por la tool
- se conecta la nueva tool en el bootstrap del servidor MCP
- se amplían las pruebas integradas del servidor MCP

## Validaciones ejecutadas
- `cd mcp-server && npm test`
- `cd mcp-server && npm run build`

## Pruebas remotas realizadas
- filtros por `category`, `condition`, `name`, `minPrice`, `maxPrice`, `available` y `limit`
- combinaciones de filtros
- escenarios sin resultados
- validaciones de entrada inválida
- verificación de salida estructurada y `pagination`

## Riesgos o notas
- no se rehace lógica de catálogo; la tool reutiliza el backend existente
- `page` no se expone en esta entrega porque no forma parte del alcance de `#198`
- los errores de rango/límite inválido provenientes de validación muestran texto base de Zod; no bloquea el issue, pero puede pulirse después

## Issue relacionado
Closes #198