### PR TITLE
feat: implementar HU-37 get_sales_report para administradores

### DIFF
--- a/backend/src/controllers/report.controller.ts
+++ b/backend/src/controllers/report.controller.ts
@@ -1,0 +1,26 @@
+import { Context } from 'hono';
+import { getSalesReport } from '../services/report.service';
+
+export const getSalesReportController = async (c: Context) => {
+  try {
+    const fromRaw = c.req.query('from');
+    const toRaw = c.req.query('to');
+
+    if (!fromRaw || !toRaw) {
+      return c.json({ success: false, errors: [{ message: 'from y to son requeridos' }] }, 400);
+    }
+
+    const report = await getSalesReport({
+      from: new Date(fromRaw),
+      to: new Date(toRaw),
+    });
+
+    return c.json({
+      success: true,
+      data: report,
+    });
+  } catch (error) {
+    console.error('Error fetching sales report:', error);
+    return c.json({ success: false, message: 'Failed to fetch sales report' }, 500);
+  }
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,6 +18,7 @@ import technicianRoutes from './routes/technician.routes';
 import addressRoutes from './routes/address.routes';
 import wishlistRoutes from './routes/wishlist.routes';
 import e2eRoutes from './routes/e2e.routes';
+import reportRoutes from './routes/report.routes';
 import { isE2ETestMode } from './lib/e2e';
 
 const app = new Hono();
@@ -51,6 +52,7 @@ app.route('/api/auth', authRoutes);
 app.route('/api/technicians', technicianRoutes);
 app.route('/api/addresses', addressRoutes);
 app.route('/api/wishlist', wishlistRoutes);
+app.route('/api/reports', reportRoutes);
 if (isE2ETestMode) {
   app.route('/api/e2e', e2eRoutes);
 }

--- a/backend/src/routes/report.routes.ts
+++ b/backend/src/routes/report.routes.ts
@@ -1,0 +1,20 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { getSalesReportController } from '../controllers/report.controller';
+import { adminAuthMiddleware } from '../middlewares/auth.middleware';
+import { salesReportQuerySchema } from '../validators/order.validator';
+
+const reportRouter = new Hono();
+
+reportRouter.get(
+  '/sales',
+  adminAuthMiddleware,
+  zValidator('query', salesReportQuerySchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  getSalesReportController,
+);
+
+export default reportRouter;

--- a/backend/src/services/report.service.test.ts
+++ b/backend/src/services/report.service.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { Order } from '../models/Order';
+import { getSalesReport } from './report.service';
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe('getSalesReport service', () => {
+  test('aggregates paid orders in the requested range', async () => {
+    const aggregate = mock(() =>
+      Promise.resolve([{ ordersCount: 3, grossRevenue: 1500 }]),
+    );
+    Order.aggregate = aggregate as typeof Order.aggregate;
+
+    const result = await getSalesReport({
+      from: new Date('2026-07-01T00:00:00.000Z'),
+      to: new Date('2026-07-14T23:59:59.999Z'),
+    });
+
+    expect(aggregate).toHaveBeenCalled();
+    expect(result).toEqual({
+      summary: {
+        ordersCount: 3,
+        grossRevenue: 1500,
+        averageOrderValue: 500,
+      },
+      range: {
+        from: '2026-07-01T00:00:00.000Z',
+        to: '2026-07-14T23:59:59.999Z',
+      },
+    });
+  });
+
+  test('returns zeroed metrics when there is no data', async () => {
+    const aggregate = mock(() => Promise.resolve([]));
+    Order.aggregate = aggregate as typeof Order.aggregate;
+
+    const result = await getSalesReport({
+      from: new Date('2026-07-01T00:00:00.000Z'),
+      to: new Date('2026-07-14T23:59:59.999Z'),
+    });
+
+    expect(result.summary).toEqual({
+      ordersCount: 0,
+      grossRevenue: 0,
+      averageOrderValue: 0,
+    });
+  });
+});

--- a/backend/src/services/report.service.ts
+++ b/backend/src/services/report.service.ts
@@ -1,0 +1,69 @@
+import { Order } from '../models/Order';
+
+interface GetSalesReportInput {
+  from: Date;
+  to: Date;
+}
+
+interface SalesReportSummary {
+  ordersCount: number;
+  grossRevenue: number;
+  averageOrderValue: number;
+}
+
+interface SalesReportRange {
+  from: string;
+  to: string;
+}
+
+export interface SalesReportResult {
+  summary: SalesReportSummary;
+  range: SalesReportRange;
+}
+
+export async function getSalesReport({ from, to }: GetSalesReportInput): Promise<SalesReportResult> {
+  const [aggregation] = await Order.aggregate<{
+    ordersCount: number;
+    grossRevenue: number;
+  }>([
+    {
+      $match: {
+        status: 'paid',
+        createdAt: {
+          $gte: from,
+          $lte: to,
+        },
+      },
+    },
+    {
+      $group: {
+        _id: null,
+        ordersCount: { $sum: 1 },
+        grossRevenue: { $sum: '$total_amount' },
+      },
+    },
+    {
+      $project: {
+        _id: 0,
+        ordersCount: 1,
+        grossRevenue: 1,
+      },
+    },
+  ]);
+
+  const ordersCount = aggregation?.ordersCount ?? 0;
+  const grossRevenue = aggregation?.grossRevenue ?? 0;
+  const averageOrderValue = ordersCount > 0 ? Number((grossRevenue / ordersCount).toFixed(2)) : 0;
+
+  return {
+    summary: {
+      ordersCount,
+      grossRevenue,
+      averageOrderValue,
+    },
+    range: {
+      from: from.toISOString(),
+      to: to.toISOString(),
+    },
+  };
+}

--- a/backend/src/validators/order.validator.test.ts
+++ b/backend/src/validators/order.validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { updateShippingSchema } from './order.validator';
+import { salesReportQuerySchema, updateShippingSchema } from './order.validator';
 
 describe('updateShippingSchema', () => {
   test('accepts a status-only update', () => {
@@ -12,7 +12,7 @@ describe('updateShippingSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  test('rejects an empty object with no fields set', () => {
+  test('rejects empty payloads', () => {
     const result = updateShippingSchema.safeParse({});
     expect(result.success).toBe(false);
   });
@@ -24,6 +24,26 @@ describe('updateShippingSchema', () => {
 
   test('rejects an empty carrier string', () => {
     const result = updateShippingSchema.safeParse({ carrier: '' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('salesReportQuerySchema', () => {
+  test('accepts a valid date range', () => {
+    const result = salesReportQuerySchema.safeParse({
+      from: '2026-07-01T00:00:00.000Z',
+      to: '2026-07-14T23:59:59.999Z',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects when from is later than to', () => {
+    const result = salesReportQuerySchema.safeParse({
+      from: '2026-07-15T00:00:00.000Z',
+      to: '2026-07-14T23:59:59.999Z',
+    });
+
     expect(result.success).toBe(false);
   });
 });

--- a/backend/src/validators/order.validator.ts
+++ b/backend/src/validators/order.validator.ts
@@ -7,3 +7,11 @@ export const updateShippingSchema = z.object({
 }).refine((data) => Object.values(data).some((value) => value !== undefined), {
   message: 'Debe enviar al menos status, carrier o trackingNumber',
 });
+
+export const salesReportQuerySchema = z.object({
+  from: z.string().datetime({ offset: true }),
+  to: z.string().datetime({ offset: true }),
+}).refine(({ from, to }) => new Date(from).getTime() <= new Date(to).getTime(), {
+  message: 'La fecha inicial no puede ser posterior a la fecha final',
+  path: ['from'],
+});

--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -13,6 +13,7 @@ import { registerAssignTechnicianTool } from './tools/admin/assign-technician.to
 import { registerCreateProductTool } from './tools/admin/create-product.tool.js';
 import { registerUpdateProductTool } from './tools/admin/update-product.tool.js';
 import { registerDeleteProductTool } from './tools/admin/delete-product.tool.js';
+import { registerGetSalesReportTool } from './tools/admin/get-sales-report.tool.js';
 import type { Logger } from './utils/logger.js';
 
 interface ServerDependencies {
@@ -40,6 +41,7 @@ export function buildServer({ env, logger, backendApi, authInfo }: ServerDepende
   registerCreateProductTool(server, { env, logger, backendApi });
   registerUpdateProductTool(server, { env, logger, backendApi });
   registerDeleteProductTool(server, { env, logger, backendApi });
+  registerGetSalesReportTool(server, { env, logger, backendApi });
 
   return server;
 }

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -15,6 +15,8 @@ import type {
   DeleteProductResult,
   OrderSummary,
   ProductSearchAdvancedInput,
+  SalesReportInput,
+  SalesReportResult,
   UpdateProductInput,
   UpdateProductResult,
   UpdateWarrantyStatusInput,
@@ -85,7 +87,12 @@ class FakeBackendApi extends BackendApiClient {
   shouldRejectDeleteProductForbidden = false;
   shouldRejectDeleteProductNotFound = false;
   shouldRejectDeleteProductBackend = false;
+  shouldRejectSalesReportAuth = false;
+  shouldRejectSalesReportForbidden = false;
+  shouldRejectSalesReportInvalid = false;
   lastOrdersToken?: string;
+  lastSalesReportToken?: string;
+  lastSalesReportInput?: SalesReportInput;
   lastWarrantiesToken?: string;
   lastCreateWarrantyToken?: string;
   lastCreateWarrantyInput?: CreateWarrantyClaimInput;
@@ -417,6 +424,44 @@ class FakeBackendApi extends BackendApiClient {
           ],
         },
       ],
+    };
+  }
+
+  override async getSalesReport(
+    token: string,
+    input: SalesReportInput,
+    _requestId: string,
+  ): Promise<{ data: SalesReportResult }> {
+    this.lastSalesReportToken = token;
+    this.lastSalesReportInput = input;
+
+    if (this.shouldRejectSalesReportAuth) {
+      throw new BackendApiError('Unauthorized', 401, { success: false, message: 'Unauthorized' });
+    }
+
+    if (this.shouldRejectSalesReportForbidden) {
+      throw new BackendApiError('Forbidden', 403, { success: false, message: 'Forbidden' });
+    }
+
+    if (this.shouldRejectSalesReportInvalid) {
+      throw new BackendApiError('Invalid query', 400, {
+        success: false,
+        errors: [{ message: 'La fecha inicial no puede ser posterior a la fecha final' }],
+      });
+    }
+
+    return {
+      data: {
+        summary: {
+          ordersCount: 3,
+          grossRevenue: 1598,
+          averageOrderValue: 532.67,
+        },
+        range: {
+          from: input.from,
+          to: input.to,
+        },
+      },
     };
   }
 
@@ -766,10 +811,10 @@ test('mcp handshake works and exposes search and catalog tools', async () => {
   assert.equal(serverVersion?.name, 'SafeTech MCP Server');
 
   const tools = await client.listTools();
-  assert.equal(tools.tools.length, 11);
+  assert.equal(tools.tools.length, 12);
   assert.deepEqual(
     tools.tools.map((tool) => tool.name).sort(),
-    ['assign_technician', 'create_product', 'create_warranty_claim', 'delete_product', 'get_product', 'list_my_orders', 'list_my_warranties', 'search_products', 'search_products_advanced', 'update_product', 'update_warranty_status'],
+    ['assign_technician', 'create_product', 'create_warranty_claim', 'delete_product', 'get_product', 'get_sales_report', 'list_my_orders', 'list_my_warranties', 'search_products', 'search_products_advanced', 'update_product', 'update_warranty_status'],
   );
 
   const result = await client.callTool({
@@ -2436,6 +2481,146 @@ test('search_products_advanced normalizes backend validation errors', async () =
   assert.deepEqual(result.structuredContent, {
     code: 'INVALID_BACKEND_REQUEST',
     message: 'La busqueda avanzada no pudo ejecutarse por filtros invalidos.',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('get_sales_report returns aggregated metrics for admins', async () => {
+  const backendApi = new FakeBackendApi();
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'get_sales_report',
+    arguments: {
+      from: '2026-07-01T00:00:00.000Z',
+      to: '2026-07-14T23:59:59.999Z',
+    },
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.equal(backendApi.lastSalesReportToken, 'test-token');
+  assert.deepEqual(backendApi.lastSalesReportInput, {
+    from: '2026-07-01T00:00:00.000Z',
+    to: '2026-07-14T23:59:59.999Z',
+  });
+  assert.deepEqual(result.structuredContent, {
+    summary: {
+      ordersCount: 3,
+      grossRevenue: 1598,
+      averageOrderValue: 532.67,
+    },
+    range: {
+      from: '2026-07-01T00:00:00.000Z',
+      to: '2026-07-14T23:59:59.999Z',
+    },
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('get_sales_report rejects non-admin users before calling the backend', async () => {
+  const backendApi = new FakeBackendApi();
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('user'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'get_sales_report',
+    arguments: {
+      from: '2026-07-01T00:00:00.000Z',
+      to: '2026-07-14T23:59:59.999Z',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'FORBIDDEN',
+    message: 'Solo un administrador puede consultar reportes de ventas.',
+  });
+  assert.equal(backendApi.lastSalesReportToken, undefined);
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('get_sales_report normalizes invalid date range errors from backend', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectSalesReportInvalid = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'get_sales_report',
+    arguments: {
+      from: '2026-07-01T00:00:00.000Z',
+      to: '2026-07-14T23:59:59.999Z',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'INVALID_DATE_RANGE',
+    message: 'La fecha inicial no puede ser posterior a la fecha final',
   });
 
   await transport.terminateSession();

--- a/mcp-server/src/services/backend-api.ts
+++ b/mcp-server/src/services/backend-api.ts
@@ -12,6 +12,7 @@ import type {
   UpdateProductInput,
   UpdateProductResult,
   BackendOrderResponse,
+  BackendSalesReportResponse,
   BackendWarrantyStatusResponse,
   BackendWarrantyResponse,
   BackendHealth,
@@ -22,6 +23,8 @@ import type {
   ProductDetailResponse,
   ProductListResponse,
   ProductSummary,
+  SalesReportInput,
+  SalesReportResult,
   UpdateWarrantyStatusInput,
   UpdateWarrantyStatusResult,
   WarrantySummary,
@@ -318,6 +321,29 @@ export class BackendApiClient {
             : {}),
         })),
       })),
+    };
+  }
+
+  async getSalesReport(
+    token: string,
+    input: SalesReportInput,
+    requestId: string,
+  ): Promise<{ data: SalesReportResult }> {
+    const search = new URLSearchParams({
+      from: input.from,
+      to: input.to,
+    });
+
+    const response = await this.request<BackendSalesReportResponse>(`/reports/sales?${search.toString()}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'x-request-id': requestId,
+      },
+    });
+
+    return {
+      data: response.data,
     };
   }
 

--- a/mcp-server/src/tools/admin/get-sales-report.tool.ts
+++ b/mcp-server/src/tools/admin/get-sales-report.tool.ts
@@ -1,0 +1,225 @@
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { z } from 'zod';
+import type { AppEnv } from '../../config/env.js';
+import { logAuditEvent } from '../../services/audit-log.js';
+import { BackendApiError, type BackendApiClient } from '../../services/backend-api.js';
+import type { Logger } from '../../utils/logger.js';
+import { buildToolMeta } from '../access-control.js';
+
+const getSalesReportInputSchema = z.object({
+  from: z.string().datetime({ offset: true }),
+  to: z.string().datetime({ offset: true }),
+}).refine(({ from, to }) => new Date(from).getTime() <= new Date(to).getTime(), {
+  message: 'La fecha inicial no puede ser posterior a la fecha final',
+  path: ['from'],
+});
+
+const getSalesReportOutputSchema = z.object({
+  summary: z.object({
+    ordersCount: z.number().int().min(0),
+    grossRevenue: z.number().min(0),
+    averageOrderValue: z.number().min(0),
+  }),
+  range: z.object({
+    from: z.string(),
+    to: z.string(),
+  }),
+});
+
+interface RegisterGetSalesReportToolDependencies {
+  env: AppEnv;
+  logger: Logger;
+  backendApi: BackendApiClient;
+}
+
+export function registerGetSalesReportTool(
+  server: McpServer,
+  { env, logger, backendApi }: RegisterGetSalesReportToolDependencies,
+) {
+  server.registerTool(
+    'get_sales_report',
+    {
+      title: 'Get Sales Report',
+      description:
+        'Consulta un reporte consolidado de ventas para un rango de fechas y devuelve metricas agregadas del backend. Solo disponible para administradores.',
+      inputSchema: getSalesReportInputSchema,
+      outputSchema: getSalesReportOutputSchema,
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
+      _meta: {
+        ...buildToolMeta('admin', {
+          issue: '#146',
+          source: `${env.BACKEND_API_URL}/reports/sales`,
+        }),
+      },
+    },
+    async (input, ctx) => {
+      const auditRequestId = randomUUID();
+      const startedAt = Date.now();
+      const authInfo = getAuthInfo(ctx);
+      const actor = authInfo?.clientId ?? 'anonymous';
+      const role = extractRole(ctx);
+      const token = authInfo?.token;
+      const auditMetadata = {
+        from: input.from,
+        to: input.to,
+      };
+
+      try {
+        if (!token) {
+          const authError = {
+            code: 'AUTH_REQUIRED',
+            message: 'Se requiere autenticacion para consultar reportes de ventas.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role,
+            action: 'tool.get_sales_report',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: authError.code,
+            metadata: auditMetadata,
+          });
+
+          return {
+            content: [{ type: 'text', text: authError.message }],
+            structuredContent: authError,
+            isError: true,
+          };
+        }
+
+        if (role !== 'admin') {
+          const forbiddenError = {
+            code: 'FORBIDDEN',
+            message: 'Solo un administrador puede consultar reportes de ventas.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role,
+            action: 'tool.get_sales_report',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: forbiddenError.code,
+            metadata: auditMetadata,
+          });
+
+          return {
+            content: [{ type: 'text', text: forbiddenError.message }],
+            structuredContent: forbiddenError,
+            isError: true,
+          };
+        }
+
+        const response = await backendApi.getSalesReport(token, input, auditRequestId);
+        const output = response.data;
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role,
+          action: 'tool.get_sales_report',
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+          metadata: {
+            ...auditMetadata,
+            ordersCount: output.summary.ordersCount,
+            grossRevenue: output.summary.grossRevenue,
+          },
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output) }],
+          structuredContent: output,
+        };
+      } catch (error) {
+        const normalizedError = normalizeToolError(error);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role,
+          action: 'tool.get_sales_report',
+          outcome: 'error',
+          durationMs: Date.now() - startedAt,
+          errorCode: normalizedError.code,
+          metadata: auditMetadata,
+        });
+
+        return {
+          content: [{ type: 'text', text: normalizedError.message }],
+          structuredContent: normalizedError,
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function extractRole(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  const roleScope = getAuthInfo(ctx)?.scopes?.find((scope: string) => scope.startsWith('role:'));
+  return roleScope?.replace('role:', '') ?? 'unknown';
+}
+
+function getAuthInfo(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  return ctx.http?.authInfo ?? (ctx as { authInfo?: { token?: string; clientId?: string; scopes?: string[] } }).authInfo;
+}
+
+function normalizeToolError(error: unknown) {
+  if (error instanceof BackendApiError) {
+    if (error.status === 401) {
+      return {
+        code: 'AUTH_REQUIRED',
+        message: 'La sesion no es valida para consultar reportes de ventas.',
+      };
+    }
+
+    if (error.status === 403) {
+      return {
+        code: 'FORBIDDEN',
+        message: 'No tienes permisos para consultar el reporte de ventas.',
+      };
+    }
+
+    if (error.status === 400) {
+      return {
+        code: 'INVALID_DATE_RANGE',
+        message: extractBackendMessage(error.body) ?? 'El rango de fechas enviado no es valido.',
+      };
+    }
+
+    return {
+      code: `BACKEND_${error.status}`,
+      message: 'No fue posible consultar el reporte de ventas en este momento.',
+    };
+  }
+
+  return {
+    code: 'INTERNAL_ERROR',
+    message: 'Ocurrio un error inesperado al consultar el reporte de ventas.',
+  };
+}
+
+function extractBackendMessage(body: unknown) {
+  if (!body || typeof body !== 'object') {
+    return undefined;
+  }
+
+  const payload = body as {
+    message?: unknown;
+    errors?: Array<{ message?: unknown }>;
+  };
+
+  if (typeof payload.message === 'string' && payload.message.length > 0) {
+    return payload.message;
+  }
+
+  const firstMessage = payload.errors?.find((issue) => typeof issue.message === 'string')?.message;
+  return typeof firstMessage === 'string' ? firstMessage : undefined;
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -259,6 +259,30 @@ export interface CreateWarrantyClaimResult {
   status: 'pending' | 'review' | 'resolved' | 'rejected' | 'refunded';
 }
 
+export interface SalesReportInput {
+  from: string;
+  to: string;
+}
+
+export interface SalesReportSummary {
+  ordersCount: number;
+  grossRevenue: number;
+  averageOrderValue: number;
+}
+
+export interface SalesReportResult {
+  summary: SalesReportSummary;
+  range: {
+    from: string;
+    to: string;
+  };
+}
+
+export interface BackendSalesReportResponse {
+  success: boolean;
+  data: SalesReportResult;
+}
+
 export interface UpdateWarrantyStatusInput {
   status: 'review' | 'resolved' | 'rejected' | 'refunded';
   repairNotes?: string;


### PR DESCRIPTION
## Resumen
Implementa la HU-37 para consultar un reporte consolidado de ventas desde el MCP de SafeTech, restringido a cuentas administradoras.

## Qué cambia
- agrega endpoint admin `GET /api/reports/sales` en backend
- valida `from` y `to` como rango de fechas válido
- agrega servicio de agregación sobre órdenes `paid`
- expone la tool MCP `get_sales_report`
- aplica restricción por rol `admin` en MCP y backend
- agrega cobertura de pruebas para validación y flujo MCP

## Alcance
Este PR implementa únicamente el alcance del issue #146:
- reporte consolidado de ventas
- métricas: `ordersCount`, `grossRevenue`, `averageOrderValue`
- rango consultado: `from`, `to`

## Validaciones ejecutadas
- `bun test backend/src/validators/order.validator.test.ts backend/src/services/report.service.test.ts`
- `npm test -- --runInBand src/server.test.ts` en `mcp-server/`

## Pruebas manuales MCP remoto
### Cuenta no admin
- `get_sales_report` devuelve `FORBIDDEN`
- no expone datos de ventas
- no acepta elevación de privilegios desde el prompt

### Cuenta admin
- devuelve reporte exitoso para rango válido
- devuelve JSON estructurado con:
  - `summary.ordersCount`
  - `summary.grossRevenue`
  - `summary.averageOrderValue`
  - `range.from`
  - `range.to`
- rechaza rango inválido con error de validación

## Riesgos / notas
- el reporte usa órdenes con estado `paid`
- el filtro temporal usa `createdAt` de la orden
- no se amplió alcance a agrupaciones por día, categoría o producto

## Issue relacionado
Closes #146
