### PR TITLE
HU-39: Administrar cupones y descuentos en checkout

### DIFF
--- a/backend/src/controllers/checkout.controller.ts
+++ b/backend/src/controllers/checkout.controller.ts
@@ -4,8 +4,10 @@ import { Product } from '../models/Product';
 import { Order } from '../models/Order';
 import { OrderItem } from '../models/OrderItem';
 import { Address } from '../models/Address';
+import { Coupon } from '../models/Coupon';
 import { Types } from 'mongoose';
 import { isE2ETestMode } from '../lib/e2e';
+import { resolveCouponDiscount } from '../lib/coupons';
 
 const getStripeClient = () => {
   const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
@@ -106,6 +108,31 @@ export const createPaymentIntentController = async (c: Context) => {
       validItems.push({ product: dbProduct, quantity: item.quantity });
     }
 
+    // Cupon de descuento (HU-39): se resuelve sobre el subtotal recien
+    // calculado, antes de bifurcar en E2E/real, para que ambos caminos y el
+    // total guardado en la orden reflejen el mismo descuento. Un cupon
+    // invalido/expirado no bloquea el checkout: simplemente no se aplica y
+    // se informa un aviso, para no dejar el pago sin PaymentIntent.
+    const couponCodeInput = typeof body.couponCode === 'string' && body.couponCode.trim()
+      ? body.couponCode.trim().toUpperCase()
+      : undefined;
+    let discountAmount = 0;
+    let appliedCouponCode: string | undefined;
+    let couponWarning: string | undefined;
+
+    if (couponCodeInput) {
+      const coupon = await Coupon.findOne({ code: couponCodeInput });
+      const resolution = resolveCouponDiscount(coupon as any, totalAmount);
+      if (resolution.valid) {
+        discountAmount = resolution.discountAmount;
+        appliedCouponCode = couponCodeInput;
+      } else {
+        couponWarning = resolution.reason;
+      }
+    }
+
+    totalAmount = Math.max(0, totalAmount - discountAmount);
+
     const amountInCents = Math.round(totalAmount * 100);
 
     // Ensure local user exists (mirrors prior behavior).
@@ -171,6 +198,8 @@ export const createPaymentIntentController = async (c: Context) => {
           status: 'pending',
           payment_intent_id: e2ePaymentIntentId,
           shippingAddress,
+          coupon_code: appliedCouponCode,
+          discount_amount: discountAmount,
           items: validItems.map((item) => ({
             product: item.product._id,
             quantity: item.quantity,
@@ -189,6 +218,8 @@ export const createPaymentIntentController = async (c: Context) => {
       } else {
         order.total_amount = totalAmount;
         order.payment_intent_id = e2ePaymentIntentId;
+        order.coupon_code = appliedCouponCode;
+        order.discount_amount = discountAmount;
         if (shippingAddress) order.shippingAddress = shippingAddress;
         await order.save();
       }
@@ -199,6 +230,9 @@ export const createPaymentIntentController = async (c: Context) => {
           paymentIntentId: e2ePaymentIntentId,
           orderId: String(order._id),
           amount: totalAmount,
+          discountAmount,
+          couponCode: appliedCouponCode,
+          couponWarning,
         },
         200,
       );
@@ -255,6 +289,8 @@ export const createPaymentIntentController = async (c: Context) => {
         status: 'pending',
         payment_intent_id: paymentIntent.id,
         shippingAddress,
+        coupon_code: appliedCouponCode,
+        discount_amount: discountAmount,
         items: validItems.map((item) => ({
           product: item.product._id,
           quantity: item.quantity,
@@ -274,6 +310,8 @@ export const createPaymentIntentController = async (c: Context) => {
       // Reusing an existing pending order — keep amount + PI in sync.
       order.total_amount = totalAmount;
       order.payment_intent_id = paymentIntent.id;
+      order.coupon_code = appliedCouponCode;
+      order.discount_amount = discountAmount;
       if (shippingAddress) order.shippingAddress = shippingAddress;
       await order.save();
     }
@@ -296,6 +334,9 @@ export const createPaymentIntentController = async (c: Context) => {
         paymentIntentId: paymentIntent.id,
         orderId: String(order._id),
         amount: totalAmount,
+        discountAmount,
+        couponCode: appliedCouponCode,
+        couponWarning,
       },
       200,
     );

--- a/backend/src/controllers/coupon.controller.test.ts
+++ b/backend/src/controllers/coupon.controller.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { createCoupon, getAllCoupons, deactivateCoupon, validateCoupon } from './coupon.controller';
+import { Coupon } from '../models/Coupon';
+
+function createContext(options: { validData?: Record<string, unknown>; param?: string } = {}) {
+  let statusCode = 200;
+  let payload: unknown;
+
+  const context = {
+    req: {
+      valid: (_key: string) => options.validData ?? {},
+      param: (_key: string) => options.param,
+    },
+    json: (value: unknown, status?: number) => {
+      payload = value;
+      statusCode = status ?? 200;
+      return { payload: value, status: statusCode };
+    },
+  };
+
+  return {
+    context,
+    get statusCode() {
+      return statusCode;
+    },
+    get payload() {
+      return payload;
+    },
+  };
+}
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe('createCoupon controller', () => {
+  test('creates a coupon with an uppercased code', async () => {
+    Coupon.findOne = mock(() => Promise.resolve(null)) as typeof Coupon.findOne;
+    const create = mock(() => Promise.resolve({ code: 'VERANO10' }));
+    Coupon.create = create as typeof Coupon.create;
+
+    const harness = createContext({
+      validData: {
+        code: 'verano10',
+        discountType: 'percentage',
+        discountValue: 10,
+        validFrom: '2026-01-01T00:00:00.000Z',
+        validUntil: '2026-12-31T00:00:00.000Z',
+      },
+    });
+
+    await createCoupon(harness.context as never);
+
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({ code: 'VERANO10' }));
+    expect(harness.statusCode).toBe(201);
+  });
+
+  test('rejects a duplicate coupon code with 409', async () => {
+    Coupon.findOne = mock(() => Promise.resolve({ code: 'VERANO10' })) as typeof Coupon.findOne;
+
+    const harness = createContext({
+      validData: {
+        code: 'VERANO10',
+        discountType: 'percentage',
+        discountValue: 10,
+        validFrom: '2026-01-01T00:00:00.000Z',
+        validUntil: '2026-12-31T00:00:00.000Z',
+      },
+    });
+
+    await createCoupon(harness.context as never);
+
+    expect(harness.statusCode).toBe(409);
+  });
+});
+
+describe('getAllCoupons controller', () => {
+  test('returns all coupons sorted by creation date', async () => {
+    const sort = mock(() => Promise.resolve([{ code: 'A' }, { code: 'B' }]));
+    Coupon.find = mock(() => ({ sort })) as unknown as typeof Coupon.find;
+
+    const harness = createContext();
+    await getAllCoupons(harness.context as never);
+
+    expect(harness.statusCode).toBe(200);
+    expect(harness.payload).toEqual([{ code: 'A' }, { code: 'B' }]);
+  });
+});
+
+describe('deactivateCoupon controller', () => {
+  test('deactivates an existing coupon', async () => {
+    Coupon.findByIdAndUpdate = mock(() => Promise.resolve({ code: 'VERANO10', active: false })) as typeof Coupon.findByIdAndUpdate;
+
+    const harness = createContext({ param: 'coupon_1' });
+    await deactivateCoupon(harness.context as never);
+
+    expect(harness.statusCode).toBe(200);
+  });
+
+  test('returns 404 when the coupon does not exist', async () => {
+    Coupon.findByIdAndUpdate = mock(() => Promise.resolve(null)) as typeof Coupon.findByIdAndUpdate;
+
+    const harness = createContext({ param: 'missing' });
+    await deactivateCoupon(harness.context as never);
+
+    expect(harness.statusCode).toBe(404);
+  });
+});
+
+describe('validateCoupon controller', () => {
+  test('returns a valid resolution for an active coupon', async () => {
+    Coupon.findOne = mock(() => Promise.resolve({
+      active: true,
+      validFrom: new Date('2020-01-01'),
+      validUntil: new Date('2030-01-01'),
+      minPurchase: 0,
+      usedCount: 0,
+      discountType: 'fixed',
+      discountValue: 20,
+    })) as typeof Coupon.findOne;
+
+    const harness = createContext({ validData: { code: 'VERANO10', subtotal: 100 } });
+    await validateCoupon(harness.context as never);
+
+    expect(harness.statusCode).toBe(200);
+    expect((harness.payload as any).valid).toBe(true);
+    expect((harness.payload as any).discountAmount).toBe(20);
+  });
+
+  test('returns an invalid resolution when the coupon does not exist', async () => {
+    Coupon.findOne = mock(() => Promise.resolve(null)) as typeof Coupon.findOne;
+
+    const harness = createContext({ validData: { code: 'NOPE', subtotal: 100 } });
+    await validateCoupon(harness.context as never);
+
+    expect(harness.statusCode).toBe(200);
+    expect((harness.payload as any).valid).toBe(false);
+  });
+});

--- a/backend/src/controllers/coupon.controller.ts
+++ b/backend/src/controllers/coupon.controller.ts
@@ -1,0 +1,78 @@
+import { Context } from 'hono';
+import { Coupon } from '../models/Coupon';
+import { resolveCouponDiscount } from '../lib/coupons';
+
+export const createCoupon = async (c: Context) => {
+  try {
+    const data = c.req.valid('json' as any) as {
+      code: string;
+      discountType: 'percentage' | 'fixed';
+      discountValue: number;
+      validFrom: string;
+      validUntil: string;
+      minPurchase?: number;
+      maxUses?: number;
+    };
+
+    const code = data.code.trim().toUpperCase();
+    const existing = await Coupon.findOne({ code });
+    if (existing) {
+      return c.json({ error: 'Ya existe un cupón con ese código' }, 409);
+    }
+
+    const coupon = await Coupon.create({
+      code,
+      discountType: data.discountType,
+      discountValue: data.discountValue,
+      validFrom: new Date(data.validFrom),
+      validUntil: new Date(data.validUntil),
+      minPurchase: data.minPurchase ?? 0,
+      maxUses: data.maxUses,
+    });
+
+    return c.json(coupon, 201);
+  } catch (error: any) {
+    console.error('[Coupon] Error creating coupon:', error);
+    return c.json({ error: error.message }, 400);
+  }
+};
+
+export const getAllCoupons = async (c: Context) => {
+  try {
+    const coupons = await Coupon.find().sort({ createdAt: -1 });
+    return c.json(coupons);
+  } catch (error: any) {
+    console.error('[Coupon] Error fetching coupons:', error);
+    return c.json({ error: 'Failed to fetch coupons' }, 500);
+  }
+};
+
+export const deactivateCoupon = async (c: Context) => {
+  try {
+    const id = c.req.param('id');
+    const coupon = await Coupon.findByIdAndUpdate(id, { active: false }, { new: true });
+
+    if (!coupon) {
+      return c.json({ error: 'Cupón no encontrado' }, 404);
+    }
+
+    return c.json(coupon);
+  } catch (error: any) {
+    console.error('[Coupon] Error deactivating coupon:', error);
+    return c.json({ error: 'Failed to deactivate coupon' }, 500);
+  }
+};
+
+export const validateCoupon = async (c: Context) => {
+  try {
+    const { code, subtotal } = c.req.valid('json' as any) as { code: string; subtotal: number };
+
+    const coupon = await Coupon.findOne({ code: code.trim().toUpperCase() });
+    const resolution = resolveCouponDiscount(coupon as any, subtotal);
+
+    return c.json(resolution);
+  } catch (error: any) {
+    console.error('[Coupon] Error validating coupon:', error);
+    return c.json({ error: 'Failed to validate coupon' }, 500);
+  }
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,6 +21,7 @@ import priceAlertRoutes from './routes/priceAlert.routes';
 import e2eRoutes from './routes/e2e.routes';
 import reportRoutes from './routes/report.routes';
 import supportRoutes from './routes/support.routes';
+import couponRoutes from './routes/coupon.routes';
 import { isE2ETestMode } from './lib/e2e';
 
 const app = new Hono();
@@ -57,6 +58,7 @@ app.route('/api/wishlist', wishlistRoutes);
 app.route('/api/price-alerts', priceAlertRoutes);
 app.route('/api/reports', reportRoutes);
 app.route('/api/support-tickets', supportRoutes);
+app.route('/api/coupons', couponRoutes);
 if (isE2ETestMode) {
   app.route('/api/e2e', e2eRoutes);
 }

--- a/backend/src/lib/coupons.test.ts
+++ b/backend/src/lib/coupons.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveCouponDiscount, type CouponRules } from './coupons';
+
+const baseCoupon: CouponRules = {
+  active: true,
+  validFrom: new Date('2026-01-01T00:00:00Z'),
+  validUntil: new Date('2026-12-31T23:59:59Z'),
+  minPurchase: 0,
+  usedCount: 0,
+  discountType: 'percentage',
+  discountValue: 10,
+};
+
+const NOW = new Date('2026-06-01T00:00:00Z');
+
+describe('resolveCouponDiscount', () => {
+  test('returns invalid when coupon is null (not found)', () => {
+    const result = resolveCouponDiscount(null, 100, NOW);
+    expect(result.valid).toBe(false);
+    expect(result.discountAmount).toBe(0);
+  });
+
+  test('returns invalid when coupon is inactive', () => {
+    const result = resolveCouponDiscount({ ...baseCoupon, active: false }, 100, NOW);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/inactivo/i);
+  });
+
+  test('returns invalid when now is before validFrom', () => {
+    const result = resolveCouponDiscount(baseCoupon, 100, new Date('2025-12-31T00:00:00Z'));
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/vigencia/i);
+  });
+
+  test('returns invalid when now is after validUntil', () => {
+    const result = resolveCouponDiscount(baseCoupon, 100, new Date('2027-01-01T00:00:00Z'));
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/vigencia/i);
+  });
+
+  test('returns invalid when subtotal is below minPurchase', () => {
+    const result = resolveCouponDiscount({ ...baseCoupon, minPurchase: 200 }, 100, NOW);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/minima/i);
+  });
+
+  test('returns invalid when usedCount reached maxUses', () => {
+    const result = resolveCouponDiscount({ ...baseCoupon, maxUses: 5, usedCount: 5 }, 100, NOW);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/agotado/i);
+  });
+
+  test('allows usage when usedCount is below maxUses', () => {
+    const result = resolveCouponDiscount({ ...baseCoupon, maxUses: 5, usedCount: 4 }, 100, NOW);
+    expect(result.valid).toBe(true);
+  });
+
+  test('computes percentage discount correctly', () => {
+    const result = resolveCouponDiscount({ ...baseCoupon, discountType: 'percentage', discountValue: 10 }, 200, NOW);
+    expect(result.valid).toBe(true);
+    expect(result.discountAmount).toBe(20);
+  });
+
+  test('computes fixed discount correctly', () => {
+    const result = resolveCouponDiscount({ ...baseCoupon, discountType: 'fixed', discountValue: 15 }, 200, NOW);
+    expect(result.valid).toBe(true);
+    expect(result.discountAmount).toBe(15);
+  });
+
+  test('clamps a fixed discount larger than the subtotal to the subtotal itself', () => {
+    const result = resolveCouponDiscount({ ...baseCoupon, discountType: 'fixed', discountValue: 500 }, 50, NOW);
+    expect(result.valid).toBe(true);
+    expect(result.discountAmount).toBe(50);
+  });
+});

--- a/backend/src/lib/coupons.ts
+++ b/backend/src/lib/coupons.ts
@@ -1,0 +1,50 @@
+export interface CouponRules {
+  active: boolean;
+  validFrom: Date;
+  validUntil: Date;
+  minPurchase: number;
+  maxUses?: number;
+  usedCount: number;
+  discountType: 'percentage' | 'fixed';
+  discountValue: number;
+}
+
+export interface CouponResolution {
+  valid: boolean;
+  reason?: string;
+  discountAmount: number;
+}
+
+export const resolveCouponDiscount = (
+  coupon: CouponRules | null,
+  subtotal: number,
+  now: Date = new Date(),
+): CouponResolution => {
+  if (!coupon) {
+    return { valid: false, reason: 'Cupón no encontrado', discountAmount: 0 };
+  }
+  if (!coupon.active) {
+    return { valid: false, reason: 'Cupón inactivo', discountAmount: 0 };
+  }
+  if (now < coupon.validFrom || now > coupon.validUntil) {
+    return { valid: false, reason: 'Cupón fuera de vigencia', discountAmount: 0 };
+  }
+  if (subtotal < coupon.minPurchase) {
+    return {
+      valid: false,
+      reason: `Requiere una compra minima de $${coupon.minPurchase.toFixed(2)}`,
+      discountAmount: 0,
+    };
+  }
+  if (coupon.maxUses !== undefined && coupon.usedCount >= coupon.maxUses) {
+    return { valid: false, reason: 'Cupón agotado', discountAmount: 0 };
+  }
+
+  const rawDiscount = coupon.discountType === 'percentage'
+    ? subtotal * (coupon.discountValue / 100)
+    : coupon.discountValue;
+
+  const discountAmount = Math.min(Math.round(rawDiscount * 100) / 100, subtotal);
+
+  return { valid: true, discountAmount };
+};

--- a/backend/src/models/Coupon.ts
+++ b/backend/src/models/Coupon.ts
@@ -1,0 +1,17 @@
+import { Schema, model } from 'mongoose';
+
+const couponSchema = new Schema({
+  code: { type: String, required: true, unique: true, uppercase: true, trim: true },
+  discountType: { type: String, enum: ['percentage', 'fixed'], required: true },
+  discountValue: { type: Number, required: true, min: 0 },
+  validFrom: { type: Date, required: true },
+  validUntil: { type: Date, required: true },
+  active: { type: Boolean, default: true },
+  // Monto minimo de compra (subtotal) para poder aplicar el cupon.
+  minPurchase: { type: Number, default: 0 },
+  // Cantidad maxima de usos totales; sin definir = ilimitado.
+  maxUses: { type: Number },
+  usedCount: { type: Number, default: 0 },
+}, { timestamps: true });
+
+export const Coupon = model('Coupon', couponSchema);

--- a/backend/src/models/Order.ts
+++ b/backend/src/models/Order.ts
@@ -15,6 +15,10 @@ const orderSchema = new Schema({
   stripe_session_id: { type: String, index: true },
   // New field — used by embedded Payment Element flow.
   payment_intent_id: { type: String, index: true },
+  // Cupon aplicado en el checkout (HU-39): se guarda el codigo y el
+  // descuento resultante para trazabilidad, no una referencia viva a Coupon.
+  coupon_code: { type: String },
+  discount_amount: { type: Number, default: 0 },
   // Snapshot de la direccion de entrega seleccionada al momento del checkout
   // (no una referencia viva a Address, para que la orden no cambie si el
   // usuario despues edita o borra esa direccion guardada).

--- a/backend/src/routes/coupon.routes.ts
+++ b/backend/src/routes/coupon.routes.ts
@@ -1,0 +1,21 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { createCoupon, getAllCoupons, deactivateCoupon, validateCoupon } from '../controllers/coupon.controller';
+import { clerkAuthMiddleware, adminAuthMiddleware } from '../middlewares/auth.middleware';
+import { createCouponSchema, validateCouponSchema } from '../validators/coupon.validator';
+
+const couponRoutes = new Hono();
+
+couponRoutes.post('/', adminAuthMiddleware, zValidator('json', createCouponSchema, (result, c) => {
+  if (!result.success) return c.json({ success: false, errors: result.error.errors }, 400);
+}), createCoupon);
+
+couponRoutes.get('/', adminAuthMiddleware, getAllCoupons);
+
+couponRoutes.patch('/:id/deactivate', adminAuthMiddleware, deactivateCoupon);
+
+couponRoutes.post('/validate', clerkAuthMiddleware, zValidator('json', validateCouponSchema, (result, c) => {
+  if (!result.success) return c.json({ success: false, errors: result.error.errors }, 400);
+}), validateCoupon);
+
+export default couponRoutes;

--- a/backend/src/services/order.service.ts
+++ b/backend/src/services/order.service.ts
@@ -3,6 +3,7 @@ import { Order } from '../models/Order';
 import { OrderItem } from '../models/OrderItem';
 import { Product } from '../models/Product';
 import { User } from '../models/User';
+import { Coupon } from '../models/Coupon';
 import { sendPurchaseConfirmationEmail } from './email.service';
 import { recordInventoryMovement } from './inventory.service';
 
@@ -68,6 +69,24 @@ export const finalizePaidOrder = async (
         performedBy: userId,
         session: session ?? undefined,
       });
+    }
+
+    // Contabiliza el uso del cupon solo al confirmarse el pago (no en cada
+    // intento de checkout), con un incremento atomico condicionado a que
+    // aun no se haya agotado maxUses, para evitar sobre-conteo por carreras.
+    if (lockedOrder.coupon_code) {
+      const couponUpdateQuery = Coupon.findOneAndUpdate(
+        {
+          code: lockedOrder.coupon_code,
+          $or: [{ maxUses: { $exists: false } }, { $expr: { $lt: ['$usedCount', '$maxUses'] } }],
+        },
+        { $inc: { usedCount: 1 } },
+      );
+      if (session) {
+        await couponUpdateQuery.session(session);
+      } else {
+        await couponUpdateQuery;
+      }
     }
 
     lockedOrder.status = 'paid';

--- a/backend/src/validators/checkout.validator.test.ts
+++ b/backend/src/validators/checkout.validator.test.ts
@@ -40,4 +40,20 @@ describe('checkoutSchema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  test('accepts an optional couponCode', () => {
+    const result = checkoutSchema.safeParse({
+      items: [{ productId: validId(), quantity: 1 }],
+      couponCode: 'VERANO10',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects an empty couponCode when provided', () => {
+    const result = checkoutSchema.safeParse({
+      items: [{ productId: validId(), quantity: 1 }],
+      couponCode: '',
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/backend/src/validators/checkout.validator.ts
+++ b/backend/src/validators/checkout.validator.ts
@@ -9,5 +9,6 @@ export const checkoutSchema = z.object({
       }),
       quantity: z.number().int().positive().min(1)
     })
-  ).min(1, 'Cart items cannot be empty')
+  ).min(1, 'Cart items cannot be empty'),
+  couponCode: z.string().trim().min(1).optional(),
 });

