### PR TITLE
HU-52: ver si un producto de la lista de deseos tuvo cambios de precio

### DIFF
--- a/backend/src/controllers/wishlist.controller.test.ts
+++ b/backend/src/controllers/wishlist.controller.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { getMyWishlist, addToWishlist } from './wishlist.controller';
+import { WishlistItem } from '../models/WishlistItem';
+import { Product } from '../models/Product';
+
+function createContext(options: { body?: Record<string, unknown>; userId?: string } = {}) {
+  let statusCode = 200;
+  let payload: unknown;
+
+  const context = {
+    req: {
+      json: async () => options.body ?? {},
+    },
+    get: (key: string) => (key === 'userId' ? options.userId : undefined),
+    json: (value: unknown, status?: number) => {
+      payload = value;
+      statusCode = status ?? 200;
+      return { payload: value, status: statusCode };
+    },
+  };
+
+  return {
+    context,
+    get statusCode() {
+      return statusCode;
+    },
+    get payload() {
+      return payload;
+    },
+  };
+}
+
+function createFindQuery(result: unknown) {
+  const query: any = {
+    populate: () => query,
+    sort: () => query,
+    lean: () => Promise.resolve(result),
+  };
+  return query;
+}
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe('addToWishlist controller', () => {
+  test('snapshots the current product price as priceAtAdded', async () => {
+    Product.findById = mock(() => Promise.resolve({ _id: 'prod_1', price: 500 })) as typeof Product.findById;
+    WishlistItem.findOne = mock(() => Promise.resolve(null)) as typeof WishlistItem.findOne;
+
+    const populatedItem = {
+      _id: 'wl_1',
+      userId: 'user_123',
+      product: { _id: 'prod_1', price: 500 },
+      priceAtAdded: 500,
+    };
+    const createdItem = { ...populatedItem, populate: mock(() => Promise.resolve(populatedItem)) };
+    const create = mock(() => Promise.resolve(createdItem));
+    WishlistItem.create = create as typeof WishlistItem.create;
+
+    const harness = createContext({ body: { productId: 'prod_1' }, userId: 'user_123' });
+
+    await addToWishlist(harness.context as never);
+
+    expect(create).toHaveBeenCalledWith({ userId: 'user_123', product: 'prod_1', priceAtAdded: 500 });
+    expect(harness.statusCode).toBe(201);
+  });
+});
+
+describe('getMyWishlist controller', () => {
+  test('returns 401 when userId is missing from auth context', async () => {
+    const harness = createContext({});
+
+    await getMyWishlist(harness.context as never);
+
+    expect(harness.statusCode).toBe(401);
+  });
+
+  test('marks priceDropped true when the current price is below priceAtAdded', async () => {
+    const items = [
+      { _id: 'wl_1', priceAtAdded: 500, product: { _id: 'prod_1', price: 400 } },
+    ];
+    WishlistItem.find = mock(() => createFindQuery(items)) as typeof WishlistItem.find;
+
+    const harness = createContext({ userId: 'user_123' });
+
+    await getMyWishlist(harness.context as never);
+
+    expect((harness.payload as any[])[0]).toEqual({ ...items[0], priceDropped: true });
+  });
+
+  test('marks priceDropped false when the current price did not drop', async () => {
+    const items = [
+      { _id: 'wl_1', priceAtAdded: 500, product: { _id: 'prod_1', price: 500 } },
+    ];
+    WishlistItem.find = mock(() => createFindQuery(items)) as typeof WishlistItem.find;
+
+    const harness = createContext({ userId: 'user_123' });
+
+    await getMyWishlist(harness.context as never);
+
+    expect((harness.payload as any[])[0].priceDropped).toBe(false);
+  });
+
+  test('falls back to no drop for legacy items without a stored priceAtAdded', async () => {
+    const items = [
+      { _id: 'wl_1', priceAtAdded: undefined, product: { _id: 'prod_1', price: 400 } },
+    ];
+    WishlistItem.find = mock(() => createFindQuery(items)) as typeof WishlistItem.find;
+
+    const harness = createContext({ userId: 'user_123' });
+
+    await getMyWishlist(harness.context as never);
+
+    expect((harness.payload as any[])[0].priceDropped).toBe(false);
+  });
+
+  test('does not crash when the referenced product no longer exists', async () => {
+    const items = [{ _id: 'wl_1', priceAtAdded: 500, product: null }];
+    WishlistItem.find = mock(() => createFindQuery(items)) as typeof WishlistItem.find;
+
+    const harness = createContext({ userId: 'user_123' });
+
+    await getMyWishlist(harness.context as never);
+
+    expect(harness.statusCode).toBe(200);
+    expect((harness.payload as any[])[0].priceDropped).toBe(false);
+  });
+});

