### PR TITLE
HU-51: alerta cuando baja el precio de un producto en la lista de deseos

### DIFF
--- a/backend/src/controllers/priceAlert.controller.test.ts
+++ b/backend/src/controllers/priceAlert.controller.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { createPriceAlert, getMyPriceAlerts, deactivatePriceAlert } from './priceAlert.controller';
+import { PriceAlert } from '../models/PriceAlert';
+import { WishlistItem } from '../models/WishlistItem';
+import { Product } from '../models/Product';
+
+function createContext(options: { body?: Record<string, unknown>; userId?: string; param?: string } = {}) {
+  let statusCode = 200;
+  let payload: unknown;
+
+  const context = {
+    req: {
+      json: async () => options.body ?? {},
+      param: () => options.param,
+    },
+    get: (key: string) => (key === 'userId' ? options.userId : undefined),
+    json: (value: unknown, status?: number) => {
+      payload = value;
+      statusCode = status ?? 200;
+      return { payload: value, status: statusCode };
+    },
+  };
+
+  return {
+    context,
+    get statusCode() {
+      return statusCode;
+    },
+    get payload() {
+      return payload;
+    },
+  };
+}
+
+function createFindQuery(result: unknown) {
+  const query: any = {
+    populate: () => query,
+    sort: () => query,
+    lean: () => Promise.resolve(result),
+  };
+  return query;
+}
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe('createPriceAlert controller', () => {
+  test('returns 401 when userId is missing from auth context', async () => {
+    const harness = createContext({ body: { productId: 'prod_1' } });
+
+    await createPriceAlert(harness.context as never);
+
+    expect(harness.statusCode).toBe(401);
+  });
+
+  test('returns 400 when the product is not in the wishlist', async () => {
+    WishlistItem.findOne = mock(() => Promise.resolve(null)) as typeof WishlistItem.findOne;
+
+    const harness = createContext({ body: { productId: 'prod_1' }, userId: 'user_123' });
+
+    await createPriceAlert(harness.context as never);
+
+    expect(harness.statusCode).toBe(400);
+    expect(harness.payload).toEqual({
+      error: 'El producto debe estar en tu lista de deseos para activar una alerta',
+    });
+  });
+
+  test('returns 404 when the product does not exist', async () => {
+    WishlistItem.findOne = mock(() => Promise.resolve({ _id: 'wl_1' })) as typeof WishlistItem.findOne;
+    Product.findById = mock(() => Promise.resolve(null)) as typeof Product.findById;
+
+    const harness = createContext({ body: { productId: 'prod_1' }, userId: 'user_123' });
+
+    await createPriceAlert(harness.context as never);
+
+    expect(harness.statusCode).toBe(404);
+  });
+
+  test('returns 409 when an active alert already exists for the product', async () => {
+    WishlistItem.findOne = mock(() => Promise.resolve({ _id: 'wl_1' })) as typeof WishlistItem.findOne;
+    Product.findById = mock(() => Promise.resolve({ _id: 'prod_1', price: 500 })) as typeof Product.findById;
+    PriceAlert.findOne = mock(() => Promise.resolve({ _id: 'alert_1' })) as typeof PriceAlert.findOne;
+
+    const harness = createContext({ body: { productId: 'prod_1' }, userId: 'user_123' });
+
+    await createPriceAlert(harness.context as never);
+
+    expect(harness.statusCode).toBe(409);
+  });
+
+  test('creates a price alert snapshotting the current product price', async () => {
+    WishlistItem.findOne = mock(() => Promise.resolve({ _id: 'wl_1' })) as typeof WishlistItem.findOne;
+    Product.findById = mock(() => Promise.resolve({ _id: 'prod_1', price: 500 })) as typeof Product.findById;
+    PriceAlert.findOne = mock(() => Promise.resolve(null)) as typeof PriceAlert.findOne;
+
+    const populatedAlert = {
+      _id: 'alert_1',
+      userId: 'user_123',
+      product: { _id: 'prod_1', price: 500 },
+      priceAtActivation: 500,
+      active: true,
+    };
+    const createdAlert = {
+      ...populatedAlert,
+      populate: mock(() => Promise.resolve(populatedAlert)),
+    };
+    const create = mock(() => Promise.resolve(createdAlert));
+    PriceAlert.create = create as typeof PriceAlert.create;
+
+    const harness = createContext({ body: { productId: 'prod_1' }, userId: 'user_123' });
+
+    await createPriceAlert(harness.context as never);
+
+    expect(create).toHaveBeenCalledWith({
+      userId: 'user_123',
+      product: 'prod_1',
+      priceAtActivation: 500,
+    });
+    expect(harness.statusCode).toBe(201);
+    expect(harness.payload).toEqual(populatedAlert);
+  });
+});
+
+describe('getMyPriceAlerts controller', () => {
+  test('returns 401 when userId is missing from auth context', async () => {
+    const harness = createContext({});
+
+    await getMyPriceAlerts(harness.context as never);
+
+    expect(harness.statusCode).toBe(401);
+  });
+
+  test('marks alerts as triggered when the current price dropped below the activation price', async () => {
+    const alerts = [
+      { _id: 'alert_1', userId: 'user_123', priceAtActivation: 500, product: { _id: 'prod_1', price: 400 } },
+      { _id: 'alert_2', userId: 'user_123', priceAtActivation: 500, product: { _id: 'prod_2', price: 600 } },
+    ];
+    PriceAlert.find = mock(() => createFindQuery(alerts)) as typeof PriceAlert.find;
+
+    const harness = createContext({ userId: 'user_123' });
+
+    await getMyPriceAlerts(harness.context as never);
+
+    expect(harness.statusCode).toBe(200);
+    expect(harness.payload).toEqual([
+      { ...alerts[0], triggered: true },
+      { ...alerts[1], triggered: false },
+    ]);
+  });
+});
+
+describe('deactivatePriceAlert controller', () => {
+  test('returns 401 when userId is missing from auth context', async () => {
+    const harness = createContext({ param: 'alert_1' });
+
+    await deactivatePriceAlert(harness.context as never);
+
+    expect(harness.statusCode).toBe(401);
+  });
+
+  test('returns 404 when the alert does not exist', async () => {
+    PriceAlert.findById = mock(() => Promise.resolve(null)) as typeof PriceAlert.findById;
+
+    const harness = createContext({ param: 'missing_alert', userId: 'user_123' });
+
+    await deactivatePriceAlert(harness.context as never);
+
+    expect(harness.statusCode).toBe(404);
+  });
+
+  test('returns 403 when the alert belongs to another user', async () => {
+    PriceAlert.findById = mock(() =>
+      Promise.resolve({ _id: 'alert_1', userId: 'someone_else', active: true }),
+    ) as typeof PriceAlert.findById;
+
+    const harness = createContext({ param: 'alert_1', userId: 'user_123' });
+
+    await deactivatePriceAlert(harness.context as never);
+
+    expect(harness.statusCode).toBe(403);
+  });
+
+  test('deactivates an alert owned by the authenticated user', async () => {
+    const alertDoc: any = {
+      _id: 'alert_1',
+      userId: 'user_123',
+      active: true,
+      save: mock(function (this: any) {
+        return Promise.resolve(this);
+      }),
+    };
+    PriceAlert.findById = mock(() => Promise.resolve(alertDoc)) as typeof PriceAlert.findById;
+
+    const harness = createContext({ param: 'alert_1', userId: 'user_123' });
+
+    await deactivatePriceAlert(harness.context as never);
+
+    expect(alertDoc.active).toBe(false);
+    expect(alertDoc.save).toHaveBeenCalled();
+    expect(harness.statusCode).toBe(200);
+  });
+});

