### PR TITLE
HU-41: Un sistema de tickets o soporte

### DIFF
--- a/backend/src/controllers/support.controller.test.ts
+++ b/backend/src/controllers/support.controller.test.ts
@@ -1,16 +1,24 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
-import { createSupportTicket } from './support.controller';
+import {
+  createSupportTicket,
+  getMySupportTickets,
+  getAllSupportTickets,
+  updateSupportTicketStatus,
+} from './support.controller';
 import { SupportTicket } from '../models/SupportTicket';
+import { User } from '../models/User';
 
-function createContext(body: Record<string, unknown>, userId?: string) {
+function createContext(options: { body?: Record<string, unknown>; userId?: string; param?: string; validData?: Record<string, unknown> } = {}) {
   let statusCode = 200;
   let payload: unknown;
 
   const context = {
     req: {
-      json: async () => body,
+      json: async () => options.body ?? {},
+      valid: (_key: string) => options.validData ?? {},
+      param: (_key: string) => options.param,
     },
-    get: (key: string) => (key === 'userId' ? userId : undefined),
+    get: (key: string) => (key === 'userId' ? options.userId : undefined),
     json: (value: unknown, status?: number) => {
       payload = value;
       statusCode = status ?? 200;
@@ -42,15 +50,16 @@ describe('createSupportTicket controller', () => {
       }),
     );
     SupportTicket.create = createTicket as typeof SupportTicket.create;
+    User.findOne = mock(() => Promise.resolve(null)) as typeof User.findOne;
 
-    const harness = createContext(
-      {
+    const harness = createContext({
+      body: {
         category: 'payments',
         description: 'Necesito ayuda con un cobro duplicado.',
         contactChannel: 'email',
       },
-      'user_123',
-    );
+      userId: 'user_123',
+    });
 
     await createSupportTicket(harness.context as never);
 
@@ -70,9 +79,11 @@ describe('createSupportTicket controller', () => {
 
   test('returns 401 when userId is missing from auth context', async () => {
     const harness = createContext({
-      category: 'payments',
-      description: 'Necesito ayuda con un cobro duplicado.',
-      contactChannel: 'email',
+      body: {
+        category: 'payments',
+        description: 'Necesito ayuda con un cobro duplicado.',
+        contactChannel: 'email',
+      },
     });
 
     await createSupportTicket(harness.context as never);
@@ -81,5 +92,63 @@ describe('createSupportTicket controller', () => {
     expect(harness.payload).toEqual({
       error: 'Unauthorized: User ID not found in context',
     });
+  });
+});
+
+describe('getMySupportTickets controller', () => {
+  test('returns the tickets belonging to the authenticated user', async () => {
+    const sort = mock(() => Promise.resolve([{ _id: 'ticket_1', status: 'open' }]));
+    SupportTicket.find = mock(() => ({ sort })) as unknown as typeof SupportTicket.find;
+
+    const harness = createContext({ userId: 'user_123' });
+    await getMySupportTickets(harness.context as never);
+
+    expect(harness.statusCode).toBe(200);
+    expect(harness.payload).toEqual([{ _id: 'ticket_1', status: 'open' }]);
+  });
+
+  test('returns 401 when userId is missing', async () => {
+    const harness = createContext({});
+    await getMySupportTickets(harness.context as never);
+
+    expect(harness.statusCode).toBe(401);
+  });
+});
+
+describe('getAllSupportTickets controller', () => {
+  test('returns all tickets sorted by creation date', async () => {
+    const sort = mock(() => Promise.resolve([{ _id: 'ticket_1' }, { _id: 'ticket_2' }]));
+    SupportTicket.find = mock(() => ({ sort })) as unknown as typeof SupportTicket.find;
+
+    const harness = createContext({});
+    await getAllSupportTickets(harness.context as never);
+
+    expect(harness.statusCode).toBe(200);
+    expect(harness.payload).toEqual([{ _id: 'ticket_1' }, { _id: 'ticket_2' }]);
+  });
+});
+
+describe('updateSupportTicketStatus controller', () => {
+  test('updates the status and notifies the owner when it changed', async () => {
+    const save = mock(() => Promise.resolve());
+    SupportTicket.findById = mock(() =>
+      Promise.resolve({ _id: 'ticket_1', userId: 'user_123', status: 'open', save }),
+    ) as typeof SupportTicket.findById;
+    User.findOne = mock(() => Promise.resolve({ email: 'user@safetech.test' })) as typeof User.findOne;
+
+    const harness = createContext({ param: 'ticket_1', validData: { status: 'in_review' } });
+    await updateSupportTicketStatus(harness.context as never);
+
+    expect(harness.statusCode).toBe(200);
+    expect(save).toHaveBeenCalled();
+  });
+
+  test('returns 404 when the ticket does not exist', async () => {
+    SupportTicket.findById = mock(() => Promise.resolve(null)) as typeof SupportTicket.findById;
+
+    const harness = createContext({ param: 'missing', validData: { status: 'closed' } });
+    await updateSupportTicketStatus(harness.context as never);
+
+    expect(harness.statusCode).toBe(404);
   });
 });

--- a/backend/src/controllers/support.controller.ts
+++ b/backend/src/controllers/support.controller.ts
@@ -1,5 +1,7 @@
 import { type Context } from 'hono';
 import { SupportTicket } from '../models/SupportTicket';
+import { User } from '../models/User';
+import { sendSupportTicketCreatedEmail, sendSupportTicketStatusChangedEmail } from '../services/email.service';
 
 export const createSupportTicket = async (c: Context) => {
   try {
@@ -19,6 +21,11 @@ export const createSupportTicket = async (c: Context) => {
       status: 'open',
     });
 
+    const reporter = await User.findOne({ clerk_id: userId });
+    if (reporter?.email) {
+      await sendSupportTicketCreatedEmail(reporter.email, ticket);
+    }
+
     return c.json(
       {
         ticketId: String(ticket._id),
@@ -29,5 +36,59 @@ export const createSupportTicket = async (c: Context) => {
   } catch (error: any) {
     console.error('[Support Ticket Error]:', error);
     return c.json({ error: error.message }, 400);
+  }
+};
+
+export const getMySupportTickets = async (c: Context) => {
+  try {
+    const userId = c.get('userId');
+
+    if (!userId) {
+      return c.json({ error: 'Unauthorized: User ID not found in context' }, 401);
+    }
+
+    const tickets = await SupportTicket.find({ userId }).sort({ createdAt: -1 });
+    return c.json(tickets);
+  } catch (error: any) {
+    console.error('[Support Ticket Error]:', error);
+    return c.json({ error: 'Failed to fetch support tickets' }, 500);
+  }
+};
+
+export const getAllSupportTickets = async (c: Context) => {
+  try {
+    const tickets = await SupportTicket.find().sort({ createdAt: -1 });
+    return c.json(tickets);
+  } catch (error: any) {
+    console.error('[Support Ticket Error]:', error);
+    return c.json({ error: 'Failed to fetch support tickets' }, 500);
+  }
+};
+
+export const updateSupportTicketStatus = async (c: Context) => {
+  try {
+    const id = c.req.param('id');
+    const { status } = c.req.valid('json' as any) as { status: 'open' | 'in_review' | 'closed' };
+
+    const ticket = await SupportTicket.findById(id);
+    if (!ticket) {
+      return c.json({ error: 'Ticket not found' }, 404);
+    }
+
+    const statusChanged = ticket.status !== status;
+    ticket.status = status;
+    await ticket.save();
+
+    if (statusChanged) {
+      const owner = await User.findOne({ clerk_id: ticket.userId });
+      if (owner?.email) {
+        await sendSupportTicketStatusChangedEmail(owner.email, ticket);
+      }
+    }
+
+    return c.json(ticket);
+  } catch (error: any) {
+    console.error('[Support Ticket Error]:', error);
+    return c.json({ error: 'Failed to update support ticket' }, 400);
   }
 };

--- a/backend/src/routes/support.routes.ts
+++ b/backend/src/routes/support.routes.ts
@@ -1,8 +1,8 @@
 import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
-import { createSupportTicket } from '../controllers/support.controller';
-import { clerkAuthMiddleware } from '../middlewares/auth.middleware';
-import { createSupportTicketSchema } from '../validators/support.validator';
+import { createSupportTicket, getMySupportTickets, getAllSupportTickets, updateSupportTicketStatus } from '../controllers/support.controller';
+import { clerkAuthMiddleware, adminAuthMiddleware } from '../middlewares/auth.middleware';
+import { createSupportTicketSchema, updateSupportTicketStatusSchema } from '../validators/support.validator';
 
 const supportRoutes = new Hono();
 
@@ -15,6 +15,21 @@ supportRoutes.post(
     }
   }),
   createSupportTicket,
+);
+
+supportRoutes.get('/mine', clerkAuthMiddleware, getMySupportTickets);
+
+supportRoutes.get('/', adminAuthMiddleware, getAllSupportTickets);
+
+supportRoutes.patch(
+  '/:id/status',
+  adminAuthMiddleware,
+  zValidator('json', updateSupportTicketStatusSchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  updateSupportTicketStatus,
 );
 
 export default supportRoutes;

--- a/backend/src/services/email.service.ts
+++ b/backend/src/services/email.service.ts
@@ -71,6 +71,12 @@ const WARRANTY_STATUS_LABEL: Record<string, string> = {
   refunded: 'Reembolsado',
 };
 
+const SUPPORT_STATUS_LABEL: Record<string, string> = {
+  open: 'Abierto',
+  in_review: 'En revisión',
+  closed: 'Cerrado',
+};
+
 export async function sendPurchaseConfirmationEmail(to: string, order: { _id: unknown; total_amount: number }): Promise<void> {
   await sendEmail(
     to,
@@ -108,6 +114,26 @@ export async function sendWarrantyStatusChangedEmail(
     to,
     `Actualizacion de tu garantia SafeTech (#${String(warranty._id).slice(-6)})`,
     `<p>El estado de tu garantia <strong>#${String(warranty._id).slice(-6)}</strong> cambio a: <strong>${label}</strong>.</p>`,
+  );
+}
+
+export async function sendSupportTicketCreatedEmail(to: string, ticket: { _id: unknown }): Promise<void> {
+  await sendEmail(
+    to,
+    `Recibimos tu ticket de soporte (#${String(ticket._id).slice(-6)})`,
+    `<p>Registramos tu ticket de soporte <strong>#${String(ticket._id).slice(-6)}</strong>. Te avisaremos por correo ante cualquier actualizacion.</p>`,
+  );
+}
+
+export async function sendSupportTicketStatusChangedEmail(
+  to: string,
+  ticket: { _id: unknown; status: string },
+): Promise<void> {
+  const label = SUPPORT_STATUS_LABEL[ticket.status] ?? ticket.status;
+  await sendEmail(
+    to,
+    `Actualizacion de tu ticket de soporte SafeTech (#${String(ticket._id).slice(-6)})`,
+    `<p>El estado de tu ticket de soporte <strong>#${String(ticket._id).slice(-6)}</strong> cambio a: <strong>${label}</strong>.</p>`,
   );
 }
 

--- a/backend/src/validators/support.validator.test.ts
+++ b/backend/src/validators/support.validator.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+import { createSupportTicketSchema, updateSupportTicketStatusSchema } from './support.validator';
+
+describe('createSupportTicketSchema', () => {
+  const valid = {
+    category: 'payments',
+    description: 'Necesito ayuda con un cobro duplicado.',
+    contactChannel: 'email',
+  };
+
+  test('accepts a valid payload', () => {
+    expect(createSupportTicketSchema.safeParse(valid).success).toBe(true);
+  });
+
+  test('rejects an empty category', () => {
+    expect(createSupportTicketSchema.safeParse({ ...valid, category: '' }).success).toBe(false);
+  });
+
+  test('rejects a description shorter than 10 characters', () => {
+    expect(createSupportTicketSchema.safeParse({ ...valid, description: 'muy corta' }).success).toBe(false);
+  });
+
+  test('rejects an empty contactChannel', () => {
+    expect(createSupportTicketSchema.safeParse({ ...valid, contactChannel: '' }).success).toBe(false);
+  });
+});
+
+describe('updateSupportTicketStatusSchema', () => {
+  test('accepts a valid status', () => {
+    expect(updateSupportTicketStatusSchema.safeParse({ status: 'in_review' }).success).toBe(true);
+  });
+
+  test('rejects an invalid status', () => {
+    expect(updateSupportTicketStatusSchema.safeParse({ status: 'archived' }).success).toBe(false);
+  });
+
+  test('rejects a missing status', () => {
+    expect(updateSupportTicketStatusSchema.safeParse({}).success).toBe(false);
+  });
+});

--- a/backend/src/validators/support.validator.ts
+++ b/backend/src/validators/support.validator.ts
@@ -5,3 +5,7 @@ export const createSupportTicketSchema = z.object({
   description: z.string().trim().min(10, 'La descripcion debe tener al menos 10 caracteres'),
   contactChannel: z.string().trim().min(1, 'Debe indicar un canal de contacto'),
 });
+
+export const updateSupportTicketStatusSchema = z.object({
+  status: z.enum(['open', 'in_review', 'closed']),
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import Nosotros from './pages/Nosotros';
 import Contacto from './pages/Contacto';
 import MyWarranties from './pages/MyWarranties';
 import Wishlist from './pages/Wishlist';
+import Support from './pages/Support';
 import { ProtectedAdminRoute, ProtectedTechnicianRoute } from './components/AdminRoute';
 import TechnicianDashboard from './pages/TechnicianDashboard';
 
@@ -60,6 +61,10 @@ function App() {
           <Route
             path="/mis-garantias"
             element={<WithNav><MyWarranties /></WithNav>}
+          />
+          <Route
+            path="/soporte"
+            element={<WithNav><Support /></WithNav>}
           />
           <Route
             path="/warranties/new"

--- a/frontend/src/components/AdminSidebar.tsx
+++ b/frontend/src/components/AdminSidebar.tsx
@@ -37,6 +37,11 @@ const CouponIcon = () => (
     <path strokeLinecap="round" strokeLinejoin="round" d="M9 8.25H7.5a2.25 2.25 0 00-2.25 2.25v7.5a2.25 2.25 0 002.25 2.25h9a2.25 2.25 0 002.25-2.25v-7.5a2.25 2.25 0 00-2.25-2.25H15m-6 0V6a3 3 0 116 0v2.25m-6 0h6" />
   </svg>
 );
+const SupportIcon = () => (
+  <svg fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm7.5 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z" />
+  </svg>
+);
 const BackIcon = () => (
   <svg fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
     <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
@@ -58,6 +63,7 @@ const navSections = [
       { id: 'products',     label: 'Productos',  icon: <ProductsIcon /> },
       { id: 'technicians',  label: 'Técnicos',   icon: <TechnicianIcon /> },
       { id: 'coupons',      label: 'Cupones',    icon: <CouponIcon /> },
+      { id: 'support',      label: 'Soporte',    icon: <SupportIcon /> },
     ],
   },
 ];

--- a/frontend/src/components/ui/menu-hover-effects.tsx
+++ b/frontend/src/components/ui/menu-hover-effects.tsx
@@ -6,6 +6,7 @@ const menuItems = [
   { label: 'Catálogo',  href: '/home' },
   { label: 'Pedidos',      href: '/orders' },
   { label: 'Garantías',   href: '/mis-garantias' },
+  { label: 'Soporte',    href: '/soporte' },
   { label: 'Nosotros',  href: '/nosotros' },
   { label: 'Contacto',  href: '/contacto' },
 ];

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -5,10 +5,12 @@ import { warrantyService } from '../services/warranty.service';
 import { ordersService } from '../services/orders.service';
 import { technicianService } from '../services/technician.service';
 import { couponService } from '../services/coupon.service';
+import { supportTicketService } from '../services/supportTicket.service';
 import type { IWarranty } from '../types/warranty';
 import type { Order } from '../types/order';
 import type { Technician } from '../types/technician';
 import type { Coupon } from '../types/coupon';
+import type { SupportTicket } from '../types/supportTicket';
 import { useState } from 'react';
 import AdminSidebar from '../components/AdminSidebar';
 import StatsCards from '../components/StatsCards';
@@ -17,7 +19,7 @@ import ProductTable from '../components/ProductTable';
 import { Badge } from '../components/ui/Badge';
 import { SkeletonTableRow } from '../components/ui/Skeleton';
 
-type SectionType = 'dashboard' | 'orders' | 'warranties' | 'products' | 'technicians' | 'coupons';
+type SectionType = 'dashboard' | 'orders' | 'warranties' | 'products' | 'technicians' | 'coupons' | 'support';
 
 const PAGE_SIZE = 10;
 
@@ -31,6 +33,9 @@ const statusVariant: Record<string, 'success' | 'warning' | 'error' | 'neutral'>
   processing: 'neutral',
   shipped:    'neutral',
   delivered:  'success',
+  open:       'warning',
+  in_review:  'neutral',
+  closed:     'success',
 };
 const statusLabel: Record<string, string> = {
   paid:       'Pagado',
@@ -42,6 +47,9 @@ const statusLabel: Record<string, string> = {
   processing: 'En preparación',
   shipped:    'Enviado',
   delivered:  'Entregado',
+  open:       'Abierto',
+  in_review:  'En revisión',
+  closed:     'Cerrado',
 };
 
 const formatDate = (d: string | Date) =>
@@ -345,6 +353,7 @@ export default function AdminDashboard() {
   const [warrantiesPage, setWarrantiesPage] = useState(1);
   const [techniciansPage, setTechniciansPage] = useState(1);
   const [couponsPage, setCouponsPage] = useState(1);
+  const [supportPage, setSupportPage] = useState(1);
   const queryClient = useQueryClient();
 
   const { data: orders, isLoading: ordersLoading } = useQuery<Order[]>({
@@ -440,6 +449,25 @@ export default function AdminDashboard() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['coupons'] }),
   });
 
+  const { data: supportTickets, isLoading: supportTicketsLoading } = useQuery<SupportTicket[]>({
+    queryKey: ['admin-support-tickets'],
+    queryFn: async () => {
+      const token = await getToken();
+      if (!token) throw new Error('No token');
+      return supportTicketService.getAllTickets(token);
+    },
+    enabled: isLoaded,
+  });
+
+  const updateTicketStatusMutation = useMutation({
+    mutationFn: async ({ id, status }: { id: string; status: 'open' | 'in_review' | 'closed' }) => {
+      const token = await getToken();
+      if (!token) throw new Error('No token');
+      return supportTicketService.updateTicketStatus(id, status, token);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['admin-support-tickets'] }),
+  });
+
   const updateShippingMutation = useMutation({
     mutationFn: async ({ orderId, data }: { orderId: string; data: { status?: 'processing' | 'shipped' | 'delivered'; carrier?: string; trackingNumber?: string } }) => {
       const token = await getToken();
@@ -467,13 +495,15 @@ export default function AdminDashboard() {
     setWarrantiesPage(1);
     setTechniciansPage(1);
     setCouponsPage(1);
+    setSupportPage(1);
     setSidebarOpen(false);
   };
 
-  const pagedOrders      = (orders      ?? []).slice((ordersPage - 1)      * PAGE_SIZE, ordersPage      * PAGE_SIZE);
-  const pagedWarranties  = (warranties  ?? []).slice((warrantiesPage - 1)  * PAGE_SIZE, warrantiesPage  * PAGE_SIZE);
-  const pagedTechnicians = (technicians ?? []).slice((techniciansPage - 1) * PAGE_SIZE, techniciansPage * PAGE_SIZE);
-  const pagedCoupons     = (coupons     ?? []).slice((couponsPage - 1)     * PAGE_SIZE, couponsPage     * PAGE_SIZE);
+  const pagedOrders         = (orders         ?? []).slice((ordersPage - 1)         * PAGE_SIZE, ordersPage         * PAGE_SIZE);
+  const pagedWarranties     = (warranties     ?? []).slice((warrantiesPage - 1)     * PAGE_SIZE, warrantiesPage     * PAGE_SIZE);
+  const pagedTechnicians    = (technicians    ?? []).slice((techniciansPage - 1)    * PAGE_SIZE, techniciansPage    * PAGE_SIZE);
+  const pagedCoupons        = (coupons        ?? []).slice((couponsPage - 1)        * PAGE_SIZE, couponsPage        * PAGE_SIZE);
+  const pagedSupportTickets = (supportTickets ?? []).slice((supportPage - 1)        * PAGE_SIZE, supportPage        * PAGE_SIZE);
 
   return (
     <div style={{ display: 'flex', minHeight: '100vh', background: 'var(--cream)' }}>
@@ -925,6 +955,71 @@ export default function AdminDashboard() {
                   </tbody>
                 </table>
                 <Pagination total={coupons?.length ?? 0} page={couponsPage} onPage={setCouponsPage} />
+              </div>
+            </div>
+          )}
+
+          {/* ══ SOPORTE ══ */}
+          {activeSection === 'support' && (
+            <div style={{ animation: 'fadeIn 0.3s ease both' }}>
+              <SectionHeader title="Tickets de soporte" count={supportTickets?.length} />
+              <div className="admin-table-wrapper">
+                <table className="admin-table">
+                  <thead>
+                    <tr>
+                      <th>Fecha</th>
+                      <th>Usuario</th>
+                      <th>Categoría</th>
+                      <th>Descripción</th>
+                      <th>Contacto</th>
+                      <th>Estado</th>
+                      <th className="actions">Acciones</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {supportTicketsLoading
+                      ? Array.from({ length: 6 }).map((_, i) => <SkeletonTableRow key={i} cols={7} />)
+                      : pagedSupportTickets.length === 0
+                        ? (
+                          <tr>
+                            <td colSpan={7} style={{ padding: '3rem', textAlign: 'center', color: 'var(--ink3)', fontSize: '0.9rem' }}>
+                              No hay tickets de soporte registrados.
+                            </td>
+                          </tr>
+                        )
+                        : pagedSupportTickets.map((ticket) => (
+                          <tr key={ticket._id}>
+                            <td style={{ fontWeight: 500 }}>{formatDate(ticket.createdAt)}</td>
+                            <td style={{ color: 'var(--ink2)', fontSize: '0.85rem' }}>{ticket.userId}</td>
+                            <td style={{ color: 'var(--ink2)', fontSize: '0.85rem' }}>{ticket.category}</td>
+                            <td style={{ maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={ticket.description}>
+                              {ticket.description}
+                            </td>
+                            <td style={{ color: 'var(--ink2)', fontSize: '0.85rem' }}>{ticket.contactChannel}</td>
+                            <td>
+                              <Badge variant={statusVariant[ticket.status] ?? 'neutral'}>
+                                {statusLabel[ticket.status] ?? ticket.status}
+                              </Badge>
+                            </td>
+                            <td className="actions">
+                              <select
+                                className="admin-select"
+                                value={ticket.status}
+                                onChange={(e) => updateTicketStatusMutation.mutate({ id: ticket._id, status: e.target.value as 'open' | 'in_review' | 'closed' })}
+                                disabled={updateTicketStatusMutation.isPending}
+                                style={{ minWidth: 140 }}
+                              >
+                                <option value="open">Abierto</option>
+                                <option value="in_review">En revisión</option>
+                                <option value="closed">Cerrado</option>
+                              </select>
+                            </td>
+                          </tr>
+                        ))
+                    }
+                  </tbody>
+                </table>
+                <Pagination total={supportTickets?.length ?? 0} page={supportPage} onPage={setSupportPage} />
               </div>
             </div>
           )}

--- a/frontend/src/pages/Support.tsx
+++ b/frontend/src/pages/Support.tsx
@@ -1,0 +1,222 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { SignInButton, useAuth } from '../lib/auth';
+import { supportTicketService } from '../services/supportTicket.service';
+import type { SupportTicket } from '../types/supportTicket';
+import { Badge } from '../components/ui/Badge';
+
+const statusVariant: Record<SupportTicket['status'], 'success' | 'warning' | 'neutral'> = {
+  open: 'warning',
+  in_review: 'neutral',
+  closed: 'success',
+};
+const statusLabel: Record<SupportTicket['status'], string> = {
+  open: 'Abierto',
+  in_review: 'En revisión',
+  closed: 'Cerrado',
+};
+
+const formatDate = (d: string) =>
+  new Date(d).toLocaleDateString('es-ES', { day: '2-digit', month: 'short', year: 'numeric' });
+
+export default function Support() {
+  const { getToken, isLoaded, isSignedIn } = useAuth();
+  const queryClient = useQueryClient();
+
+  const [category, setCategory] = useState('');
+  const [description, setDescription] = useState('');
+  const [contactChannel, setContactChannel] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+  const [lastTicketId, setLastTicketId] = useState<string | null>(null);
+
+  const { data: tickets, isLoading: ticketsLoading } = useQuery<SupportTicket[]>({
+    queryKey: ['my-support-tickets'],
+    queryFn: async () => {
+      const token = await getToken();
+      if (!token) throw new Error('No autenticado');
+      return supportTicketService.getMyTickets(token);
+    },
+    enabled: isLoaded && isSignedIn,
+  });
+
+  const createTicketMutation = useMutation({
+    mutationFn: async (data: { category: string; description: string; contactChannel: string }) => {
+      const token = await getToken();
+      if (!token) throw new Error('No autenticado');
+      return supportTicketService.createTicket(data, token);
+    },
+    onSuccess: (result) => {
+      setLastTicketId(result.ticketId);
+      setCategory('');
+      setDescription('');
+      setContactChannel('');
+      queryClient.invalidateQueries({ queryKey: ['my-support-tickets'] });
+    },
+    onError: (err: unknown) => {
+      const axiosMessage = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      const message = err instanceof Error ? err.message : undefined;
+      setFormError(axiosMessage || message || 'No pudimos crear el ticket.');
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError(null);
+    setLastTicketId(null);
+
+    if (!category.trim() || !description.trim() || !contactChannel.trim()) {
+      setFormError('Todos los campos son obligatorios.');
+      return;
+    }
+    if (description.trim().length < 10) {
+      setFormError('La descripción debe tener al menos 10 caracteres.');
+      return;
+    }
+
+    createTicketMutation.mutate({
+      category: category.trim(),
+      description: description.trim(),
+      contactChannel: contactChannel.trim(),
+    });
+  };
+
+  if (!isLoaded) {
+    return (
+      <div className="op-root">
+        <main className="op-body">
+          <div className="page-container">
+            <div className="op-empty">
+              <h3>Preparando soporte</h3>
+              <p>Validando tu sesión.</p>
+            </div>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  if (!isSignedIn) {
+    return (
+      <div className="op-root">
+        <main className="op-body">
+          <div className="page-container">
+            <div className="op-empty">
+              <h3>Debes iniciar sesión para contactar a soporte</h3>
+              <SignInButton mode="modal">
+                <button className="op-cta">Iniciar sesión</button>
+              </SignInButton>
+            </div>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  return (
+    <div className="op-root">
+      <header className="op-hero">
+        <div className="op-noise" />
+        <div className="op-diag" />
+        <div className="page-container op-hero-inner">
+          <div className="op-hero-text">
+            <p className="op-eyebrow">Ayuda de SafeTech</p>
+            <h1 className="op-title">
+              Centro de<br />
+              <em>soporte</em>
+            </h1>
+          </div>
+        </div>
+      </header>
+
+      <main className="op-body">
+        <div className="page-container" style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem', maxWidth: 720 }}>
+          <section className="oc-card" style={{ padding: '1.5rem' }}>
+            <h2 style={{ fontFamily: 'var(--font-display)', fontSize: '1rem', marginBottom: '1rem' }}>
+              Abrir un ticket
+            </h2>
+            <p style={{ color: 'var(--ink2)', fontSize: '0.85rem', marginBottom: '1.25rem' }}>
+              Para problemas que no encajen en una garantía o un pedido puntual.
+            </p>
+
+            <form onSubmit={handleSubmit} style={{ display: 'grid', gap: '0.75rem' }}>
+              <input
+                className="input"
+                placeholder="Categoría (ej: pagos, cuenta, envíos)"
+                value={category}
+                onChange={(e) => setCategory(e.target.value)}
+              />
+              <textarea
+                className="input"
+                placeholder="Describe el problema (mínimo 10 caracteres)"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={4}
+              />
+              <input
+                className="input"
+                placeholder="Canal de contacto preferido (email, teléfono, etc.)"
+                value={contactChannel}
+                onChange={(e) => setContactChannel(e.target.value)}
+              />
+
+              {formError && <div className="alert alert-error">{formError}</div>}
+              {lastTicketId && (
+                <div className="alert alert-success">
+                  Ticket creado: #{lastTicketId.slice(-6)}. Te avisaremos por correo ante cualquier actualización.
+                </div>
+              )}
+
+              <button
+                type="submit"
+                className="btn-primary"
+                disabled={createTicketMutation.isPending}
+                style={{ justifySelf: 'start', padding: '10px 22px' }}
+              >
+                {createTicketMutation.isPending ? 'Enviando…' : 'Enviar ticket'}
+              </button>
+            </form>
+          </section>
+
+          <section className="oc-card" style={{ padding: '1.5rem' }}>
+            <h2 style={{ fontFamily: 'var(--font-display)', fontSize: '1rem', marginBottom: '1rem' }}>
+              Mis tickets
+            </h2>
+
+            {ticketsLoading && <p style={{ color: 'var(--ink2)' }}>Cargando tickets...</p>}
+
+            {!ticketsLoading && (!tickets || tickets.length === 0) && (
+              <p style={{ color: 'var(--ink3)' }}>Todavía no abriste ningún ticket de soporte.</p>
+            )}
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+              {(tickets ?? []).map((ticket) => (
+                <div
+                  key={ticket._id}
+                  style={{
+                    border: '1px solid var(--line)',
+                    borderRadius: 'var(--radius-ui)',
+                    padding: '0.9rem 1rem',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '0.4rem',
+                  }}
+                >
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.75rem' }}>
+                    <strong style={{ fontSize: '0.85rem' }}>
+                      #{ticket._id.slice(-6)} · {ticket.category}
+                    </strong>
+                    <Badge variant={statusVariant[ticket.status]}>{statusLabel[ticket.status]}</Badge>
+                  </div>
+                  <p style={{ fontSize: '0.85rem', color: 'var(--ink2)', margin: 0 }}>{ticket.description}</p>
+                  <span style={{ fontSize: '0.75rem', color: 'var(--ink3)' }}>
+                    Abierto el {formatDate(ticket.createdAt)} · Contacto: {ticket.contactChannel}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/services/supportTicket.service.ts
+++ b/frontend/src/services/supportTicket.service.ts
@@ -1,0 +1,38 @@
+import axios from 'axios';
+import type { SupportTicket } from '../types/supportTicket';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
+
+export const supportTicketService = {
+  createTicket: async (
+    data: { category: string; description: string; contactChannel: string },
+    token: string,
+  ): Promise<{ ticketId: string; status: string }> => {
+    const response = await axios.post(`${API_URL}/support-tickets`, data, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.data;
+  },
+  getMyTickets: async (token: string): Promise<SupportTicket[]> => {
+    const response = await axios.get(`${API_URL}/support-tickets/mine`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.data;
+  },
+  getAllTickets: async (token: string): Promise<SupportTicket[]> => {
+    const response = await axios.get(`${API_URL}/support-tickets`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.data;
+  },
+  updateTicketStatus: async (
+    id: string,
+    status: 'open' | 'in_review' | 'closed',
+    token: string,
+  ): Promise<SupportTicket> => {
+    const response = await axios.patch(`${API_URL}/support-tickets/${id}/status`, { status }, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.data;
+  },
+};

--- a/frontend/src/types/supportTicket.ts
+++ b/frontend/src/types/supportTicket.ts
@@ -1,0 +1,10 @@
+export interface SupportTicket {
+  _id: string;
+  userId: string;
+  category: string;
+  description: string;
+  contactChannel: string;
+  status: 'open' | 'in_review' | 'closed';
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
Closes #150

### Cambios

Este ticket partía de un scaffold parcial ya existente en `develop` (`SupportTicket` model + `createSupportTicket` sin listar/gestionar). Esta PR completa el ciclo de vida.

**Backend**
- `support.controller.ts`: se agregan `getMySupportTickets` (`GET /support-tickets/mine`), `getAllSupportTickets` (`GET /support-tickets`, admin) y `updateSupportTicketStatus` (`PATCH /support-tickets/:id/status`, admin). Sin esto, "consultar el estado del ticket" solo podría mostrar siempre `open` — el ciclo de estados es necesario para que el criterio de aceptación tenga sentido, mismo razonamiento aplicado en HU-39/40.
- `createSupportTicket` ahora también envía un correo de confirmación (`sendSupportTicketCreatedEmail`), y el cambio de estado dispara `sendSupportTicketStatusChangedEmail` — mismo patrón ya establecido para garantías y órdenes.
- No se agregó una secuencia de "número de ticket": no existe ese patrón en ningún otro lado del repo (ni en `WarrantyReport`), así que se usa el `_id` de Mongo como identificador único, igual que garantías — visible en la UI como `#${_id.slice(-6)}`.
- Alcance deliberadamente menor que garantías: sin asignación a técnicos, sin adjuntar evidencia, sin campo de notas de resolución — nada de eso está en los criterios de aceptación.

**Frontend**
- Página nueva combinada `Support.tsx` en `/soporte`: formulario para abrir un ticket + lista de "mis tickets" con estado, en una sola página (en vez de replicar el wizard de 3 pasos + página separada que usa Garantías) — la superficie de datos de un ticket de soporte (3 campos) no lo justifica.
- Link "Soporte" agregado al menú de navegación.
- Nueva sección "Soporte" en el panel admin: tabla de tickets con selector de estado inline (mismo patrón que la asignación de técnico en Garantías).

### Verificación
- `bun test`: 165 pass, 0 fail. Se actualizó el test existente de `createSupportTicket` para mockear `User.findOne` (necesario tras agregar el envío de correo; sin el mock el test colgaba contra una DB no conectada — mismo problema que ya había aparecido en HU-40 con `updateShippingInfo`).
- `npm run build` (frontend): OK. `npm run lint`: sin errores nuevos.
- Verificación manual end-to-end contra Mongo desechable en `E2E_TEST_MODE`, incluyendo el recorrido completo del criterio 3 (no solo CRUD aislado): creación no autenticada (401) → usuario crea ticket → usuario lista y ve `open` → usuario no-admin intenta listar todos / cambiar estado (403 en ambos) → admin lista todos → admin cambia a `in_review` → **usuario vuelve a listar y ve `in_review` reflejado** → status inválido (400) → ticket inexistente (404).
- UI no verificada visualmente en navegador (sin herramienta de navegador disponible en esta sesión).

### Criterios de aceptación
- [x] El usuario puede abrir un ticket con categoría y descripción.
- [x] El sistema asigna un identificador único por ticket (`_id` de Mongo, mostrado como `#slice(-6)`).
- [x] El usuario puede consultar el estado del ticket, y ese estado refleja los cambios hechos por un admin.