--- a/backend/src/controllers/wishlist.controller.ts
+++ b/backend/src/controllers/wishlist.controller.ts
@@ -43,7 +43,15 @@ export const getMyWishlist = async (c: Context) => {
       .sort({ createdAt: -1 })
       .lean();
 
-    return c.json(items);
+    const withPriceStatus = items.map((item: any) => {
+      // Items creados antes de HU-52 no tienen priceAtAdded; se asume el
+      // precio actual como referencia, por lo que no se marcan como bajados.
+      const priceAtAdded = item.priceAtAdded ?? item.product?.price;
+      const priceDropped = item.product ? priceAtAdded > item.product.price : false;
+      return { ...item, priceAtAdded, priceDropped };
+    });
+
+    return c.json(withPriceStatus);
   } catch (error) {
     console.error('Error fetching wishlist:', error);
     return c.json({ error: 'Failed to fetch wishlist' }, 500);
@@ -63,7 +71,7 @@ export const addToWishlist = async (c: Context) => {
     const existing = await WishlistItem.findOne({ userId, product: productId });
     if (existing) return c.json({ error: 'El producto ya está en tu lista de deseos' }, 409);
 
-    const item = await WishlistItem.create({ userId, product: productId });
+    const item = await WishlistItem.create({ userId, product: productId, priceAtAdded: product.price });
     const populated = await item.populate('product');
 
     return c.json(populated, 201);

--- a/backend/src/models/WishlistItem.ts
+++ b/backend/src/models/WishlistItem.ts
@@ -4,6 +4,9 @@ const wishlistItemSchema = new Schema({
   userId: { type: String, required: true, index: true },
   product: { type: Schema.Types.ObjectId, ref: 'Product', required: true },
   note: { type: String, default: '' },
+  // Precio del producto en el momento en que se agregó a la lista de deseos,
+  // usado para detectar si bajó de precio desde entonces (HU-52).
+  priceAtAdded: { type: Number, required: true },
 }, { timestamps: true });
 
 wishlistItemSchema.index({ userId: 1, product: 1 }, { unique: true });

--- a/frontend/src/pages/Wishlist.tsx
+++ b/frontend/src/pages/Wishlist.tsx
@@ -141,9 +141,17 @@ const Wishlist: React.FC = () => {
                   <div className="wl-card-body">
                     <Link to={`/product/${item.product._id}`} className="wl-card-name">{item.product.name}</Link>
                     <p className="wl-card-cat">{CATEGORY_LABEL[item.product.category] ?? item.product.category}</p>
-                    <p className="wl-card-price">{fmt(item.product.price)}</p>
+                    {item.priceDropped ? (
+                      <p className="wl-card-price">
+                        <span className="wl-card-price-old">{fmt(item.priceAtAdded)}</span>
+                        <span className="wl-card-price-drop">{fmt(item.product.price)}</span>
+                      </p>
+                    ) : (
+                      <p className="wl-card-price">{fmt(item.product.price)}</p>
+                    )}
+                    {item.priceDropped && <p className="wl-price-drop-badge">▼ Bajó de precio desde que lo agregaste</p>}
                     {getActiveAlert(item.product._id)?.triggered && (
-                      <p className="wl-price-drop-badge">¡Bajó de precio!</p>
+                      <p className="wl-price-drop-badge">🔔 Tu alerta de precio se activó</p>
                     )}
 
                     {editingNote === item.product._id ? (
@@ -241,6 +249,8 @@ const Wishlist: React.FC = () => {
         .wl-card-name:hover { text-decoration: underline; }
         .wl-card-cat { font-family: var(--font-mono); font-size: .6rem; font-weight: 500; text-transform: uppercase; letter-spacing: 1.5px; color: var(--ink3); }
         .wl-card-price { font-family: var(--font-display); font-size: 1.15rem; font-weight: 700; color: var(--ink); margin-top: 4px; }
+        .wl-card-price-old { font-size: .8rem; font-weight: 500; color: var(--ink3); text-decoration: line-through; margin-right: 8px; }
+        .wl-card-price-drop { color: #2e7d32; }
         .wl-note-text { font-family: var(--font-sans); font-size: .78rem; font-style: italic; color: var(--ink2); margin-top: 6px; padding: 8px 10px; background: rgba(0,0,0,.025); border-radius: var(--radius-xs); border-left: 3px solid var(--sand); }
         .wl-note-edit { margin-top: 6px; }
         .wl-note-input { width: 100%; padding: 8px 10px; font-family: var(--font-sans); font-size: .82rem; border: 1px solid var(--line); border-radius: var(--radius-xs); resize: vertical; background: var(--white); color: var(--ink); }

--- a/frontend/src/types/wishlist.ts
+++ b/frontend/src/types/wishlist.ts
@@ -5,6 +5,8 @@ export interface WishlistItem {
   userId: string;
   product: Product;
   note: string;
+  priceAtAdded: number;
+  priceDropped: boolean;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
Closes #161

### Cambios

- `backend/src/models/WishlistItem.ts`: nuevo campo `priceAtAdded` (precio del producto en el momento en que se agregó a la lista de deseos).
- `backend/src/controllers/wishlist.controller.ts`:
  - `addToWishlist` guarda `priceAtAdded = product.price` al crear el item.
  - `getMyWishlist` calcula y devuelve `priceDropped` (booleano) comparando `priceAtAdded` contra el precio actual del producto poblado.
  - Items creados antes de este cambio (sin `priceAtAdded` guardado) usan el precio actual como referencia por defecto, por lo que **no** se marcan falsamente como bajados por falta de dato histórico. También se protege contra el caso de un producto eliminado (`product: null`), sin romper la respuesta.
- Frontend (`Wishlist.tsx` + `types/wishlist.ts`): cada tarjeta muestra el precio original tachado junto al precio actual en verde cuando `priceDropped` es verdadero, más una etiqueta "▼ Bajó de precio desde que lo agregaste". Se mantiene, por separado, la etiqueta de HU-51 "🔔 Tu alerta de precio se activó" cuando corresponde, para no mezclar ambas señales (una es el estado propio de la lista de deseos; la otra depende de si el usuario activó una alerta).

### Relación con HU-51

Este PR no toca el modelo `PriceAlert` ni sus endpoints — `priceAtAdded`/`priceDropped` son independientes de si el usuario activó una alerta de precio. Un producto puede mostrar "bajó de precio" en la lista de deseos sin que exista ninguna alerta creada.

### Validaciones ejecutadas

- `bun test` (backend): 119 pass, 0 fail (agrega 5 tests nuevos en `wishlist.controller.test.ts`: snapshot al agregar, `priceDropped` true/false, fallback para items legacy sin `priceAtAdded`, y no-crash cuando el producto referenciado ya no existe).
- `npm run build` (frontend): `tsc -b && vite build` sin errores.
- Verificación manual end-to-end vía curl contra un Mongo temporal en `E2E_TEST_MODE`: agregar a la lista de deseos con precio 499 → `priceAtAdded: 499`, `priceDropped: false`; bajada real de precio a 350 vía `PUT /api/products/:id` (admin) → `GET /api/wishlist/mine` refleja `priceDropped: true` manteniendo `priceAtAdded: 499` y el precio actual 350.
- **UI no verificada visualmente en navegador** (sin herramienta de browser disponible en esta sesión, igual que en el PR de HU-51): el indicador de precio tachado y la etiqueta de bajada están verificados a nivel de compilación y de datos (mismos endpoints que consume `Wishlist.tsx`), pero no con un smoke test real en navegador.

### Criterios de aceptación

- [x] La lista de deseos muestra el precio actual de cada producto guardado.
- [x] El sistema indica cuando un producto bajó de precio desde que fue agregado a la lista.
- [x] El usuario puede identificar visualmente cuáles productos tuvieron cambios (precio tachado + etiqueta).