--- a/backend/src/controllers/priceAlert.controller.ts
+++ b/backend/src/controllers/priceAlert.controller.ts
@@ -1,0 +1,81 @@
+import { type Context } from 'hono';
+import { PriceAlert } from '../models/PriceAlert';
+import { WishlistItem } from '../models/WishlistItem';
+import { Product } from '../models/Product';
+import { isPriceAlertTriggered } from '../lib/priceAlerts';
+
+export const createPriceAlert = async (c: Context) => {
+  try {
+    const userId = c.get('userId');
+    if (!userId) return c.json({ error: 'Unauthorized' }, 401);
+
+    const { productId } = await c.req.json();
+
+    const inWishlist = await WishlistItem.findOne({ userId, product: productId });
+    if (!inWishlist) {
+      return c.json({ error: 'El producto debe estar en tu lista de deseos para activar una alerta' }, 400);
+    }
+
+    const product = await Product.findById(productId);
+    if (!product) return c.json({ error: 'Producto no encontrado' }, 404);
+
+    const existing = await PriceAlert.findOne({ userId, product: productId, active: true });
+    if (existing) {
+      return c.json({ error: 'Ya tienes una alerta activa para este producto' }, 409);
+    }
+
+    const alert = await PriceAlert.create({
+      userId,
+      product: productId,
+      priceAtActivation: product.price,
+    });
+    const populated = await alert.populate('product');
+
+    return c.json(populated, 201);
+  } catch (error) {
+    console.error('Error creating price alert:', error);
+    return c.json({ error: 'Failed to create price alert' }, 500);
+  }
+};
+
+export const getMyPriceAlerts = async (c: Context) => {
+  try {
+    const userId = c.get('userId');
+    if (!userId) return c.json({ error: 'Unauthorized' }, 401);
+
+    const alerts = await PriceAlert.find({ userId }).populate('product').sort({ createdAt: -1 }).lean();
+
+    const withStatus = alerts.map((alert: any) => ({
+      ...alert,
+      triggered: alert.product ? isPriceAlertTriggered(alert.priceAtActivation, alert.product.price) : false,
+    }));
+
+    return c.json(withStatus);
+  } catch (error) {
+    console.error('Error fetching price alerts:', error);
+    return c.json({ error: 'Failed to fetch price alerts' }, 500);
+  }
+};
+
+export const deactivatePriceAlert = async (c: Context) => {
+  try {
+    const userId = c.get('userId');
+    if (!userId) return c.json({ error: 'Unauthorized' }, 401);
+
+    const id = c.req.param('id');
+    const alert = await PriceAlert.findById(id);
+
+    if (!alert) return c.json({ error: 'Alerta no encontrada' }, 404);
+    if (alert.userId !== userId) {
+      return c.json({ error: 'No autorizado: Esta alerta no te pertenece' }, 403);
+    }
+
+    alert.active = false;
+    await alert.save();
+
+    return c.json(alert);
+  } catch (error) {
+    console.error('Error deactivating price alert:', error);
+    return c.json({ error: 'Failed to deactivate price alert' }, 500);
+  }
+};

