### PR TITLE
feat: implementar HU-42 create_support_ticket en backend y MCP

### DIFF
--- a/backend/src/controllers/support.controller.test.ts
+++ b/backend/src/controllers/support.controller.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { createSupportTicket } from './support.controller';
+import { SupportTicket } from '../models/SupportTicket';
+
+function createContext(body: Record<string, unknown>, userId?: string) {
+  let statusCode = 200;
+  let payload: unknown;
+
+  const context = {
+    req: {
+      json: async () => body,
+    },
+    get: (key: string) => (key === 'userId' ? userId : undefined),
+    json: (value: unknown, status?: number) => {
+      payload = value;
+      statusCode = status ?? 200;
+      return { payload: value, status: statusCode };
+    },
+  };
+
+  return {
+    context,
+    get statusCode() {
+      return statusCode;
+    },
+    get payload() {
+      return payload;
+    },
+  };
+}
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe('createSupportTicket controller', () => {
+  test('creates a support ticket associated to the authenticated user', async () => {
+    const createTicket = mock(() =>
+      Promise.resolve({
+        _id: 'support_1',
+        status: 'open',
+      }),
+    );
+    SupportTicket.create = createTicket as typeof SupportTicket.create;
+
+    const harness = createContext(
+      {
+        category: 'payments',
+        description: 'Necesito ayuda con un cobro duplicado.',
+        contactChannel: 'email',
+      },
+      'user_123',
+    );
+
+    await createSupportTicket(harness.context as never);
+
+    expect(createTicket).toHaveBeenCalledWith({
+      userId: 'user_123',
+      category: 'payments',
+      description: 'Necesito ayuda con un cobro duplicado.',
+      contactChannel: 'email',
+      status: 'open',
+    });
+    expect(harness.statusCode).toBe(201);
+    expect(harness.payload).toEqual({
+      ticketId: 'support_1',
+      status: 'open',
+    });
+  });
+
+  test('returns 401 when userId is missing from auth context', async () => {
+    const harness = createContext({
+      category: 'payments',
+      description: 'Necesito ayuda con un cobro duplicado.',
+      contactChannel: 'email',
+    });
+
+    await createSupportTicket(harness.context as never);
+
+    expect(harness.statusCode).toBe(401);
+    expect(harness.payload).toEqual({
+      error: 'Unauthorized: User ID not found in context',
+    });
+  });
+});