--- a/backend/src/validators/coupon.validator.test.ts
+++ b/backend/src/validators/coupon.validator.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+import { createCouponSchema, validateCouponSchema } from './coupon.validator';
+
+describe('createCouponSchema', () => {
+  const valid = {
+    code: 'VERANO10',
+    discountType: 'percentage' as const,
+    discountValue: 10,
+    validFrom: '2026-01-01T00:00:00.000Z',
+    validUntil: '2026-12-31T00:00:00.000Z',
+  };
+
+  test('accepts a valid coupon', () => {
+    expect(createCouponSchema.safeParse(valid).success).toBe(true);
+  });
+
+  test('rejects a short code', () => {
+    expect(createCouponSchema.safeParse({ ...valid, code: 'AB' }).success).toBe(false);
+  });
+
+  test('rejects validFrom after validUntil', () => {
+    const result = createCouponSchema.safeParse({ ...valid, validFrom: '2027-01-01T00:00:00.000Z' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a percentage discount over 100', () => {
+    const result = createCouponSchema.safeParse({ ...valid, discountValue: 150 });
+    expect(result.success).toBe(false);
+  });
+
+  test('accepts a fixed discount over 100', () => {
+    const result = createCouponSchema.safeParse({ ...valid, discountType: 'fixed', discountValue: 150 });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects a negative discountValue', () => {
+    expect(createCouponSchema.safeParse({ ...valid, discountValue: -5 }).success).toBe(false);
+  });
+});
+
+describe('validateCouponSchema', () => {
+  test('accepts a valid payload', () => {
+    expect(validateCouponSchema.safeParse({ code: 'VERANO10', subtotal: 100 }).success).toBe(true);
+  });
+
+  test('rejects an empty code', () => {
+    expect(validateCouponSchema.safeParse({ code: '', subtotal: 100 }).success).toBe(false);
+  });
+
+  test('rejects a non-positive subtotal', () => {
+    expect(validateCouponSchema.safeParse({ code: 'VERANO10', subtotal: 0 }).success).toBe(false);
+  });
+});

--- a/backend/src/validators/coupon.validator.ts
+++ b/backend/src/validators/coupon.validator.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const createCouponSchema = z.object({
+  code: z.string().trim().min(3, 'El codigo debe tener al menos 3 caracteres').max(30),
+  discountType: z.enum(['percentage', 'fixed']),
+  discountValue: z.number().positive(),
+  validFrom: z.string().datetime({ offset: true }),
+  validUntil: z.string().datetime({ offset: true }),
+  minPurchase: z.number().min(0).optional(),
+  maxUses: z.number().int().positive().optional(),
+}).refine((data) => new Date(data.validFrom).getTime() < new Date(data.validUntil).getTime(), {
+  message: 'validFrom debe ser anterior a validUntil',
+  path: ['validFrom'],
+}).refine((data) => data.discountType !== 'percentage' || data.discountValue <= 100, {
+  message: 'El descuento porcentual no puede superar 100',
+  path: ['discountValue'],
+});
+
+export const validateCouponSchema = z.object({
+  code: z.string().trim().min(1, 'Debe indicar un codigo de cupon'),
+  subtotal: z.number().positive(),
+});

--- a/frontend/src/components/AdminSidebar.tsx
+++ b/frontend/src/components/AdminSidebar.tsx
@@ -32,6 +32,11 @@ const TechnicianIcon = () => (
     <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
   </svg>
 );
+const CouponIcon = () => (
+  <svg fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9 8.25H7.5a2.25 2.25 0 00-2.25 2.25v7.5a2.25 2.25 0 002.25 2.25h9a2.25 2.25 0 002.25-2.25v-7.5a2.25 2.25 0 00-2.25-2.25H15m-6 0V6a3 3 0 116 0v2.25m-6 0h6" />
+  </svg>
+);
 const BackIcon = () => (
   <svg fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
     <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
@@ -52,6 +57,7 @@ const navSections = [
       { id: 'warranties',   label: 'Garantías',  icon: <WarrantyIcon /> },
       { id: 'products',     label: 'Productos',  icon: <ProductsIcon /> },
       { id: 'technicians',  label: 'Técnicos',   icon: <TechnicianIcon /> },
+      { id: 'coupons',      label: 'Cupones',    icon: <CouponIcon /> },
     ],
   },
 ];

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -4,9 +4,11 @@ import { useAuth } from '../lib/auth';
 import { warrantyService } from '../services/warranty.service';
 import { ordersService } from '../services/orders.service';
 import { technicianService } from '../services/technician.service';
+import { couponService } from '../services/coupon.service';
 import type { IWarranty } from '../types/warranty';
 import type { Order } from '../types/order';
 import type { Technician } from '../types/technician';
+import type { Coupon } from '../types/coupon';
 import { useState } from 'react';
 import AdminSidebar from '../components/AdminSidebar';
 import StatsCards from '../components/StatsCards';
@@ -15,7 +17,7 @@ import ProductTable from '../components/ProductTable';
 import { Badge } from '../components/ui/Badge';
 import { SkeletonTableRow } from '../components/ui/Skeleton';
 
-type SectionType = 'dashboard' | 'orders' | 'warranties' | 'products' | 'technicians';
+type SectionType = 'dashboard' | 'orders' | 'warranties' | 'products' | 'technicians' | 'coupons';
 
 const PAGE_SIZE = 10;
 
@@ -219,6 +221,121 @@ function TechnicianForm({ onSubmit, isPending }: { onSubmit: (d: { name: string;
   );
 }
 
+/* ── Coupon form ── */
+function CouponForm({
+  onSubmit,
+  isPending,
+}: {
+  onSubmit: (d: {
+    code: string;
+    discountType: 'percentage' | 'fixed';
+    discountValue: number;
+    validFrom: string;
+    validUntil: string;
+    minPurchase?: number;
+    maxUses?: number;
+  }) => void;
+  isPending: boolean;
+}) {
+  const [code, setCode] = useState('');
+  const [discountType, setDiscountType] = useState<'percentage' | 'fixed'>('percentage');
+  const [discountValue, setDiscountValue] = useState('');
+  const [validFrom, setValidFrom] = useState('');
+  const [validUntil, setValidUntil] = useState('');
+  const [minPurchase, setMinPurchase] = useState('');
+  const [maxUses, setMaxUses] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError(null);
+
+    if (!code.trim() || !discountValue || !validFrom || !validUntil) {
+      setFormError('Código, valor de descuento y vigencia son obligatorios.');
+      return;
+    }
+
+    onSubmit({
+      code: code.trim(),
+      discountType,
+      discountValue: Number(discountValue),
+      validFrom: new Date(validFrom).toISOString(),
+      validUntil: new Date(validUntil).toISOString(),
+      minPurchase: minPurchase ? Number(minPurchase) : undefined,
+      maxUses: maxUses ? Number(maxUses) : undefined,
+    });
+
+    setCode(''); setDiscountValue(''); setValidFrom(''); setValidUntil(''); setMinPurchase(''); setMaxUses('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{
+      background: 'var(--white)',
+      border: '1.5px solid var(--line)',
+      borderRadius: 'var(--radius-card)',
+      padding: '1.75rem',
+      marginBottom: '1.75rem',
+    }}>
+      <p style={{ fontSize: '0.8rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '1px', color: 'var(--ink3)', marginBottom: '1.25rem' }}>
+        Crear cupón
+      </p>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '1rem', marginBottom: '1rem' }}>
+        <div>
+          <label style={{ display: 'block', fontSize: '0.72rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.8px', color: 'var(--ink3)', marginBottom: 5 }}>
+            Código
+          </label>
+          <input value={code} onChange={e => setCode(e.target.value)} placeholder="VERANO10" className="input" required style={{ fontSize: '0.875rem' }} />
+        </div>
+        <div>
+          <label style={{ display: 'block', fontSize: '0.72rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.8px', color: 'var(--ink3)', marginBottom: 5 }}>
+            Tipo
+          </label>
+          <select value={discountType} onChange={e => setDiscountType(e.target.value as 'percentage' | 'fixed')} className="input" style={{ fontSize: '0.875rem' }}>
+            <option value="percentage">Porcentaje</option>
+            <option value="fixed">Monto fijo</option>
+          </select>
+        </div>
+        <div>
+          <label style={{ display: 'block', fontSize: '0.72rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.8px', color: 'var(--ink3)', marginBottom: 5 }}>
+            Valor
+          </label>
+          <input value={discountValue} onChange={e => setDiscountValue(e.target.value)} type="number" min="0" placeholder={discountType === 'percentage' ? '10' : '15.00'} className="input" required style={{ fontSize: '0.875rem' }} />
+        </div>
+        <div>
+          <label style={{ display: 'block', fontSize: '0.72rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.8px', color: 'var(--ink3)', marginBottom: 5 }}>
+            Compra mínima
+          </label>
+          <input value={minPurchase} onChange={e => setMinPurchase(e.target.value)} type="number" min="0" placeholder="Opcional" className="input" style={{ fontSize: '0.875rem' }} />
+        </div>
+        <div>
+          <label style={{ display: 'block', fontSize: '0.72rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.8px', color: 'var(--ink3)', marginBottom: 5 }}>
+            Válido desde
+          </label>
+          <input value={validFrom} onChange={e => setValidFrom(e.target.value)} type="date" className="input" required style={{ fontSize: '0.875rem' }} />
+        </div>
+        <div>
+          <label style={{ display: 'block', fontSize: '0.72rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.8px', color: 'var(--ink3)', marginBottom: 5 }}>
+            Válido hasta
+          </label>
+          <input value={validUntil} onChange={e => setValidUntil(e.target.value)} type="date" className="input" required style={{ fontSize: '0.875rem' }} />
+        </div>
+        <div>
+          <label style={{ display: 'block', fontSize: '0.72rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.8px', color: 'var(--ink3)', marginBottom: 5 }}>
+            Usos máximos
+          </label>
+          <input value={maxUses} onChange={e => setMaxUses(e.target.value)} type="number" min="1" placeholder="Ilimitado" className="input" style={{ fontSize: '0.875rem' }} />
+        </div>
+        <div style={{ display: 'flex', alignItems: 'end' }}>
+          <button type="submit" disabled={isPending} className="btn-primary" style={{ height: 42, padding: '0 22px', fontSize: '0.85rem', width: '100%' }}>
+            {isPending ? 'Creando…' : 'Crear cupón'}
+          </button>
+        </div>
+      </div>
+      {formError && <div className="alert alert-error">{formError}</div>}
+    </form>
+  );
+}
+
 /* ══════════════════ Main Dashboard ══════════════════ */
 export default function AdminDashboard() {
   const { getToken, isLoaded } = useAuth();
@@ -227,6 +344,7 @@ export default function AdminDashboard() {
   const [ordersPage, setOrdersPage] = useState(1);
   const [warrantiesPage, setWarrantiesPage] = useState(1);
   const [techniciansPage, setTechniciansPage] = useState(1);
+  const [couponsPage, setCouponsPage] = useState(1);
   const queryClient = useQueryClient();
 
   const { data: orders, isLoading: ordersLoading } = useQuery<Order[]>({
@@ -286,6 +404,42 @@ export default function AdminDashboard() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['technicians'] }),
   });
 
+  const { data: coupons, isLoading: couponsLoading } = useQuery<Coupon[]>({
+    queryKey: ['coupons'],
+    queryFn: async () => {
+      const token = await getToken();
+      if (!token) throw new Error('No token');
+      return couponService.getCoupons(token);
+    },
+    enabled: isLoaded,
+  });
+
+  const couponMutation = useMutation({
+    mutationFn: async (data: {
+      code: string;
+      discountType: 'percentage' | 'fixed';
+      discountValue: number;
+      validFrom: string;
+      validUntil: string;
+      minPurchase?: number;
+      maxUses?: number;
+    }) => {
+      const token = await getToken();
+      if (!token) throw new Error('No token');
+      return couponService.createCoupon(data, token);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['coupons'] }),
+  });
+
+  const deactivateCouponMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const token = await getToken();
+      if (!token) throw new Error('No token');
+      return couponService.deactivateCoupon(id, token);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['coupons'] }),
+  });
+
   const updateShippingMutation = useMutation({
     mutationFn: async ({ orderId, data }: { orderId: string; data: { status?: 'processing' | 'shipped' | 'delivered'; carrier?: string; trackingNumber?: string } }) => {
       const token = await getToken();
@@ -303,12 +457,14 @@ export default function AdminDashboard() {
     setOrdersPage(1);
     setWarrantiesPage(1);
     setTechniciansPage(1);
+    setCouponsPage(1);
     setSidebarOpen(false);
   };
 
   const pagedOrders      = (orders      ?? []).slice((ordersPage - 1)      * PAGE_SIZE, ordersPage      * PAGE_SIZE);
   const pagedWarranties  = (warranties  ?? []).slice((warrantiesPage - 1)  * PAGE_SIZE, warrantiesPage  * PAGE_SIZE);
   const pagedTechnicians = (technicians ?? []).slice((techniciansPage - 1) * PAGE_SIZE, techniciansPage * PAGE_SIZE);
+  const pagedCoupons     = (coupons     ?? []).slice((couponsPage - 1)     * PAGE_SIZE, couponsPage     * PAGE_SIZE);
 
   return (
     <div style={{ display: 'flex', minHeight: '100vh', background: 'var(--cream)' }}>
@@ -647,6 +803,90 @@ export default function AdminDashboard() {
                   </tbody>
                 </table>
                 <Pagination total={technicians?.length ?? 0} page={techniciansPage} onPage={setTechniciansPage} />
+              </div>
+            </div>
+          )}
+
+          {/* ══ CUPONES ══ */}
+          {activeSection === 'coupons' && (
+            <div style={{ animation: 'fadeIn 0.3s ease both' }}>
+              <SectionHeader title="Cupones" count={coupons?.length} />
+              <CouponForm
+                onSubmit={(d) => couponMutation.mutate(d)}
+                isPending={couponMutation.isPending}
+              />
+              <div className="admin-table-wrapper">
+                <table className="admin-table">
+                  <thead>
+                    <tr>
+                      <th>Código</th>
+                      <th>Descuento</th>
+                      <th>Vigencia</th>
+                      <th>Usos</th>
+                      <th>Estado</th>
+                      <th>Acciones</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {couponsLoading
+                      ? Array.from({ length: 4 }).map((_, i) => <SkeletonTableRow key={i} cols={6} />)
+                      : pagedCoupons.length === 0
+                        ? (
+                          <tr>
+                            <td colSpan={6} style={{ padding: '3rem', textAlign: 'center', color: 'var(--ink3)', fontSize: '0.9rem' }}>
+                              No hay cupones registrados.
+                            </td>
+                          </tr>
+                        )
+                        : pagedCoupons.map((coupon) => (
+                          <tr key={coupon._id}>
+                            <td style={{ fontWeight: 600 }}>{coupon.code}</td>
+                            <td style={{ color: 'var(--ink2)', fontSize: '0.875rem' }}>
+                              {coupon.discountType === 'percentage' ? `${coupon.discountValue}%` : `$${coupon.discountValue.toFixed(2)}`}
+                            </td>
+                            <td style={{ color: 'var(--ink2)', fontSize: '0.8rem' }}>
+                              {formatDate(coupon.validFrom)} – {formatDate(coupon.validUntil)}
+                            </td>
+                            <td style={{ color: 'var(--ink2)', fontSize: '0.875rem' }}>
+                              {coupon.usedCount}{coupon.maxUses ? ` / ${coupon.maxUses}` : ''}
+                            </td>
+                            <td>
+                              <Badge variant={coupon.active ? 'success' : 'neutral'}>
+                                {coupon.active ? 'Activo' : 'Inactivo'}
+                              </Badge>
+                            </td>
+                            <td className="actions">
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  const confirmed = window.confirm(`¿Desactivar el cupón ${coupon.code}?`);
+                                  if (!confirmed) return;
+                                  deactivateCouponMutation.mutate(coupon._id);
+                                }}
+                                disabled={!coupon.active || deactivateCouponMutation.isPending}
+                                style={{
+                                  padding: '7px 12px',
+                                  border: '1px solid var(--line)',
+                                  borderRadius: 'var(--radius-ui)',
+                                  background: 'var(--white)',
+                                  color: 'var(--ink)',
+                                  fontSize: '0.78rem',
+                                  fontWeight: 500,
+                                  fontFamily: 'var(--font-sans)',
+                                  cursor: (!coupon.active || deactivateCouponMutation.isPending) ? 'not-allowed' : 'pointer',
+                                  opacity: (!coupon.active || deactivateCouponMutation.isPending) ? 0.6 : 1,
+                                }}
+                                title={`Desactivar ${coupon.code}`}
+                              >
+                                {deactivateCouponMutation.isPending ? 'Desactivando…' : 'Desactivar'}
+                              </button>
+                            </td>
+                          </tr>
+                        ))
+                    }
+                  </tbody>
+                </table>
+                <Pagination total={coupons?.length ?? 0} page={couponsPage} onPage={setCouponsPage} />
               </div>
             </div>
           )}

--- a/frontend/src/pages/Checkout.tsx
+++ b/frontend/src/pages/Checkout.tsx
@@ -5,6 +5,7 @@ import { Elements, PaymentElement, useElements, useStripe } from '@stripe/react-
 import { loadStripe } from '@stripe/stripe-js';
 import { checkoutService } from '../services/checkout.service';
 import { ordersService } from '../services/orders.service';
+import { couponService } from '../services/coupon.service';
 import { useCartStore } from '../store/cart.store';
 import { useAddresses, useCreateAddress } from '../hooks/useAddresses';
 
@@ -126,6 +127,11 @@ export default function Checkout() {
   const [isCreatingIntent, setIsCreatingIntent] = useState(false);
   const [isConfirmingTestPayment, setIsConfirmingTestPayment] = useState(false);
   const [selectedAddressId, setSelectedAddressId] = useState<string | null>(null);
+  const [couponInput, setCouponInput] = useState('');
+  const [appliedCoupon, setAppliedCoupon] = useState<{ code: string; discountAmount: number } | null>(null);
+  const [couponError, setCouponError] = useState<string | null>(null);
+  const [isValidatingCoupon, setIsValidatingCoupon] = useState(false);
+  const [serverDiscount, setServerDiscount] = useState(0);
   const createdSignatureRef = useRef<string | null>(null);
 
   const { data: addresses } = useAddresses();
@@ -145,6 +151,7 @@ export default function Checkout() {
   const cartSignature = [
     cartPayload.map((item) => `${item.productId}:${item.quantity}`).sort().join('|'),
     selectedAddressId ?? '',
+    appliedCoupon?.code ?? '',
   ].join('::');
 
   useEffect(() => {
@@ -159,10 +166,21 @@ export default function Checkout() {
       try {
         const token = await getToken();
         if (!token) throw new Error('No autenticado');
-        const response = await checkoutService.createPaymentIntent(cartPayload, token, selectedAddressId ?? undefined);
+        const response = await checkoutService.createPaymentIntent(
+          cartPayload,
+          token,
+          selectedAddressId ?? undefined,
+          appliedCoupon?.code,
+        );
         setClientSecret(response.clientSecret);
         setPaymentIntentId(response.paymentIntentId ?? null);
         setServerAmount(response.amount);
+        setServerDiscount(response.discountAmount ?? 0);
+
+        if (response.couponWarning) {
+          setCouponError(response.couponWarning);
+          setAppliedCoupon(null);
+        }
       } catch (err: any) {
         createdSignatureRef.current = null;
         setError(err.message || 'No pudimos preparar el pago.');
@@ -172,7 +190,40 @@ export default function Checkout() {
     };
 
     createIntent();
-  }, [cartPayload, cartSignature, getToken, isLoaded, isSignedIn, selectedAddressId]);
+  }, [cartPayload, cartSignature, getToken, isLoaded, isSignedIn, selectedAddressId, appliedCoupon]);
+
+  const handleApplyCoupon = async () => {
+    const code = couponInput.trim();
+    if (!code) return;
+
+    setIsValidatingCoupon(true);
+    setCouponError(null);
+
+    try {
+      const token = await getToken();
+      if (!token) throw new Error('No autenticado');
+      const result = await couponService.validateCoupon(code, clientSubtotal, token);
+
+      if (result.valid) {
+        setAppliedCoupon({ code: code.toUpperCase(), discountAmount: result.discountAmount });
+        setCouponInput('');
+      } else {
+        setCouponError(result.reason || 'Cupón inválido.');
+      }
+    } catch (err) {
+      const axiosMessage = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      const message = err instanceof Error ? err.message : undefined;
+      setCouponError(axiosMessage || message || 'No pudimos validar el cupón.');
+    } finally {
+      setIsValidatingCoupon(false);
+    }
+  };
+
+  const handleRemoveCoupon = () => {
+    setAppliedCoupon(null);
+    setCouponError(null);
+    setServerDiscount(0);
+  };
 
   const handleTestPayment = async () => {
     if (!paymentIntentId) return;
@@ -343,9 +394,51 @@ export default function Checkout() {
                 </div>
               ))}
             </div>
-            <div style={{ borderTop: '1px solid var(--line)', marginTop: '1rem', paddingTop: '1rem', display: 'flex', justifyContent: 'space-between' }}>
-              <strong>Total</strong>
-              <strong>${(serverAmount ?? clientSubtotal).toFixed(2)}</strong>
+            <div style={{ borderTop: '1px solid var(--line)', marginTop: '1rem', paddingTop: '1rem', display: 'flex', flexDirection: 'column', gap: '0.6rem' }}>
+              <label style={{ display: 'block', fontSize: '0.72rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.8px', color: 'var(--ink3)' }}>
+                Cupón de descuento
+              </label>
+              {appliedCoupon ? (
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.5rem' }}>
+                  <span style={{ fontSize: '0.85rem' }}>
+                    <strong>{appliedCoupon.code}</strong> aplicado
+                  </span>
+                  <button type="button" className="btn-outline" style={{ padding: '4px 10px', fontSize: '0.75rem' }} onClick={handleRemoveCoupon}>
+                    Quitar
+                  </button>
+                </div>
+              ) : (
+                <div style={{ display: 'flex', gap: '0.5rem' }}>
+                  <input
+                    className="input"
+                    placeholder="Código de cupón"
+                    value={couponInput}
+                    onChange={(e) => setCouponInput(e.target.value)}
+                    style={{ flex: 1 }}
+                  />
+                  <button
+                    type="button"
+                    className="btn-outline"
+                    onClick={handleApplyCoupon}
+                    disabled={isValidatingCoupon || !couponInput.trim()}
+                  >
+                    {isValidatingCoupon ? 'Validando...' : 'Aplicar'}
+                  </button>
+                </div>
+              )}
+              {couponError && <div className="alert alert-error" style={{ fontSize: '0.8rem' }}>{couponError}</div>}
+            </div>
+            <div style={{ borderTop: '1px solid var(--line)', marginTop: '1rem', paddingTop: '1rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+              {serverDiscount > 0 && (
+                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.85rem', color: '#2e7d32' }}>
+                  <span>Descuento{appliedCoupon ? ` (${appliedCoupon.code})` : ''}</span>
+                  <span>-${serverDiscount.toFixed(2)}</span>
+                </div>
+              )}
+              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <strong>Total</strong>
+                <strong>${(serverAmount ?? clientSubtotal).toFixed(2)}</strong>
+              </div>
             </div>
             <p style={{ marginTop: '0.75rem', color: 'var(--ink2)', fontSize: '0.78rem', lineHeight: 1.5 }}>
               El total final se recalcula en el servidor con precios y stock actuales.

--- a/frontend/src/services/checkout.service.ts
+++ b/frontend/src/services/checkout.service.ts
@@ -5,6 +5,9 @@ export interface CreatePaymentIntentResponse {
   paymentIntentId?: string;
   orderId: string;
   amount: number;
+  discountAmount?: number;
+  couponCode?: string;
+  couponWarning?: string;
 }
 
 export const checkoutService = {
@@ -12,6 +15,7 @@ export const checkoutService = {
     items: { productId: string; quantity: number }[],
     token: string,
     addressId?: string,
+    couponCode?: string,
   ): Promise<CreatePaymentIntentResponse> => {
     const response = await fetch(`${API_URL}/checkout`, {
       method: 'POST',
@@ -19,7 +23,11 @@ export const checkoutService = {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify({ items, ...(addressId ? { addressId } : {}) }),
+      body: JSON.stringify({
+        items,
+        ...(addressId ? { addressId } : {}),
+        ...(couponCode ? { couponCode } : {}),
+      }),
     });
 
     if (!response.ok) {

--- a/frontend/src/services/coupon.service.ts
+++ b/frontend/src/services/coupon.service.ts
@@ -1,0 +1,44 @@
+import axios from 'axios';
+import type { Coupon, CouponValidationResult } from '../types/coupon';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
+
+export const couponService = {
+  validateCoupon: async (code: string, subtotal: number, token: string): Promise<CouponValidationResult> => {
+    const response = await axios.post(
+      `${API_URL}/coupons/validate`,
+      { code, subtotal },
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    return response.data;
+  },
+  getCoupons: async (token: string): Promise<Coupon[]> => {
+    const response = await axios.get(`${API_URL}/coupons`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.data;
+  },
+  createCoupon: async (
+    data: {
+      code: string;
+      discountType: 'percentage' | 'fixed';
+      discountValue: number;
+      validFrom: string;
+      validUntil: string;
+      minPurchase?: number;
+      maxUses?: number;
+    },
+    token: string,
+  ): Promise<Coupon> => {
+    const response = await axios.post(`${API_URL}/coupons`, data, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.data;
+  },
+  deactivateCoupon: async (id: string, token: string): Promise<Coupon> => {
+    const response = await axios.patch(`${API_URL}/coupons/${id}/deactivate`, {}, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.data;
+  },
+};

--- a/frontend/src/types/coupon.ts
+++ b/frontend/src/types/coupon.ts
@@ -1,0 +1,20 @@
+export interface Coupon {
+  _id: string;
+  code: string;
+  discountType: 'percentage' | 'fixed';
+  discountValue: number;
+  validFrom: string;
+  validUntil: string;
+  active: boolean;
+  minPurchase: number;
+  maxUses?: number;
+  usedCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CouponValidationResult {
+  valid: boolean;
+  reason?: string;
+  discountAmount: number;
+}


### PR DESCRIPTION
Closes #148

### Cambios

**Backend**
- Nuevo modelo `Coupon` (`code` único, `discountType: percentage|fixed`, `discountValue`, `validFrom`/`validUntil`, `active`, `minPurchase`, `maxUses` opcional, `usedCount`).
- `lib/coupons.ts`: función pura `resolveCouponDiscount` que valida vigencia, monto mínimo y usos disponibles y calcula el descuento — testeable sin DB (11 tests).
- `controllers/coupon.controller.ts` + `routes/coupon.routes.ts` montado en `/api/coupons`:
  - `POST /` y `GET /` (admin) — crear/listar cupones.
  - `PATCH /:id/deactivate` (admin) — desactivar.
  - `POST /validate` (usuario autenticado) — valida un código contra un subtotal y devuelve un preview del descuento, sin tocar el checkout.
- `checkout.controller.ts`: acepta `couponCode` opcional, resuelve el descuento **antes** de bifurcar en el flujo E2E/real (para que ambos caminos y el total guardado coincidan), y lo resta del subtotal recalculado server-side. Un cupón inválido/expirado **no bloquea el checkout**: se ignora y se devuelve `couponWarning` para que el frontend lo informe sin dejar el pago sin PaymentIntent.
- `Order` ahora guarda `coupon_code` y `discount_amount` (snapshot, no referencia viva) para trazabilidad.
- `order.service.ts`: `usedCount` del cupón se incrementa solo al confirmarse el pago (`finalizePaidOrder`, rama no-ya-pagado), con un `findOneAndUpdate` atómico condicionado a `usedCount < maxUses` para evitar sobre-conteo por carreras o reintentos de checkout abandonados.

**Frontend**
- `Checkout.tsx`: input de cupón en el resumen con botón "Aplicar" que llama a `/coupons/validate` antes de comprometerse (evita que un cupón inválido trabe el formulario de pago ya renderizado); el código aplicado entra a la firma que dispara la recreación del PaymentIntent, y el total/descuento mostrados vienen siempre de la respuesta del servidor, nunca calculados en el cliente.
- Nueva sección "Cupones" en `AdminDashboard.tsx` (mismo patrón que Técnicos): formulario de creación + tabla con estado/usos + acción "Desactivar".

### Verificación
- `bun test`: 147 pass, 0 fail (incluye 11 tests de `resolveCouponDiscount`, tests de validators y de controller con el patrón de mocks establecido).
- `npm run build` (frontend): OK. `npm run lint`: no se introdujeron errores nuevos (verificado línea por línea contra `develop`; los errores preexistentes de `no-explicit-any` en Checkout.tsx/AdminDashboard.tsx no fueron tocados).
- Verificación manual end-to-end contra un Mongo desechable en `E2E_TEST_MODE`: creación de cupón admin, rechazo de código duplicado (409) y de creación por no-admin (403), validación de cupón (10% y monto fijo), checkout con/sin cupón recalculando el total server-side, cupón inválido degradando con aviso sin bloquear, confirmación de pago con `usedCount` incrementando de 0→1, y desactivación de cupón volviéndolo inválido para `/validate`.
- UI no verificada visualmente en navegador (sin herramienta de navegador disponible en esta sesión); sí verificado por build + tipos + flujo de red simulado.

### Criterios de aceptación
- [x] El sistema permite crear cupones con vigencia y reglas (fechas, monto mínimo, usos máximos).
- [x] El checkout valida y aplica cupones válidos.
- [x] El backend recalcula el total final aplicando el descuento correcto (nunca confía en el subtotal del cliente).