### PR TITLE
feat: implementar get_warranty_report para HU-38

### DIFF
--- a/backend/src/controllers/report.controller.ts
+++ b/backend/src/controllers/report.controller.ts
@@ -1,5 +1,5 @@
 import { Context } from 'hono';
-import { getSalesReport } from '../services/report.service';
+import { getSalesReport, getWarrantyReport } from '../services/report.service';
 
 export const getSalesReportController = async (c: Context) => {
   try {
@@ -22,5 +22,29 @@ export const getSalesReportController = async (c: Context) => {
   } catch (error) {
     console.error('Error fetching sales report:', error);
     return c.json({ success: false, message: 'Failed to fetch sales report' }, 500);
+  }
+};
+
+export const getWarrantyReportController = async (c: Context) => {
+  try {
+    const fromRaw = c.req.query('from');
+    const toRaw = c.req.query('to');
+
+    if (!fromRaw || !toRaw) {
+      return c.json({ success: false, errors: [{ message: 'from y to son requeridos' }] }, 400);
+    }
+
+    const report = await getWarrantyReport({
+      from: new Date(fromRaw),
+      to: new Date(toRaw),
+    });
+
+    return c.json({
+      success: true,
+      data: report,
+    });
+  } catch (error) {
+    console.error('Error fetching warranty report:', error);
+    return c.json({ success: false, message: 'Failed to fetch warranty report' }, 500);
   }
 };

--- a/backend/src/routes/report.routes.ts
+++ b/backend/src/routes/report.routes.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { getSalesReportController } from '../controllers/report.controller';
+import { getSalesReportController, getWarrantyReportController } from '../controllers/report.controller';
 import { adminAuthMiddleware } from '../middlewares/auth.middleware';
 import { salesReportQuerySchema } from '../validators/order.validator';
 
@@ -15,6 +15,17 @@ reportRouter.get(
     }
   }),
   getSalesReportController,
+);
+
+reportRouter.get(
+  '/warranties',
+  adminAuthMiddleware,
+  zValidator('query', salesReportQuerySchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  getWarrantyReportController,
 );
 
 export default reportRouter;

--- a/backend/src/services/report.service.test.ts
+++ b/backend/src/services/report.service.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { Order } from '../models/Order';
-import { getSalesReport } from './report.service';
+import { WarrantyReport } from '../models/WarrantyReport';
+import { getSalesReport, getWarrantyReport } from './report.service';
 
 afterEach(() => {
   mock.restore();
@@ -45,6 +46,87 @@ describe('getSalesReport service', () => {
       ordersCount: 0,
       grossRevenue: 0,
       averageOrderValue: 0,
+    });
+  });
+});
+
+describe('getWarrantyReport service', () => {
+  test('aggregates warranty cases by status and technician in the requested range', async () => {
+    const aggregate = mock((pipeline: unknown[]) => {
+      const countStage = pipeline.find(
+        (stage) => typeof stage === 'object' && stage !== null && '$count' in stage,
+      );
+      const groupStage = pipeline.find(
+        (stage) => typeof stage === 'object' && stage !== null && '$group' in stage,
+      ) as { $group?: { _id?: unknown } } | undefined;
+
+      if (countStage) {
+        return Promise.resolve([{ totalCases: 4 }]);
+      }
+
+      if (
+        groupStage?.$group &&
+        typeof groupStage.$group._id === 'string' &&
+        groupStage.$group._id === '$status'
+      ) {
+        return Promise.resolve([
+          { status: 'pending', count: 2 },
+          { status: 'resolved', count: 2 },
+        ]);
+      }
+
+      return Promise.resolve([
+        { technicianId: 'tech_1', technicianName: 'Maria Gomez', count: 3 },
+        { technicianId: undefined, technicianName: 'Sin tecnico asignado', count: 1 },
+      ]);
+    });
+
+    WarrantyReport.aggregate = aggregate as typeof WarrantyReport.aggregate;
+
+    const result = await getWarrantyReport({
+      from: new Date('2026-07-01T00:00:00.000Z'),
+      to: new Date('2026-07-14T23:59:59.999Z'),
+    });
+
+    expect(aggregate).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({
+      summary: {
+        totalCases: 4,
+      },
+      byStatus: [
+        { status: 'pending', count: 2 },
+        { status: 'resolved', count: 2 },
+      ],
+      byTechnician: [
+        { technicianId: 'tech_1', technicianName: 'Maria Gomez', count: 3 },
+        { technicianId: undefined, technicianName: 'Sin tecnico asignado', count: 1 },
+      ],
+      range: {
+        from: '2026-07-01T00:00:00.000Z',
+        to: '2026-07-14T23:59:59.999Z',
+      },
+    });
+  });
+
+  test('returns empty sections when there is no warranty data', async () => {
+    const aggregate = mock(() => Promise.resolve([]));
+    WarrantyReport.aggregate = aggregate as typeof WarrantyReport.aggregate;
+
+    const result = await getWarrantyReport({
+      from: new Date('2026-07-01T00:00:00.000Z'),
+      to: new Date('2026-07-14T23:59:59.999Z'),
+    });
+
+    expect(result).toEqual({
+      summary: {
+        totalCases: 0,
+      },
+      byStatus: [],
+      byTechnician: [],
+      range: {
+        from: '2026-07-01T00:00:00.000Z',
+        to: '2026-07-14T23:59:59.999Z',
+      },
     });
   });
 });