--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -4,6 +4,7 @@ import { Product } from '../models/Product';
 import { Order } from '../models/Order';
 import { InventoryMovement } from '../models/InventoryMovement';
 import { recordInventoryMovement } from '../services/inventory.service';
+import { notifyPriceDrop } from '../services/priceAlert.service';
 
 export const getProducts = async (c: Context) => {
   try {
@@ -135,6 +136,10 @@ export const updateProduct = async (c: Context) => {
         reason: reason?.trim() || 'Ajuste manual de stock',
         performedBy: userId ?? 'system',
       });
+    }
+
+    if (data.price !== undefined && data.price < previousProduct.price) {
+      await notifyPriceDrop(updatedProduct._id, updatedProduct.name, updatedProduct.price);
     }
 
     return c.json({ success: true, data: updatedProduct });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,6 +17,7 @@ import authRoutes from './routes/auth.routes';
 import technicianRoutes from './routes/technician.routes';
 import addressRoutes from './routes/address.routes';
 import wishlistRoutes from './routes/wishlist.routes';
+import priceAlertRoutes from './routes/priceAlert.routes';
 import e2eRoutes from './routes/e2e.routes';
 import reportRoutes from './routes/report.routes';
 import supportRoutes from './routes/support.routes';
@@ -53,6 +54,7 @@ app.route('/api/auth', authRoutes);
 app.route('/api/technicians', technicianRoutes);
 app.route('/api/addresses', addressRoutes);
 app.route('/api/wishlist', wishlistRoutes);