--- a/backend/src/controllers/support.controller.ts
+++ b/backend/src/controllers/support.controller.ts
@@ -1,0 +1,33 @@
+import { type Context } from 'hono';
+import { SupportTicket } from '../models/SupportTicket';
+
+export const createSupportTicket = async (c: Context) => {
+  try {
+    const userId = c.get('userId');
+
+    if (!userId) {
+      return c.json({ error: 'Unauthorized: User ID not found in context' }, 401);
+    }
+
+    const { category, description, contactChannel } = await c.req.json();
+
+    const ticket = await SupportTicket.create({
+      userId,
+      category,
+      description,
+      contactChannel,
+      status: 'open',
+    });
+
+    return c.json(
+      {
+        ticketId: String(ticket._id),
+        status: ticket.status,
+      },
+      201,
+    );
+  } catch (error: any) {
+    console.error('[Support Ticket Error]:', error);
+    return c.json({ error: error.message }, 400);
+  }
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,7 @@ import addressRoutes from './routes/address.routes';
 import wishlistRoutes from './routes/wishlist.routes';
 import e2eRoutes from './routes/e2e.routes';
 import reportRoutes from './routes/report.routes';
+import supportRoutes from './routes/support.routes';
 import { isE2ETestMode } from './lib/e2e';
 
 const app = new Hono();
@@ -53,6 +54,7 @@ app.route('/api/technicians', technicianRoutes);
 app.route('/api/addresses', addressRoutes);
 app.route('/api/wishlist', wishlistRoutes);
 app.route('/api/reports', reportRoutes);
+app.route('/api/support-tickets', supportRoutes);
 if (isE2ETestMode) {
   app.route('/api/e2e', e2eRoutes);
 }

--- a/backend/src/models/SupportTicket.ts
+++ b/backend/src/models/SupportTicket.ts
@@ -1,0 +1,28 @@
+import { Schema, model, type Document } from 'mongoose';
+
+export interface ISupportTicket extends Document {
+  userId: string;
+  category: string;
+  description: string;
+  contactChannel: string;
+  status: 'open' | 'in_review' | 'closed';
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const SupportTicketSchema = new Schema<ISupportTicket>(
+  {
+    userId: { type: String, required: true, index: true },
+    category: { type: String, required: true, trim: true },
+    description: { type: String, required: true, trim: true },
+    contactChannel: { type: String, required: true, trim: true },
+    status: {
+      type: String,
+      enum: ['open', 'in_review', 'closed'],
+      default: 'open',
+    },
+  },
+  { timestamps: true },
+);
+
+export const SupportTicket = model<ISupportTicket>('SupportTicket', SupportTicketSchema);

--- a/backend/src/routes/support.routes.ts
+++ b/backend/src/routes/support.routes.ts
@@ -1,0 +1,20 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { createSupportTicket } from '../controllers/support.controller';
+import { clerkAuthMiddleware } from '../middlewares/auth.middleware';
+import { createSupportTicketSchema } from '../validators/support.validator';
+
+const supportRoutes = new Hono();
+
+supportRoutes.post(
+  '/',
+  clerkAuthMiddleware,
+  zValidator('json', createSupportTicketSchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  createSupportTicket,
+);
+
+export default supportRoutes;

--- a/backend/src/validators/support.validator.ts
+++ b/backend/src/validators/support.validator.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const createSupportTicketSchema = z.object({
+  category: z.string().trim().min(1, 'Debe indicar una categoria'),
+  description: z.string().trim().min(10, 'La descripcion debe tener al menos 10 caracteres'),
+  contactChannel: z.string().trim().min(1, 'Debe indicar un canal de contacto'),
+});

--- a/mcp-server/src/bootstrap.ts
+++ b/mcp-server/src/bootstrap.ts
@@ -8,6 +8,7 @@ import { registerGetProductTool } from './tools/public/get-product.tool.js';
 import { registerListMyOrdersTool } from './tools/user/list-my-orders.tool.js';
 import { registerListMyWarrantiesTool } from './tools/user/list-my-warranties.tool.js';
 import { registerCreateWarrantyClaimTool } from './tools/user/create-warranty-claim.tool.js';
+import { registerCreateSupportTicketTool } from './tools/user/create-support-ticket.tool.js';
 import { registerUpdateWarrantyStatusTool } from './tools/admin/update-warranty-status.tool.js';
 import { registerAssignTechnicianTool } from './tools/admin/assign-technician.tool.js';
 import { registerCreateProductTool } from './tools/admin/create-product.tool.js';
@@ -37,6 +38,7 @@ export function buildServer({ env, logger, backendApi, authInfo }: ServerDepende
   registerListMyOrdersTool(server, { env, logger, backendApi });
   registerListMyWarrantiesTool(server, { env, logger, backendApi });
   registerCreateWarrantyClaimTool(server, { env, logger, backendApi });
+  registerCreateSupportTicketTool(server, { env, logger, backendApi });
   registerUpdateWarrantyStatusTool(server, { env, logger, backendApi });
   registerAssignTechnicianTool(server, { env, logger, backendApi });
   registerCreateProductTool(server, { env, logger, backendApi });

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -10,6 +10,8 @@ import type {
   AssignTechnicianResult,
   CreateProductInput,
   CreateProductResult,
+  CreateSupportTicketInput,
+  CreateSupportTicketResult,
   CreateWarrantyClaimInput,
   CreateWarrantyClaimResult,
   DeleteProductResult,
@@ -68,6 +70,8 @@ class FakeBackendApi extends BackendApiClient {
   shouldRejectCreateWarrantyNotFound = false;
   shouldRejectCreateWarrantyConflict = false;
   shouldRejectCreateWarrantyInvalid = false;
+  shouldRejectCreateSupportAuth = false;
+  shouldRejectCreateSupportInvalid = false;
   shouldRejectUpdateWarrantyAuth = false;
   shouldRejectUpdateWarrantyForbidden = false;
   shouldRejectUpdateWarrantyNotFound = false;
@@ -103,6 +107,8 @@ class FakeBackendApi extends BackendApiClient {
   lastWarrantiesToken?: string;
   lastCreateWarrantyToken?: string;
   lastCreateWarrantyInput?: CreateWarrantyClaimInput;
+  lastCreateSupportToken?: string;
+  lastCreateSupportInput?: CreateSupportTicketInput;
   lastCreateProductToken?: string;
   lastCreateProductInput?: CreateProductInput;
   lastUpdateProductToken?: string;
@@ -598,6 +604,34 @@ class FakeBackendApi extends BackendApiClient {
     };
   }
 
+  override async createSupportTicket(
+    token: string,
+    input: CreateSupportTicketInput,
+    _requestId: string,
+  ): Promise<{ data: CreateSupportTicketResult }> {
+    this.lastCreateSupportToken = token;
+    this.lastCreateSupportInput = input;
+
+    if (this.shouldRejectCreateSupportAuth) {
+      throw new BackendApiError('Unauthorized', 401, {
+        error: 'Unauthorized: User ID not found',
+      });
+    }
+
+    if (this.shouldRejectCreateSupportInvalid) {
+      throw new BackendApiError('Bad request', 400, {
+        error: 'La descripcion debe tener al menos 10 caracteres',
+      });
+    }
+
+    return {
+      data: {
+        ticketId: 'support_new_1',
+        status: 'open',
+      },
+    };
+  }
+
   override async updateWarrantyStatus(
     token: string,
     warrantyId: string,
@@ -863,10 +897,10 @@ test('mcp handshake works and exposes search and catalog tools', async () => {
   assert.equal(serverVersion?.name, 'SafeTech MCP Server');
 
   const tools = await client.listTools();
-  assert.equal(tools.tools.length, 13);
+  assert.equal(tools.tools.length, 14);
   assert.deepEqual(
     tools.tools.map((tool) => tool.name).sort(),
-    ['assign_technician', 'create_product', 'create_warranty_claim', 'delete_product', 'get_product', 'get_sales_report', 'get_warranty_report', 'list_my_orders', 'list_my_warranties', 'search_products', 'search_products_advanced', 'update_product', 'update_warranty_status'],
+    ['assign_technician', 'create_product', 'create_support_ticket', 'create_warranty_claim', 'delete_product', 'get_product', 'get_sales_report', 'get_warranty_report', 'list_my_orders', 'list_my_warranties', 'search_products', 'search_products_advanced', 'update_product', 'update_warranty_status'],
   );
 
   const result = await client.callTool({
@@ -2103,6 +2137,141 @@ test('create_warranty_claim normalizes backend validation failures in a controll
   assert.deepEqual(result.structuredContent, {
     code: 'INVALID_WARRANTY_CLAIM',
     message: 'Garantía Expirada. Plazo Legal agotado',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('create_support_ticket creates a support ticket for the authenticated user', async () => {
+  const backendApi = new FakeBackendApi();
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'create_support_ticket',
+    arguments: {
+      category: 'payments',
+      description: 'Necesito ayuda con un cobro duplicado.',
+      contactChannel: 'email',
+    },
+  });
+
+  assert.equal(result.isError, undefined);
+  assert.equal(backendApi.lastCreateSupportToken, 'test-token');
+  assert.deepEqual(backendApi.lastCreateSupportInput, {
+    category: 'payments',
+    description: 'Necesito ayuda con un cobro duplicado.',
+    contactChannel: 'email',
+  });
+  assert.deepEqual(result.structuredContent, {
+    ticketId: 'support_new_1',
+    status: 'open',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('create_support_ticket rejects invalid authenticated sessions in a controlled way', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectCreateSupportAuth = true;
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'create_support_ticket',
+    arguments: {
+      category: 'payments',
+      description: 'Necesito ayuda con un cobro duplicado.',
+      contactChannel: 'email',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'AUTH_REQUIRED',
+    message: 'La sesion no es valida para crear tickets de soporte.',
+  });
+
+  await transport.terminateSession();
+  await client.close();
+});
+
+test('create_support_ticket normalizes backend validation failures in a controlled way', async () => {
+  const backendApi = new FakeBackendApi();
+  backendApi.shouldRejectCreateSupportInvalid = true;
+
+  const { app } = createApp({
+    env,
+    logger: createLogger(),
+    authenticator: new FakeAuthenticator(),
+    backendApi,
+  });
+
+  const transport = new StreamableHTTPClientTransport(new URL('http://test.local/mcp'), {
+    fetch: async (url, init) => app.fetch(new Request(url, init)),
+    authProvider: {
+      token: async () => 'test-token',
+    },
+  });
+
+  const client = new Client(
+    { name: 'test-harness', version: '1.0.0' },
+    { versionNegotiation: { mode: 'auto' } },
+  );
+
+  await client.connect(transport);
+
+  const result = await client.callTool({
+    name: 'create_support_ticket',
+    arguments: {
+      category: 'payments',
+      description: 'Necesito ayuda con un cobro duplicado.',
+      contactChannel: 'email',
+    },
+  });
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    code: 'INVALID_SUPPORT_TICKET',
+    message: 'La descripcion debe tener al menos 10 caracteres',
   });
 
   await transport.terminateSession();

--- a/mcp-server/src/services/backend-api.ts
+++ b/mcp-server/src/services/backend-api.ts
@@ -2,8 +2,11 @@ import type {
   AssignTechnicianInput,
   AssignTechnicianResult,
   BackendAssignTechnicianResponse,
+  BackendSupportTicketResponse,
   CreateWarrantyClaimInput,
   CreateWarrantyClaimResult,
+  CreateSupportTicketInput,
+  CreateSupportTicketResult,
   DeleteProductResult,
   CreateProductInput,
   CreateProductResult,
@@ -404,6 +407,29 @@ export class BackendApiClient {
     requestId: string,
   ): Promise<{ data: CreateWarrantyClaimResult }> {
     const response = await this.request<CreateWarrantyClaimResult>('/warranties', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'x-request-id': requestId,
+      },
+      body: JSON.stringify(input),
+    });
+
+    return {
+      data: {
+        ticketId: response.ticketId,
+        status: response.status,
+      },
+    };
+  }
+
+  async createSupportTicket(
+    token: string,
+    input: CreateSupportTicketInput,
+    requestId: string,
+  ): Promise<{ data: CreateSupportTicketResult }> {
+    const response = await this.request<BackendSupportTicketResponse>('/support-tickets', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/mcp-server/src/tools/user/create-support-ticket.tool.ts
+++ b/mcp-server/src/tools/user/create-support-ticket.tool.ts
@@ -1,0 +1,163 @@
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { z } from 'zod';
+import type { AppEnv } from '../../config/env.js';
+import { logAuditEvent } from '../../services/audit-log.js';
+import { BackendApiError, type BackendApiClient } from '../../services/backend-api.js';
+import type { Logger } from '../../utils/logger.js';
+import { buildToolMeta } from '../access-control.js';
+
+const createSupportTicketInputSchema = z.object({
+  category: z.string().trim().min(1),
+  description: z.string().trim().min(10),
+  contactChannel: z.string().trim().min(1),
+});
+
+const createSupportTicketOutputSchema = z.object({
+  ticketId: z.string(),
+  status: z.enum(['open', 'in_review', 'closed']),
+});
+
+interface RegisterCreateSupportTicketToolDependencies {
+  env: AppEnv;
+  logger: Logger;
+  backendApi: BackendApiClient;
+}
+
+export function registerCreateSupportTicketTool(
+  server: McpServer,
+  { env, logger, backendApi }: RegisterCreateSupportTicketToolDependencies,
+) {
+  server.registerTool(
+    'create_support_ticket',
+    {
+      title: 'Create Support Ticket',
+      description:
+        'Crea un ticket de soporte para el usuario autenticado con categoria, descripcion y canal de contacto.',
+      inputSchema: createSupportTicketInputSchema,
+      outputSchema: createSupportTicketOutputSchema,
+      annotations: {
+        readOnlyHint: false,
+        openWorldHint: false,
+      },
+      _meta: {
+        ...buildToolMeta('user', {
+          issue: '#151',
+          source: `${env.BACKEND_API_URL}/support-tickets`,
+        }),
+      },
+    },
+    async (input, ctx) => {
+      const auditRequestId = randomUUID();
+      const startedAt = Date.now();
+      const authInfo = getAuthInfo(ctx);
+      const actor = authInfo?.clientId ?? 'anonymous';
+      const token = authInfo?.token;
+
+      try {
+        if (!token) {
+          const authError = {
+            code: 'AUTH_REQUIRED',
+            message: 'Se requiere autenticacion para crear tickets de soporte.',
+          };
+
+          logAuditEvent(logger, {
+            requestId: auditRequestId,
+            actor,
+            role: extractRole(ctx),
+            action: 'tool.create_support_ticket',
+            outcome: 'error',
+            durationMs: Date.now() - startedAt,
+            errorCode: authError.code,
+          });
+
+          return {
+            content: [{ type: 'text', text: authError.message }],
+            structuredContent: authError,
+            isError: true,
+          };
+        }
+
+        const response = await backendApi.createSupportTicket(token, input, auditRequestId);
+        const output = response.data;
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role: extractRole(ctx),
+          action: 'tool.create_support_ticket',
+          outcome: 'success',
+          durationMs: Date.now() - startedAt,
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output) }],
+          structuredContent: output,
+        };
+      } catch (error) {
+        const normalizedError = normalizeToolError(error);
+
+        logAuditEvent(logger, {
+          requestId: auditRequestId,
+          actor,
+          role: extractRole(ctx),
+          action: 'tool.create_support_ticket',
+          outcome: 'error',
+          durationMs: Date.now() - startedAt,
+          errorCode: normalizedError.code,
+        });
+
+        return {
+          content: [{ type: 'text', text: normalizedError.message }],
+          structuredContent: normalizedError,
+          isError: true,
+        };
+      }
+    },
+  );
+}
+
+function extractRole(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  const roleScope = getAuthInfo(ctx)?.scopes?.find((scope: string) => scope.startsWith('role:'));
+  return roleScope?.replace('role:', '') ?? 'unknown';
+}
+
+function getAuthInfo(ctx: Parameters<Parameters<McpServer['registerTool']>[2]>[1]) {
+  return ctx.http?.authInfo ?? (ctx as { authInfo?: { token?: string; clientId?: string; scopes?: string[] } }).authInfo;
+}
+
+function normalizeToolError(error: unknown) {
+  if (error instanceof BackendApiError) {
+    if (error.status === 401) {
+      return {
+        code: 'AUTH_REQUIRED',
+        message: 'La sesion no es valida para crear tickets de soporte.',
+      };
+    }
+
+    if (error.status === 400) {
+      return {
+        code: 'INVALID_SUPPORT_TICKET',
+        message: extractBackendMessage(error.body) ?? 'Los datos del ticket de soporte no son validos.',
+      };
+    }
+
+    return {
+      code: `BACKEND_${error.status}`,
+      message: 'No fue posible crear el ticket de soporte en este momento.',
+    };
+  }
+
+  return {
+    code: 'INTERNAL_ERROR',
+    message: 'Ocurrio un error inesperado al crear el ticket de soporte.',
+  };
+}
+
+function extractBackendMessage(body: unknown) {
+  if (typeof body === 'object' && body !== null && 'error' in body && typeof body.error === 'string') {
+    return body.error;
+  }
+
+  return null;
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -259,6 +259,17 @@ export interface CreateWarrantyClaimResult {
   status: 'pending' | 'review' | 'resolved' | 'rejected' | 'refunded';
 }
 
+export interface CreateSupportTicketInput {
+  category: string;
+  description: string;
+  contactChannel: string;
+}
+
+export interface CreateSupportTicketResult {
+  ticketId: string;
+  status: 'open' | 'in_review' | 'closed';
+}
+
 export interface SalesReportInput {
   from: string;
   to: string;
@@ -404,4 +415,9 @@ export interface BackendAssignTechnicianResponse {
   createdAt: string;
   updatedAt?: string;
   resolvedAt?: string;
+}
+
+export interface BackendSupportTicketResponse {
+  ticketId: string;
+  status: 'open' | 'in_review' | 'closed';
 }


### PR DESCRIPTION
## Resumen
Implementa la HU-42 para permitir abrir tickets de soporte desde el agente IA, cubriendo tanto el backend mínimo como la exposición MCP del tool `create_support_ticket`.

## Cambios realizados
- se agrega el modelo `SupportTicket`
- se agrega validación Zod para creación de tickets de soporte
- se implementa el controlador `createSupportTicket`
- se expone la ruta autenticada `POST /api/support-tickets`
- se registra la nueva ruta en el backend
- se agrega el método `createSupportTicket` al cliente de backend del MCP
- se implementa y registra la tool MCP `create_support_ticket`
- se agregan pruebas para backend y MCP

## Comportamiento esperado
- cualquier usuario autenticado puede crear un ticket de soporte
- el ticket guarda `category`, `description` y `contactChannel`
- el ticket se asocia al usuario autenticado
- la respuesta devuelve `ticketId` y `status`
- el estado inicial del ticket es `open`

## Validaciones ejecutadas
### Pruebas automáticas
- `bun test backend/src/controllers/support.controller.test.ts`
- `bun test backend/src/controllers/warranty.controller.test.ts backend/src/services/report.service.test.ts`
- `bun test mcp-server/src/server.test.ts`

### Pruebas manuales
- creación exitosa con categoría `pagos`, devolviendo:
  - `ticketId: 6a5694bfa861b115553d37a6`
  - `status: open`
- creación exitosa con categoría `envío`, devolviendo:
  - `ticketId: 6a5694e3a861b115553d37a8`
  - `status: open`
- creación exitosa con categoría `cuenta`, devolviendo:
  - `ticketId: 6a569504a861b115553d37aa`
  - `status: open`
- creación exitosa con categoría `producto`, devolviendo:
  - `ticketId: 6a569538a861b115553d37ac`
  - `status: open`
- validación de descripción corta:
  - error por longitud mínima en `description`
- validación de categoría vacía:
  - error por valor vacío en `category`
- validación de canal de contacto faltante:
  - rechazo por campo obligatorio ausente

## Issue relacionado
Closes #151