--- a/backend/src/services/report.service.ts
+++ b/backend/src/services/report.service.ts
@@ -1,4 +1,5 @@
 import { Order } from '../models/Order';
+import { WarrantyReport } from '../models/WarrantyReport';
 
 interface GetSalesReportInput {
   from: Date;
@@ -18,6 +19,33 @@ interface SalesReportRange {
 
 export interface SalesReportResult {
   summary: SalesReportSummary;
+  range: SalesReportRange;
+}
+
+interface GetWarrantyReportInput {
+  from: Date;
+  to: Date;
+}
+
+interface WarrantyReportSummary {
+  totalCases: number;
+}
+
+interface WarrantyReportByStatusItem {
+  status: 'pending' | 'review' | 'resolved' | 'rejected' | 'refunded';
+  count: number;
+}
+
+interface WarrantyReportByTechnicianItem {
+  technicianId?: string;
+  technicianName: string;
+  count: number;
+}
+
+export interface WarrantyReportResult {
+  summary: WarrantyReportSummary;
+  byStatus: WarrantyReportByStatusItem[];
+  byTechnician: WarrantyReportByTechnicianItem[];
   range: SalesReportRange;
 }
 
@@ -61,6 +89,99 @@ export async function getSalesReport({ from, to }: GetSalesReportInput): Promise
       grossRevenue,
       averageOrderValue,
     },
+    range: {
+      from: from.toISOString(),
+      to: to.toISOString(),
+    },
+  };
+}
+
+export async function getWarrantyReport({ from, to }: GetWarrantyReportInput): Promise<WarrantyReportResult> {
+  const [totalCasesAggregation, byStatusAggregation, byTechnicianAggregation] = await Promise.all([
+    WarrantyReport.aggregate<{ totalCases: number }>([
+      {
+        $match: {
+          createdAt: {
+            $gte: from,
+            $lte: to,
+          },
+        },
+      },
+      {
+        $count: 'totalCases',
+      },
+    ]),
+    WarrantyReport.aggregate<WarrantyReportByStatusItem>([
+      {
+        $match: {
+          createdAt: {
+            $gte: from,
+            $lte: to,
+          },
+        },
+      },
+      {
+        $group: {
+          _id: '$status',
+          count: { $sum: 1 },
+        },
+      },
+      {
+        $project: {
+          _id: 0,
+          status: '$_id',
+          count: 1,
+        },
+      },
+      {
+        $sort: {
+          status: 1,
+        },
+      },
+    ]),
+    WarrantyReport.aggregate<WarrantyReportByTechnicianItem>([
+      {
+        $match: {
+          createdAt: {
+            $gte: from,
+            $lte: to,
+          },
+        },
+      },
+      {
+        $group: {
+          _id: {
+            technicianId: '$technicianId',
+            technicianName: '$technicianName',
+          },
+          count: { $sum: 1 },
+        },
+      },
+      {
+        $project: {
+          _id: 0,
+          technicianId: '$_id.technicianId',
+          technicianName: {
+            $ifNull: ['$_id.technicianName', 'Sin tecnico asignado'],
+          },
+          count: 1,
+        },
+      },
+      {
+        $sort: {
+          count: -1,
+          technicianName: 1,
+        },
+      },
+    ]),
+  ]);
+
+  return {
+    summary: {
+      totalCases: totalCasesAggregation[0]?.totalCases ?? 0,
+    },
+    byStatus: byStatusAggregation,
+    byTechnician: byTechnicianAggregation,
     range: {
       from: from.toISOString(),
       to: to.toISOString(),

--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -14,6 +14,7 @@ import { registerCreateProductTool } from './tools/admin/create-product.tool.js'
 import { registerUpdateProductTool } from './tools/admin/update-product.tool.js';
 import { registerDeleteProductTool } from './tools/admin/delete-product.tool.js';
 import { registerGetSalesReportTool } from './tools/admin/get-sales-report.tool.js';
+import { registerGetWarrantyReportTool } from './tools/admin/get-warranty-report.tool.js';
 import type { Logger } from './utils/logger.js';
 
 interface ServerDependencies {
@@ -42,6 +43,7 @@ export function buildServer({ env, logger, backendApi, authInfo }: ServerDepende
   registerUpdateProductTool(server, { env, logger, backendApi });
   registerDeleteProductTool(server, { env, logger, backendApi });
   registerGetSalesReportTool(server, { env, logger, backendApi });
+  registerGetWarrantyReportTool(server, { env, logger, backendApi });
 
   return server;
 }

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -2783,6 +2783,49 @@ test('get_warranty_report rejects non-admin users before calling the backend', a
   await client.close();
 });
 
+test('get_warranty_report rejects non-admin users even with an inverted date range', async () => {
+  const backendApi = new FakeBackendApi();
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('user'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'get_warranty_report',
+    arguments: {
+      from: '2026-07-14T23:59:59.999Z',
+      to: '2026-07-01T00:00:00.000Z',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'FORBIDDEN',
+    message: 'Solo un administrador puede consultar reportes de garantias.',
+  });
+  assert.equal(backendApi.lastWarrantyReportToken, undefined);
+
+  await transport.terminateSession();
+  await client.close();
+});
+
 test('get_warranty_report normalizes invalid date range errors from backend', async () => {
   const backendApi = new FakeBackendApi();
   backendApi.shouldRejectWarrantyReportInvalid = true;

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -21,6 +21,8 @@ import type {
   UpdateProductResult,
   UpdateWarrantyStatusInput,
   UpdateWarrantyStatusResult,
+  WarrantyReportInput,
+  WarrantyReportResult,
   WarrantySummary,
 } from './types.js';
 
@@ -90,9 +92,14 @@ class FakeBackendApi extends BackendApiClient {
   shouldRejectSalesReportAuth = false;
   shouldRejectSalesReportForbidden = false;
   shouldRejectSalesReportInvalid = false;
+  shouldRejectWarrantyReportAuth = false;
+  shouldRejectWarrantyReportForbidden = false;
+  shouldRejectWarrantyReportInvalid = false;
   lastOrdersToken?: string;
   lastSalesReportToken?: string;
   lastSalesReportInput?: SalesReportInput;
+  lastWarrantyReportToken?: string;
+  lastWarrantyReportInput?: WarrantyReportInput;
   lastWarrantiesToken?: string;
   lastCreateWarrantyToken?: string;
   lastCreateWarrantyInput?: CreateWarrantyClaimInput;
@@ -465,6 +472,51 @@ class FakeBackendApi extends BackendApiClient {
     };
   }
 
+  override async getWarrantyReport(
+    token: string,
+    input: WarrantyReportInput,
+    _requestId: string,
+  ): Promise<{ data: WarrantyReportResult }> {
+    this.lastWarrantyReportToken = token;
+    this.lastWarrantyReportInput = input;
+
+    if (this.shouldRejectWarrantyReportAuth) {
+      throw new BackendApiError('Unauthorized', 401, { success: false, message: 'Unauthorized' });
+    }
+
+    if (this.shouldRejectWarrantyReportForbidden) {
+      throw new BackendApiError('Forbidden', 403, { success: false, message: 'Forbidden' });
+    }
+
+    if (this.shouldRejectWarrantyReportInvalid) {
+      throw new BackendApiError('Invalid query', 400, {
+        success: false,
+        errors: [{ message: 'La fecha inicial no puede ser posterior a la fecha final' }],
+      });
+    }
+
+    return {
+      data: {
+        summary: {
+          totalCases: 4,
+        },
+        byStatus: [
+          { status: 'pending', count: 2 },
+          { status: 'resolved', count: 1 },
+          { status: 'review', count: 1 },
+        ],
+        byTechnician: [
+          { technicianId: 'tech_1', technicianName: 'Maria Gomez', count: 3 },
+          { technicianName: 'Sin tecnico asignado', count: 1 },
+        ],
+        range: {
+          from: input.from,
+          to: input.to,
+        },
+      },
+    };
+  }
+
   override async getMyWarranties(
     token: string,
     _requestId: string,
@@ -811,10 +863,10 @@ test('mcp handshake works and exposes search and catalog tools', async () => {
   assert.equal(serverVersion?.name, 'SafeTech MCP Server');
 
   const tools = await client.listTools();
-  assert.equal(tools.tools.length, 12);
+  assert.equal(tools.tools.length, 13);
   assert.deepEqual(
     tools.tools.map((tool) => tool.name).sort(),
-    ['assign_technician', 'create_product', 'create_warranty_claim', 'delete_product', 'get_product', 'get_sales_report', 'list_my_orders', 'list_my_warranties', 'search_products', 'search_products_advanced', 'update_product', 'update_warranty_status'],
+    ['assign_technician', 'create_product', 'create_warranty_claim', 'delete_product', 'get_product', 'get_sales_report', 'get_warranty_report', 'list_my_orders', 'list_my_warranties', 'search_products', 'search_products_advanced', 'update_product', 'update_warranty_status'],
   );
 
   const result = await client.callTool({
@@ -2611,6 +2663,153 @@ test('get_sales_report normalizes invalid date range errors from backend', async
 
   const result = await client.callTool({
     name: 'get_sales_report',
+    arguments: {
+      from: '2026-07-01T00:00:00.000Z',
+      to: '2026-07-14T23:59:59.999Z',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'INVALID_DATE_RANGE',
+    message: 'La fecha inicial no puede ser posterior a la fecha final',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('get_warranty_report returns aggregated metrics for admins', async () => {
+  const backendApi = new FakeBackendApi();
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'get_warranty_report',
+    arguments: {
+      from: '2026-07-01T00:00:00.000Z',
+      to: '2026-07-14T23:59:59.999Z',
+    },
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.equal(backendApi.lastWarrantyReportToken, 'test-token');
+  assert.deepEqual(backendApi.lastWarrantyReportInput, {
+    from: '2026-07-01T00:00:00.000Z',
+    to: '2026-07-14T23:59:59.999Z',
+  });
+  assert.deepEqual(result.structuredContent, {
+    summary: {
+      totalCases: 4,
+    },
+    byStatus: [
+      { status: 'pending', count: 2 },
+      { status: 'resolved', count: 1 },
+      { status: 'review', count: 1 },
+    ],
+    byTechnician: [
+      { technicianId: 'tech_1', technicianName: 'Maria Gomez', count: 3 },
+      { technicianName: 'Sin tecnico asignado', count: 1 },
+    ],
+    range: {
+      from: '2026-07-01T00:00:00.000Z',
+      to: '2026-07-14T23:59:59.999Z',
+    },
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('get_warranty_report rejects non-admin users before calling the backend', async () => {
+  const backendApi = new FakeBackendApi();
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('user'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'get_warranty_report',
+    arguments: {
+      from: '2026-07-01T00:00:00.000Z',
+      to: '2026-07-14T23:59:59.999Z',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'FORBIDDEN',
+    message: 'Solo un administrador puede consultar reportes de garantias.',
+  });
+  assert.equal(backendApi.lastWarrantyReportToken, undefined);
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('get_warranty_report normalizes invalid date range errors from backend', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectWarrantyReportInvalid = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator('admin'),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'get_warranty_report',
     arguments: {
       from: '2026-07-01T00:00:00.000Z',
       to: '2026-07-14T23:59:59.999Z',

--- a/mcp-server/src/services/backend-api.ts
+++ b/mcp-server/src/services/backend-api.ts
@@ -13,6 +13,7 @@ import type {
   UpdateProductResult,
   BackendOrderResponse,
   BackendSalesReportResponse,
+  BackendWarrantyReportResponse,
   BackendWarrantyStatusResponse,
   BackendWarrantyResponse,
   BackendHealth,
@@ -27,6 +28,8 @@ import type {
   SalesReportResult,
   UpdateWarrantyStatusInput,
   UpdateWarrantyStatusResult,
+  WarrantyReportInput,
+  WarrantyReportResult,
   WarrantySummary,
 } from '../types.js';
 
@@ -335,6 +338,29 @@ export class BackendApiClient {
     });
 
     const response = await this.request<BackendSalesReportResponse>(`/reports/sales?${search.toString()}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'x-request-id': requestId,
+      },
+    });
+
+    return {
+      data: response.data,
+    };
+  }
+
+  async getWarrantyReport(
+    token: string,
+    input: WarrantyReportInput,
+    requestId: string,
+  ): Promise<{ data: WarrantyReportResult }> {
+    const search = new URLSearchParams({
+      from: input.from,
+      to: input.to,
+    });
+
+    const response = await this.request<BackendWarrantyReportResponse>(`/reports/warranties?${search.toString()}`, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,

--- a/mcp-server/src/tools/admin/get-warranty-report.tool.ts
+++ b/mcp-server/src/tools/admin/get-warranty-report.tool.ts
@@ -1,0 +1,231 @@
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { z } from 'zod';
+import type { AppEnv } from '../../config/env.js';
+import { logAuditEvent } from '../../services/audit-log.js';
+import { BackendApiError, type BackendApiClient } from '../../services/backend-api.js';
+import type { Logger } from '../../utils/logger.js';
+import { buildToolMeta } from '../access-control.js';
+
+const getWarrantyReportInputSchema = z.object({
+  from: z.string().datetime({ offset: true }),
+  to: z.string().datetime({ offset: true }),
+}).refine(({ from, to }) => new Date(from).getTime() <= new Date(to).getTime(), {
+  message: 'La fecha inicial no puede ser posterior a la fecha final',
+  path: ['from'],
+});
+
+const getWarrantyReportOutputSchema = z.object({
+  summary: z.object({
+    totalCases: z.number().int().min(0),
+  }),
+  byStatus: z.array(z.object({
+    status: z.enum(['pending', 'review', 'resolved', 'rejected', 'refunded']),
+    count: z.number().int().min(0),
+  })),
+  byTechnician: z.array(z.object({
+    technicianId: z.string().optional(),
+    technicianName: z.string().min(1),
+    count: z.number().int().min(0),
+  })),
+  range: z.object({
+    from: z.string(),
+    to: z.string(),
+  }),
+});
+
+interface RegisterGetWarrantyReportToolDependencies {
+  env: AppEnv;
+  logger: Logger;
+  backendApi: BackendApiClient;
+}
+
+export function registerGetWarrantyReportTool(
+  server: McpServer,
+  { env, logger, backendApi }: RegisterGetWarrantyReportToolDependencies,
+) {
+  server.registerTool(
+    'get_warranty_report',
+    {
+      title: 'Get Warranty Report',
+      description:
+        'Consulta un reporte de garantias para un rango de fechas y devuelve volumen de casos por estado y tecnico. Solo disponible para administradores.',
+      inputSchema: getWarrantyReportInputSchema,
+      outputSchema: getWarrantyReportOutputSchema,
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
+      _meta: {
+        ...buildToolMeta('admin', {
+          issue: '#147',
+          source: `${env.BACKEND_API_URL}/reports/warranties`,
+        }),
+      },
+    },
+    async (input, ctx) => {
+      const auditRequestId = randomUUID();
+      const startedAt = Date.now();
+      const authInfo = getAuthInfo(ctx);
+      const actor = authInfo?.clientId ?? 'anonymous';
+      const role = extractRole(ctx);
+      const token = authInfo?.token;
+      const auditMetadata = {
+        from: input.from,
+        to: input.to,
+      };
+
+      try {
+        if (!token) {
+          const authError = {
+            code: 'AUTH_REQUIRED',
+            message: 'Se requiere autenticacion para consultar reportes de garantias.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role,
+            action: 'tool.get_warranty_report',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: authError.code,
+            metadata: auditMetadata,
+          });
+
+          return {
+            content: [{ type: 'text', text: authError.message }],
+            structuredContent: authError,
+            isError: true,
+          };
+        }
+
+        if (role !== 'admin') {
+          const forbiddenError = {
+            code: 'FORBIDDEN',
+            message: 'Solo un administrador puede consultar reportes de garantias.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role,
+            action: 'tool.get_warranty_report',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: forbiddenError.code,
+            metadata: auditMetadata,
+          });
+
+          return {
+            content: [{ type: 'text', text: forbiddenError.message }],
+            structuredContent: forbiddenError,
+            isError: true,
+          };
+        }
+
+        const response = await backendApi.getWarrantyReport(token, input, auditRequestId);
+        const output = response.data;
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role,
+          action: 'tool.get_warranty_report',
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+          metadata: {
+            ...auditMetadata,
+            totalCases: output.summary.totalCases,
+          },
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output) }],
+          structuredContent: output,
+        };
+      } catch (error) {
+        const normalizedError = normalizeToolError(error);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role,
+          action: 'tool.get_warranty_report',
+          outcome: 'error',
+          durationMs: Date.now() - startedAt,
+          errorCode: normalizedError.code,
+          metadata: auditMetadata,
+        });
+
+        return {
+          content: [{ type: 'text', text: normalizedError.message }],
+          structuredContent: normalizedError,
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function extractRole(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  const roleScope = getAuthInfo(ctx)?.scopes?.find((scope: string) => scope.startsWith('role:'));
+  return roleScope?.replace('role:', '') ?? 'unknown';
+}
+
+function getAuthInfo(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  return ctx.http?.authInfo ?? (ctx as { authInfo?: { token?: string; clientId?: string; scopes?: string[] } }).authInfo;
+}
+
+function normalizeToolError(error: unknown) {
+  if (error instanceof BackendApiError) {
+    if (error.status === 401) {
+      return {
+        code: 'AUTH_REQUIRED',
+        message: 'La sesion no es valida para consultar reportes de garantias.',
+      };
+    }
+
+    if (error.status === 403) {
+      return {
+        code: 'FORBIDDEN',
+        message: 'No tienes permisos para consultar el reporte de garantias.',
+      };
+    }
+
+    if (error.status === 400) {
+      return {
+        code: 'INVALID_DATE_RANGE',
+        message: extractBackendMessage(error.body) ?? 'El rango de fechas enviado no es valido.',
+      };
+    }
+
+    return {
+      code: `BACKEND_${error.status}`,
+      message: 'No fue posible consultar el reporte de garantias en este momento.',
+    };
+  }
+
+  return {
+    code: 'INTERNAL_ERROR',
+    message: 'Ocurrio un error inesperado al consultar el reporte de garantias.',
+  };
+}
+
+function extractBackendMessage(body: unknown) {
+  if (!body || typeof body !== 'object') {
+    return undefined;
+  }
+
+  const payload = body as {
+    message?: unknown;
+    errors?: Array<{ message?: unknown }>;
+  };
+
+  if (typeof payload.message === 'string' && payload.message.length > 0) {
+    return payload.message;
+  }
+
+  const firstMessage = payload.errors?.find((issue) => typeof issue.message === 'string')?.message;
+  return typeof firstMessage === 'string' ? firstMessage : undefined;
+}

--- a/mcp-server/src/tools/admin/get-warranty-report.tool.ts
+++ b/mcp-server/src/tools/admin/get-warranty-report.tool.ts
@@ -8,11 +8,8 @@ import type { Logger } from '../../utils/logger.js';
 import { buildToolMeta } from '../access-control.js';
 
 const getWarrantyReportInputSchema = z.object({
-  from: z.string().datetime({ offset: true }),
-  to: z.string().datetime({ offset: true }),
-}).refine(({ from, to }) => new Date(from).getTime() <= new Date(to).getTime(), {
-  message: 'La fecha inicial no puede ser posterior a la fecha final',
-  path: ['from'],
+  from: z.string().min(1),
+  to: z.string().min(1),
 });
 
 const getWarrantyReportOutputSchema = z.object({
@@ -124,7 +121,9 @@ export function registerGetWarrantyReportTool(
           };
         }
 
-        const response = await backendApi.getWarrantyReport(token, input, auditRequestId);
+        const validatedInput = validateWarrantyReportInput(input);
+
+        const response = await backendApi.getWarrantyReport(token, validatedInput, auditRequestId);
         const output = response.data;
 
         logAuditEvent(logger, {
@@ -210,6 +209,27 @@ function normalizeToolError(error: unknown) {
     code: 'INTERNAL_ERROR',
     message: 'Ocurrio un error inesperado al consultar el reporte de garantias.',
   };
+}
+
+function validateWarrantyReportInput(input: { from: string; to: string }) {
+  const fromValidation = z.string().datetime({ offset: true }).safeParse(input.from);
+  const toValidation = z.string().datetime({ offset: true }).safeParse(input.to);
+
+  if (!fromValidation.success || !toValidation.success) {
+    throw new BackendApiError('Invalid query', 400, {
+      success: false,
+      errors: [{ message: 'from y to deben ser fechas ISO 8601 validas con zona horaria' }],
+    });
+  }
+
+  if (new Date(input.from).getTime() > new Date(input.to).getTime()) {
+    throw new BackendApiError('Invalid query', 400, {
+      success: false,
+      errors: [{ message: 'La fecha inicial no puede ser posterior a la fecha final' }],
+    });
+  }
+
+  return input;
 }
 
 function extractBackendMessage(body: unknown) {

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -283,6 +283,39 @@ export interface BackendSalesReportResponse {
   data: SalesReportResult;
 }
 
+export interface WarrantyReportInput {
+  from: string;
+  to: string;
+}
+
+export interface WarrantyReportSummaryByStatus {
+  status: 'pending' | 'review' | 'resolved' | 'rejected' | 'refunded';
+  count: number;
+}
+
+export interface WarrantyReportSummaryByTechnician {
+  technicianId?: string;
+  technicianName: string;
+  count: number;
+}
+
+export interface WarrantyReportResult {
+  summary: {
+    totalCases: number;
+  };
+  byStatus: WarrantyReportSummaryByStatus[];
+  byTechnician: WarrantyReportSummaryByTechnician[];
+  range: {
+    from: string;
+    to: string;
+  };
+}
+
+export interface BackendWarrantyReportResponse {
+  success: boolean;
+  data: WarrantyReportResult;
+}
+
 export interface UpdateWarrantyStatusInput {
   status: 'review' | 'resolved' | 'rejected' | 'refunded';
   repairNotes?: string;


### PR DESCRIPTION
## Resumen
Implementa la HU-38 agregando el reporte de garantías en backend y su exposición vía MCP con control de acceso para administradores.

## Qué cambia
- agrega endpoint admin `GET /api/reports/warranties`
- crea agregación backend de garantías por rango de fechas
- devuelve resumen total, desglose por estado y desglose por técnico
- expone el tool MCP `get_warranty_report`
- añade contratos tipados, cliente backend y registro del tool
- agrega pruebas backend y MCP
- ajusta `get_warranty_report` para priorizar autorización antes de validar rango en usuarios no admin

## Validaciones
- `bun test backend/src/services/report.service.test.ts`
- `npm test -- --testPathPattern=server.test` en `mcp-server`

## Pruebas manuales
- usuario no admin con rango válido: responde `FORBIDDEN`
- usuario no admin con rango invertido: responde `FORBIDDEN`
- usuario admin con rango válido: devuelve reporte estructurado
- usuario admin con rango invertido: responde `INVALID_DATE_RANGE`

## Riesgos / notas
- no se agregó filtro por `technicianId`; queda fuera del alcance actual
- los casos sin técnico asignado se agrupan como `Sin tecnico asignado`

## Issue relacionado
Closes #147