+app.route('/api/price-alerts', priceAlertRoutes);
 app.route('/api/reports', reportRoutes);
 app.route('/api/support-tickets', supportRoutes);
 if (isE2ETestMode) {

--- a/backend/src/lib/priceAlerts.test.ts
+++ b/backend/src/lib/priceAlerts.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+import { isPriceAlertTriggered } from './priceAlerts';
+
+describe('isPriceAlertTriggered', () => {
+  test('returns true when the current price is lower than the activation price', () => {
+    expect(isPriceAlertTriggered(1000, 800)).toBe(true);
+  });
+
+  test('returns false when the current price equals the activation price', () => {
+    expect(isPriceAlertTriggered(1000, 1000)).toBe(false);
+  });
+
+  test('returns false when the current price is higher than the activation price', () => {
+    expect(isPriceAlertTriggered(1000, 1200)).toBe(false);
+  });
+});

--- a/backend/src/lib/priceAlerts.ts
+++ b/backend/src/lib/priceAlerts.ts
@@ -1,0 +1,2 @@
+export const isPriceAlertTriggered = (priceAtActivation: number, currentPrice: number): boolean =>
+  currentPrice < priceAtActivation;

--- a/backend/src/models/PriceAlert.ts
+++ b/backend/src/models/PriceAlert.ts
@@ -1,0 +1,30 @@
+import { Schema, model, type Document, type Types } from 'mongoose';
+
+export interface IPriceAlert extends Document {
+  userId: string;
+  product: Types.ObjectId;
+  priceAtActivation: number;
+  active: boolean;
+  triggeredAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const priceAlertSchema = new Schema<IPriceAlert>(
+  {
+    userId: { type: String, required: true, index: true },
+    product: { type: Schema.Types.ObjectId, ref: 'Product', required: true },
+    priceAtActivation: { type: Number, required: true },
+    active: { type: Boolean, default: true },
+    triggeredAt: { type: Date, default: null },
+  },
+  { timestamps: true },
+);
+
+// Solo puede existir una alerta activa por usuario+producto a la vez. El
+// filtro parcial excluye las alertas desactivadas del índice único, para que
+// desactivar una alerta y luego volver a activarla para el mismo producto
+// no choque con un duplicado fantasma.
+priceAlertSchema.index({ userId: 1, product: 1 }, { unique: true, partialFilterExpression: { active: true } });
+
+export const PriceAlert = model<IPriceAlert>('PriceAlert', priceAlertSchema);

--- a/backend/src/routes/priceAlert.routes.ts
+++ b/backend/src/routes/priceAlert.routes.ts
@@ -1,0 +1,24 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { createPriceAlert, getMyPriceAlerts, deactivatePriceAlert } from '../controllers/priceAlert.controller';
+import { clerkAuthMiddleware } from '../middlewares/auth.middleware';
+import { createPriceAlertSchema } from '../validators/priceAlert.validator';
+
+const priceAlertRoutes = new Hono();
+
+priceAlertRoutes.get('/mine', clerkAuthMiddleware, getMyPriceAlerts);
+
+priceAlertRoutes.post(
+  '/',
+  clerkAuthMiddleware,
+  zValidator('json', createPriceAlertSchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  createPriceAlert,
+);
+
+priceAlertRoutes.put('/:id/deactivate', clerkAuthMiddleware, deactivatePriceAlert);
+
+export default priceAlertRoutes;

--- a/backend/src/services/email.service.ts
+++ b/backend/src/services/email.service.ts
@@ -109,3 +109,14 @@ export async function sendWarrantyStatusChangedEmail(
     `<p>El estado de tu garantia <strong>#${String(warranty._id).slice(-6)}</strong> cambio a: <strong>${label}</strong>.</p>`,
   );
 }
+
+export async function sendPriceDropAlertEmail(
+  to: string,
+  data: { productName: string; oldPrice: number; newPrice: number },
+): Promise<void> {
+  await sendEmail(
+    to,
+    `¡Bajó de precio! ${data.productName}`,
+    `<p>El producto <strong>${data.productName}</strong> de tu lista de deseos bajó de precio.</p><p>Antes: <strong>$${data.oldPrice.toFixed(2)}</strong> &rarr; Ahora: <strong>$${data.newPrice.toFixed(2)}</strong></p>`,
+  );
+}

--- a/backend/src/services/priceAlert.service.test.ts
+++ b/backend/src/services/priceAlert.service.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { PriceAlert } from '../models/PriceAlert';
+import { User } from '../models/User';
+import { notifyPriceDrop } from './priceAlert.service';
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe('notifyPriceDrop service', () => {
+  test('marks matching alerts as triggered and leaves non-matching alerts untouched', async () => {
+    const droppedAlert: any = {
+      _id: 'alert_1',
+      userId: 'user_123',
+      priceAtActivation: 500,
+      triggeredAt: null,
+      save: mock(function (this: any) {
+        return Promise.resolve(this);
+      }),
+    };
+    const notYetDroppedAlert: any = {
+      _id: 'alert_2',
+      userId: 'user_456',
+      priceAtActivation: 300,
+      triggeredAt: null,
+      save: mock(function (this: any) {
+        return Promise.resolve(this);
+      }),
+    };
+
+    PriceAlert.find = mock(() => Promise.resolve([droppedAlert, notYetDroppedAlert])) as typeof PriceAlert.find;
+    User.findOne = mock(() => Promise.resolve(null)) as typeof User.findOne;
+
+    await notifyPriceDrop('prod_1', 'iPhone 13', 400);
+
+    expect(droppedAlert.triggeredAt).not.toBeNull();
+    expect(droppedAlert.save).toHaveBeenCalled();
+
+    expect(notYetDroppedAlert.triggeredAt).toBeNull();
+    expect(notYetDroppedAlert.save).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when there are no active, un-triggered alerts for the product', async () => {
+    PriceAlert.find = mock(() => Promise.resolve([])) as typeof PriceAlert.find;
+    const findUser = mock(() => Promise.resolve(null));
+    User.findOne = findUser as typeof User.findOne;
+
+    await notifyPriceDrop('prod_1', 'iPhone 13', 400);
+
+    expect(findUser).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/priceAlert.service.ts
+++ b/backend/src/services/priceAlert.service.ts
@@ -1,0 +1,24 @@
+import { PriceAlert } from '../models/PriceAlert';
+import { User } from '../models/User';
+import { isPriceAlertTriggered } from '../lib/priceAlerts';
+import { sendPriceDropAlertEmail } from './email.service';
+
+export const notifyPriceDrop = async (productId: unknown, productName: string, newPrice: number): Promise<void> => {
+  const alerts = await PriceAlert.find({ product: productId, active: true, triggeredAt: null });
+
+  for (const alert of alerts) {
+    if (!isPriceAlertTriggered(alert.priceAtActivation, newPrice)) continue;
+
+    alert.triggeredAt = new Date();
+    await alert.save();
+
+    const user = await User.findOne({ clerk_id: alert.userId });
+    if (user?.email) {
+      await sendPriceDropAlertEmail(user.email, {
+        productName,
+        oldPrice: alert.priceAtActivation,
+        newPrice,
+      });
+    }
+  }
+};

--- a/backend/src/validators/priceAlert.validator.test.ts
+++ b/backend/src/validators/priceAlert.validator.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test';
+import { createPriceAlertSchema } from './priceAlert.validator';
+
+describe('createPriceAlertSchema', () => {
+  test('accepts a valid productId', () => {
+    const result = createPriceAlertSchema.safeParse({ productId: 'prod_1' });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects an empty productId', () => {
+    const result = createPriceAlertSchema.safeParse({ productId: '' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a missing productId', () => {
+    const result = createPriceAlertSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/src/validators/priceAlert.validator.ts
+++ b/backend/src/validators/priceAlert.validator.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const createPriceAlertSchema = z.object({
+  productId: z.string().min(1, 'El ID del producto es requerido'),
+});

--- a/frontend/src/hooks/usePriceAlerts.ts
+++ b/frontend/src/hooks/usePriceAlerts.ts
@@ -1,0 +1,43 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '../lib/auth';
+import { priceAlertService } from '../services/priceAlert.service';
+import type { PriceAlert } from '../types/priceAlert';
+
+export const usePriceAlerts = () => {
+  const { getToken } = useAuth();
+  return useQuery<PriceAlert[], Error>({
+    queryKey: ['price-alerts'],
+    queryFn: async () => {
+      const token = await getToken();
+      return priceAlertService.getMyPriceAlerts(token!);
+    },
+  });
+};
+
+export const useCreatePriceAlert = () => {
+  const { getToken } = useAuth();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (productId: string) => {
+      const token = await getToken();
+      return priceAlertService.createPriceAlert(productId, token!);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['price-alerts'] });
+    },
+  });
+};
+
+export const useDeactivatePriceAlert = () => {
+  const { getToken } = useAuth();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const token = await getToken();
+      return priceAlertService.deactivatePriceAlert(id, token!);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['price-alerts'] });
+    },
+  });
+};

--- a/frontend/src/pages/Wishlist.tsx
+++ b/frontend/src/pages/Wishlist.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useWishlist, useRemoveFromWishlist, useUpdateWishlistNote, useWishlistSuggestions } from '../hooks/useWishlist';
+import { usePriceAlerts, useCreatePriceAlert, useDeactivatePriceAlert } from '../hooks/usePriceAlerts';
 import { useCartStore } from '../store/cart.store';
 import { SignInButton, useAuth } from '../lib/auth';
 import { Skeleton } from '../components/ui/Skeleton';
@@ -17,8 +18,11 @@ const Wishlist: React.FC = () => {
   const { isLoaded, isSignedIn } = useAuth();
   const { data: items, isLoading, isError } = useWishlist();
   const { data: suggestions } = useWishlistSuggestions();
+  const { data: priceAlerts } = usePriceAlerts();
   const removeMutation = useRemoveFromWishlist();
   const updateNoteMutation = useUpdateWishlistNote();
+  const createAlertMutation = useCreatePriceAlert();
+  const deactivateAlertMutation = useDeactivatePriceAlert();
   const addItem = useCartStore(s => s.addItem);
   const toggleDrawer = useCartStore(s => s.toggleDrawer);
   const [editingNote, setEditingNote] = useState<string | null>(null);
@@ -41,6 +45,18 @@ const Wishlist: React.FC = () => {
     toggleDrawer();
     setAddedId(product._id);
     setTimeout(() => setAddedId(null), 1500);
+  };
+
+  const getActiveAlert = (productId: string) =>
+    priceAlerts?.find(alert => alert.product && alert.product._id === productId && alert.active);
+
+  const handleTogglePriceAlert = (productId: string) => {
+    const activeAlert = getActiveAlert(productId);
+    if (activeAlert) {
+      deactivateAlertMutation.mutate(activeAlert._id);
+    } else {
+      createAlertMutation.mutate(productId);
+    }
   };
 
   if (isLoaded && !isSignedIn) {
@@ -126,6 +142,9 @@ const Wishlist: React.FC = () => {
                     <Link to={`/product/${item.product._id}`} className="wl-card-name">{item.product.name}</Link>
                     <p className="wl-card-cat">{CATEGORY_LABEL[item.product.category] ?? item.product.category}</p>
                     <p className="wl-card-price">{fmt(item.product.price)}</p>
+                    {getActiveAlert(item.product._id)?.triggered && (
+                      <p className="wl-price-drop-badge">¡Bajó de precio!</p>
+                    )}
 
                     {editingNote === item.product._id ? (
                       <div className="wl-note-edit">
@@ -155,6 +174,13 @@ const Wishlist: React.FC = () => {
                         onClick={() => handleToggleNote(item.product._id, item.note)}
                       >
                         {editingNote === item.product._id ? 'Guardar nota' : 'Nota'}
+                      </button>
+                      <button
+                        className={`wl-btn wl-btn-alert ${getActiveAlert(item.product._id) ? 'wl-btn-alert-active' : ''}`}
+                        onClick={() => handleTogglePriceAlert(item.product._id)}
+                        title={getActiveAlert(item.product._id) ? 'Desactivar alerta de precio' : 'Avisarme si baja de precio'}
+                      >
+                        {getActiveAlert(item.product._id) ? '🔔' : '🔕'}
                       </button>
                       <button
                         className="wl-btn wl-btn-remove"
@@ -226,8 +252,11 @@ const Wishlist: React.FC = () => {
         .wl-btn-cart:hover { background: #333; }
         .wl-btn-cart:disabled { opacity: .5; cursor: not-allowed; }
         .wl-btn-note { flex: none; width: 36px; flex-shrink: 0; }
+        .wl-btn-alert { flex: none; width: 36px; flex-shrink: 0; }
+        .wl-btn-alert-active { background: rgba(46,125,50,.08); border-color: rgba(46,125,50,.4); }
         .wl-btn-remove { flex: none; width: 36px; flex-shrink: 0; color: #ef4444; border-color: rgba(239,68,68,.3); }
         .wl-btn-remove:hover { background: rgba(239,68,68,.06); border-color: #ef4444; }
+        .wl-price-drop-badge { display: inline-block; margin-top: 2px; padding: 3px 9px; font-family: var(--font-sans); font-size: .68rem; font-weight: 600; color: #2e7d32; background: rgba(46,125,50,.1); border-radius: var(--radius-pill); width: fit-content; }
         .wl-empty { display: flex; flex-direction: column; align-items: center; text-align: center; padding: 6rem 2rem; gap: .625rem; }
         .wl-empty-icon { width: 60px; height: 60px; display: flex; align-items: center; justify-content: center; border-radius: var(--radius-sm); background: rgba(46,45,43,.05); border: 1px solid var(--line); color: var(--ink3); margin-bottom: 1rem; }
         .wl-empty h3 { font-family: var(--font-display); font-size: 1.35rem; font-weight: 400; color: var(--ink); letter-spacing: -.02em; }

--- a/frontend/src/services/priceAlert.service.ts
+++ b/frontend/src/services/priceAlert.service.ts
@@ -1,0 +1,27 @@
+import axios from 'axios';
+import type { PriceAlert } from '../types/priceAlert';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
+
+export const priceAlertService = {
+  getMyPriceAlerts: async (token: string): Promise<PriceAlert[]> => {
+    const { data } = await axios.get(`${API_URL}/price-alerts/mine`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return data;
+  },
+
+  createPriceAlert: async (productId: string, token: string): Promise<PriceAlert> => {
+    const { data } = await axios.post(`${API_URL}/price-alerts`, { productId }, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return data;
+  },
+
+  deactivatePriceAlert: async (id: string, token: string): Promise<PriceAlert> => {
+    const { data } = await axios.put(`${API_URL}/price-alerts/${id}/deactivate`, {}, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return data;
+  },
+};

--- a/frontend/src/types/priceAlert.ts
+++ b/frontend/src/types/priceAlert.ts
@@ -1,0 +1,13 @@
+import type { Product } from './product';
+
+export interface PriceAlert {
+  _id: string;
+  userId: string;
+  product: Product;
+  priceAtActivation: number;
+  active: boolean;
+  triggeredAt: string | null;
+  triggered: boolean;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
Closes #160

### Cambios

- `backend/src/models/PriceAlert.ts`: `userId`, `product`, `priceAtActivation` (snapshot del precio al activar), `active`, `triggeredAt`. Índice único **parcial** sobre `{userId, product}` filtrado a `active: true` — permite desactivar una alerta y volver a activarla más tarde para el mismo producto sin chocar con un duplicado fantasma.
- `backend/src/routes/priceAlert.routes.ts` + `priceAlert.controller.ts`, montado en `/api/price-alerts`:
  - `POST /` — crea una alerta. Exige que el producto esté en la lista de deseos del usuario (400 si no), 404 si el producto no existe, 409 si ya hay una alerta activa para ese producto.
  - `GET /mine` — lista las alertas del usuario (activas e inactivas, para poder consultar el historial), con un campo `triggered` calculado en vivo (`precio actual < precio de activación`).
  - `PUT /:id/deactivate` — desactiva una alerta propia (403 si pertenece a otro usuario).
- `backend/src/services/priceAlert.service.ts` (`notifyPriceDrop`) enganchado en `updateProduct` (`product.controller.ts`), con el mismo patrón que `recordInventoryMovement` para stock: cuando un admin baja el precio de un producto, se detectan las alertas activas afectadas, se marca `triggeredAt` y se envía un correo (`sendPriceDropAlertEmail` en `email.service.ts`).
- El estado `triggered` también se recalcula al consultar (`GET /mine`), para cubrir alertas creadas después de que el precio ya había bajado, sin depender únicamente de que el hook de `updateProduct` haya corrido.
- Frontend: en `Wishlist.tsx`, cada tarjeta tiene un botón de campana (🔔/🔕) para activar/desactivar la alerta del producto, y una etiqueta "¡Bajó de precio!" cuando la alerta activa ya se disparó. Nuevos `types/priceAlert.ts`, `services/priceAlert.service.ts`, `hooks/usePriceAlerts.ts` siguiendo el mismo patrón que wishlist.

### Decisiones de diseño

- **Sin cron ni workflow programado**: la detección es síncrona (al actualizar el precio) + calculada en vivo (al consultar), no un job periódico. Este repo no tiene backend desplegado ni base de datos de producción real, así que un cron no tendría a qué conectarse; la detección basada en el único punto real donde el precio cambia (`updateProduct`) sí funciona de punta a punta hoy.
- **Alcance de frontend**: contenido dentro de las tarjetas de `Wishlist.tsx` ya existentes — sin ruta ni página nueva, ya que los criterios de aceptación (consultar/desactivar, indicar visualmente) se satisfacen ahí directamente.

### Validaciones ejecutadas

- `bun test` (backend): 113 pass, 0 fail (incluye 15 tests nuevos: validator, lib puro, controller con mocks, service con mocks).
- `npm run build` (frontend): `tsc -b && vite build` sin errores.
- Verificación manual end-to-end vía curl contra un Mongo temporal en modo `E2E_TEST_MODE`: gate de "debe estar en la lista de deseos" (400), creación (201), duplicado activo (409), snapshot de `priceAtActivation`, bajada de precio real vía `PUT /api/products/:id` disparando `triggered:true` + `triggeredAt` + correo capturado en `/api/e2e/emails`, desactivar → volver a crear la alerta para el mismo producto (confirma que el índice parcial funciona y no queda bloqueado en 409 para siempre), y 403 al intentar desactivar la alerta de otro usuario.
- **UI no verificada visualmente en navegador** (no hubo herramienta de browser disponible en esta sesión): el botón de campana y la etiqueta de "bajó de precio" están verificados a nivel de compilación (`tsc -b` + `vite build`) y de datos (los mismos endpoints que consume `usePriceAlerts`/`Wishlist.tsx` fueron probados por curl arriba), pero no se hizo un smoke test clickeando en un navegador real. Vale la pena una revisión visual rápida antes o después de mergear.

### Criterios de aceptación

- [x] El sistema solo permite alertas de precio sobre productos que estén en la lista de deseos del usuario.
- [x] El sistema detecta cuando el precio actual es menor al precio registrado al activar la alerta (al actualizar el producto y al consultar).
- [x] El usuario puede consultar y desactivar sus alertas de precio.
