### PR TITLE
feat: comparar varios productos lado a lado para HU-43

### DIFF
--- a/backend/src/controllers/product.controller.test.ts
+++ b/backend/src/controllers/product.controller.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
-import { deleteProduct } from './product.controller';
+import { deleteProduct, getProductsForComparison } from './product.controller';
 import { Product } from '../models/Product';
 
 function createContext(id = 'prod_1') {
@@ -9,6 +9,32 @@ function createContext(id = 'prod_1') {
   const context = {
     req: {
       param: () => id,
+    },
+    json: (value: unknown, status?: number) => {
+      payload = value;
+      statusCode = status ?? 200;
+      return { payload: value, status: statusCode };
+    },
+  };
+
+  return {
+    context,
+    get statusCode() {
+      return statusCode;
+    },
+    get payload() {
+      return payload;
+    },
+  };
+}
+
+function createQueryContext(query: Record<string, unknown>) {
+  let statusCode = 200;
+  let payload: unknown;
+
+  const context = {
+    req: {
+      valid: (_key: string) => query,
     },
     json: (value: unknown, status?: number) => {
       payload = value;
@@ -74,5 +100,41 @@ describe('deleteProduct controller', () => {
       success: false,
       message: 'Producto no encontrado',
     });
+  });
+});
+
+describe('getProductsForComparison controller', () => {
+  test('queries by the deduplicated list of ids and returns the matches', async () => {
+    const products = [
+      { _id: '507f1f77bcf86cd799439011', name: 'iPhone 13' },
+      { _id: '507f1f77bcf86cd799439012', name: 'Galaxy S22' },
+    ];
+
+    const find = mock(() => Promise.resolve(products));
+    Product.find = find as unknown as typeof Product.find;
+
+    const harness = createQueryContext({
+      ids: '507f1f77bcf86cd799439011,507f1f77bcf86cd799439012,507f1f77bcf86cd799439011',
+    });
+
+    await getProductsForComparison(harness.context as never);
+
+    expect(find).toHaveBeenCalledWith({
+      _id: { $in: ['507f1f77bcf86cd799439011', '507f1f77bcf86cd799439012'] },
+    });
+    expect(harness.statusCode).toBe(200);
+    expect(harness.payload).toEqual({ success: true, data: products });
+  });
+
+  test('returns a 500 when the lookup fails', async () => {
+    const find = mock(() => Promise.reject(new Error('db down')));
+    Product.find = find as unknown as typeof Product.find;
+
+    const harness = createQueryContext({ ids: '507f1f77bcf86cd799439011,507f1f77bcf86cd799439012' });
+
+    await getProductsForComparison(harness.context as never);
+
+    expect(harness.statusCode).toBe(500);
+    expect(harness.payload).toEqual({ success: false, message: 'db down' });
   });
 });

--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -60,6 +60,19 @@ export const getProducts = async (c: Context) => {
   }
 };
 
+export const getProductsForComparison = async (c: Context) => {
+  try {
+    const { ids } = c.req.valid('query' as any) as { ids: string };
+    const productIds = [...new Set(ids.split(',').map((id) => id.trim()).filter(Boolean))];
+
+    const products = await Product.find({ _id: { $in: productIds } });
+
+    return c.json({ success: true, data: products });
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};
+
 export const getProductById = async (c: Context) => {
   try {
     const id = c.req.param('id');

--- a/backend/src/routes/product.routes.ts
+++ b/backend/src/routes/product.routes.ts
@@ -8,11 +8,13 @@ import {
   getProductById,
   getProductInventoryMovements,
   getProducts,
+  getProductsForComparison,
   updateProduct,
 } from '../controllers/product.controller';
 import {
   createProductSchema,
   bestSellersQuerySchema,
+  compareQuerySchema,
   lowStockQuerySchema,
   productFilterSchema,
   updateProductSchema,
@@ -54,6 +56,18 @@ productRoutes.get(
     }
   }),
   getBestSellingProducts
+);
+
+// Productos a comparar lado a lado (HU-43). Registrada antes de '/:id' para
+// que "compare" no se interprete como un id.
+productRoutes.get(
+  '/compare',
+  zValidator('query', compareQuerySchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  getProductsForComparison
 );
 
 // Obtener un producto por ID

--- a/backend/src/validators/product.validator.test.ts
+++ b/backend/src/validators/product.validator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   bestSellersQuerySchema,
+  compareQuerySchema,
   createProductSchema,
   lowStockQuerySchema,
   productFilterSchema,
@@ -118,6 +119,36 @@ describe('bestSellersQuerySchema', () => {
 
   test('rejects a limit above 12', () => {
     const result = bestSellersQuerySchema.safeParse({ limit: '13' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('compareQuerySchema', () => {
+  test('accepts two to four valid ObjectIds', () => {
+    const result = compareQuerySchema.safeParse({
+      ids: '507f1f77bcf86cd799439011,507f1f77bcf86cd799439012',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects a single id', () => {
+    const result = compareQuerySchema.safeParse({ ids: '507f1f77bcf86cd799439011' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects more than four ids', () => {
+    const ids = Array.from({ length: 5 }, (_, i) => `507f1f77bcf86cd79943901${i}`).join(',');
+    const result = compareQuerySchema.safeParse({ ids });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects an invalid ObjectId in the list', () => {
+    const result = compareQuerySchema.safeParse({ ids: '507f1f77bcf86cd799439011,not-an-id' });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a missing ids param', () => {
+    const result = compareQuerySchema.safeParse({});
     expect(result.success).toBe(false);
   });
 });

--- a/backend/src/validators/product.validator.ts
+++ b/backend/src/validators/product.validator.ts
@@ -51,3 +51,23 @@ export const lowStockQuerySchema = z.object({
 export const bestSellersQuerySchema = z.object({
   limit: z.coerce.number().int().min(1, 'limit debe ser al menos 1').max(12, 'limit no puede superar 12').optional(),
 });
+
+const objectIdRegex = /^[0-9a-fA-F]{24}$/;
+
+// HU-43: ids llega como query string separado por comas (?ids=a,b,c). Se
+// valida en el propio schema (2 a 4 productos, todos ObjectId válidos) para
+// no duplicar esa lógica en el controller.
+export const compareQuerySchema = z
+  .object({
+    ids: z.string().min(1, 'Debe indicar los ids de los productos a comparar'),
+  })
+  .refine(
+    (data) => {
+      const ids = data.ids.split(',').map((id) => id.trim()).filter(Boolean);
+      return ids.length >= 2 && ids.length <= 4 && ids.every((id) => objectIdRegex.test(id));
+    },
+    {
+      message: 'Debe indicar entre 2 y 4 ids de producto válidos, separados por comas',
+      path: ['ids'],
+    }
+  );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import Nosotros from './pages/Nosotros';
 import Contacto from './pages/Contacto';
 import MyWarranties from './pages/MyWarranties';
 import Wishlist from './pages/Wishlist';
+import Compare from './pages/Compare';
 import Support from './pages/Support';
 import { ProtectedAdminRoute, ProtectedTechnicianRoute } from './components/AdminRoute';
 import TechnicianDashboard from './pages/TechnicianDashboard';
@@ -56,6 +57,12 @@ function App() {
             path="/wishlist"
             element={
               <WithNav><Wishlist /></WithNav>
+            }
+          />
+          <Route
+            path="/compare"
+            element={
+              <WithNav><Compare /></WithNav>
             }
           />
           <Route

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -6,6 +6,7 @@ import { CartDrawer } from "./CartDrawer";
 import { useCartStore } from "../store/cart.store";
 import { useAdminCheck } from "./AdminRoute";
 import { useWishlist } from "../hooks/useWishlist";
+import { useCompareStore } from "../store/compare.store";
 
 const CART_USER_KEY = 'safetech-cart-user';
 
@@ -14,6 +15,7 @@ export default function Header() {
   const clearCart = useCartStore(state => state.clearCart);
   const { isAdmin, loading } = useAdminCheck();
   const { data: wishlistItems } = useWishlist();
+  const compareCount = useCompareStore((s) => s.productIds.length);
 
   useEffect(() => {
     const storedUserId = localStorage.getItem(CART_USER_KEY);
@@ -45,6 +47,22 @@ export default function Header() {
                   fontFamily: 'var(--font-mono)',
                 }}>
                   {wishlistItems.length}
+                </span>
+              )}
+            </Link>
+            <Link to="/compare" className="nav-link" style={{ position: 'relative' }} title="Comparar productos">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M9 3v18M15 3v18M4 8h5m6 0h5M4 16h5m6 0h5" />
+              </svg>
+              {compareCount > 0 && (
+                <span style={{
+                  position: 'absolute', top: -4, right: -6,
+                  background: '#ef4444', color: '#fff', borderRadius: '50%',
+                  width: 15, height: 15, fontSize: '.55rem', fontWeight: 700,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  fontFamily: 'var(--font-mono)',
+                }}>
+                  {compareCount}
                 </span>
               )}
             </Link>

--- a/frontend/src/components/ProductList.tsx
+++ b/frontend/src/components/ProductList.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useProductsPaginated } from '../hooks/useProducts';
 import { useCartStore } from '../store/cart.store';
+import { useCompareStore, MAX_COMPARE_ITEMS } from '../store/compare.store';
 import { SkeletonCard } from './ui/Skeleton';
 import { EmptyState } from './ui/EmptyState';
 
@@ -212,6 +213,10 @@ interface ProductCardProps {
 const ProductCard: React.FC<ProductCardProps> = ({ product, onAdd, featured }) => {
   const [hovered, setHovered] = useState(false);
   const [imgLoaded, setImgLoaded] = useState(false);
+  const isComparing = useCompareStore((s) => s.productIds.includes(product._id));
+  const compareCount = useCompareStore((s) => s.productIds.length);
+  const toggleCompare = useCompareStore((s) => s.toggleProduct);
+  const compareDisabled = !isComparing && compareCount >= MAX_COMPARE_ITEMS;
 
   const badgeColor = product.condition === 'A' ? 'var(--ink)' : product.condition === 'B' ? '#D97706' : 'var(--line)';
   const badgeText = product.condition === 'A' ? 'var(--white)' : product.condition === 'B' ? 'var(--white)' : 'var(--ink2)';
@@ -296,6 +301,19 @@ const ProductCard: React.FC<ProductCardProps> = ({ product, onAdd, featured }) =
             <span style={{ width: 6, height: 6, borderRadius: '50%', background: isLowStock ? '#DC2626' : 'var(--gray)' }} />
             {isLowStock ? `Solo ${product.stock} disponibles` : `${product.stock} en stock`}
           </p>
+          <label
+            onClick={(e) => e.stopPropagation()}
+            style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: '0.75rem', fontSize: '0.72rem', color: 'var(--gray)', fontFamily: 'var(--font-sans)', cursor: compareDisabled ? 'not-allowed' : 'pointer', opacity: compareDisabled ? 0.5 : 1 }}
+          >
+            <input
+              type="checkbox"
+              checked={isComparing}
+              disabled={compareDisabled}
+              onChange={() => toggleCompare(product._id)}
+              onClick={(e) => e.stopPropagation()}
+            />
+            Comparar
+          </label>
           <button
             onClick={handleAddClick}
             disabled={product.stock === 0}

--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -25,3 +25,11 @@ export const useProduct = (id: string | undefined) => {
     enabled: Boolean(id),
   });
 };
+
+export const useProductsCompare = (ids: string[]) => {
+  return useQuery<Product[], Error>({
+    queryKey: ['products', 'compare', ids],
+    queryFn: () => productsService.compare(ids),
+    enabled: ids.length >= 2,
+  });
+};

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useCompareStore } from '../store/compare.store';
+import { useProductsCompare } from '../hooks/useProducts';
+import { SkeletonCard } from '../components/ui/Skeleton';
+import { EmptyState } from '../components/ui/EmptyState';
+import type { Product } from '../types/product';
+
+const CATEGORY_LABEL: Record<string, string> = {
+  celular: 'Celular',
+  laptop: 'Laptop',
+  pc: 'PC',
+  auriculares: 'Auriculares',
+  tablet: 'Tablet',
+};
+
+const CONDITION_LABEL: Record<string, string> = {
+  A: 'Excelente',
+  B: 'Buena',
+  C: 'Regular',
+};
+
+const fmt = (n: number) =>
+  `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const ROWS: { label: string; render: (p: Product) => React.ReactNode }[] = [
+  { label: 'Precio', render: (p) => fmt(p.price) },
+  { label: 'Condición', render: (p) => CONDITION_LABEL[p.condition] ?? p.condition },
+  { label: 'Categoría', render: (p) => CATEGORY_LABEL[p.category] ?? p.category },
+  { label: 'Stock', render: (p) => (p.stock > 0 ? `${p.stock} disponibles` : 'Agotado') },
+  { label: 'Descripción', render: (p) => p.description || '—' },
+];
+
+const Compare: React.FC = () => {
+  const productIds = useCompareStore((s) => s.productIds);
+  const removeProduct = useCompareStore((s) => s.removeProduct);
+  const clearCompare = useCompareStore((s) => s.clearCompare);
+
+  const { data: products, isLoading, isError, error } = useProductsCompare(productIds);
+
+  return (
+    <div className="page-container" style={{ padding: '3rem 2.5rem' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '2rem', flexWrap: 'wrap', gap: '1rem' }}>
+        <h1 style={{ fontFamily: 'var(--font-display)', fontSize: '1.75rem', fontWeight: 400, color: 'var(--ink)' }}>
+          Comparar productos
+        </h1>
+        {productIds.length > 0 && (
+          <button className="btn-outline" onClick={clearCompare} style={{ fontSize: '0.78rem', padding: '8px 16px' }}>
+            Vaciar comparación
+          </button>
+        )}
+      </div>
+
+      {productIds.length < 2 ? (
+        <EmptyState
+          icon={
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 3v18m6-18v18M4 8h5m6 0h5M4 16h5m6 0h5" />
+            </svg>
+          }
+          title="Selecciona al menos dos productos"
+          description="Agrega productos a la comparación desde el catálogo para ver sus diferencias lado a lado."
+          cta={
+            <Link to="/home" className="btn-outline" style={{ fontSize: '0.78rem', padding: '8px 16px', textDecoration: 'none' }}>
+              Ir al catálogo
+            </Link>
+          }
+        />
+      ) : isLoading ? (
+        <div className="products-grid">
+          {productIds.map((id) => <SkeletonCard key={id} />)}
+        </div>
+      ) : isError ? (
+        <EmptyState
+          icon={
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+            </svg>
+          }
+          title="Error al cargar la comparación"
+          description={error?.message || 'No pudimos cargar los productos seleccionados.'}
+        />
+      ) : (
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 560 }}>
+            <thead>
+              <tr>
+                <th style={{ textAlign: 'left', padding: '0.75rem', width: 140, borderBottom: '1px solid var(--line)' }} />
+                {products?.map((product) => (
+                  <th key={product._id} style={{ padding: '0.75rem', borderBottom: '1px solid var(--line)', minWidth: 200, verticalAlign: 'top' }}>
+                    <div style={{ position: 'relative' }}>
+                      <button
+                        onClick={() => removeProduct(product._id)}
+                        aria-label={`Quitar ${product.name} de la comparación`}
+                        style={{
+                          position: 'absolute', top: -8, right: -8, width: 22, height: 22, borderRadius: '50%',
+                          border: '1px solid var(--line)', background: 'var(--white)', cursor: 'pointer',
+                          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '0.7rem', color: 'var(--ink2)',
+                        }}
+                      >
+                        ×
+                      </button>
+                      <img
+                        src={product.image_urls?.[0] || `https://picsum.photos/seed/${product._id}/300/220`}
+                        alt={product.name}
+                        style={{ width: '100%', aspectRatio: '4/3', objectFit: 'cover', borderRadius: 'var(--radius-md)', marginBottom: '0.75rem' }}
+                      />
+                      <Link
+                        to={`/product/${product._id}`}
+                        style={{ fontFamily: 'var(--font-display)', fontSize: '0.9rem', fontWeight: 500, color: 'var(--ink)', textDecoration: 'none' }}
+                      >
+                        {product.name}
+                      </Link>
+                    </div>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {ROWS.map((row) => (
+                <tr key={row.label}>
+                  <td style={{ padding: '0.75rem', fontSize: '0.8rem', fontWeight: 600, color: 'var(--ink2)', borderBottom: '1px solid var(--line)' }}>
+                    {row.label}
+                  </td>
+                  {products?.map((product) => (
+                    <td key={product._id} style={{ padding: '0.75rem', fontSize: '0.85rem', color: 'var(--ink)', borderBottom: '1px solid var(--line)' }}>
+                      {row.render(product)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Compare;

--- a/frontend/src/pages/ProductDetail.tsx
+++ b/frontend/src/pages/ProductDetail.tsx
@@ -6,6 +6,7 @@ import { SkeletonCard } from '../components/ui/Skeleton';
 import { EmptyState } from '../components/ui/EmptyState';
 import { useWishlistCheck, useAddToWishlist, useRemoveFromWishlist } from '../hooks/useWishlist';
 import { useAuth } from '../lib/auth';
+import { useCompareStore, MAX_COMPARE_ITEMS } from '../store/compare.store';
 
 const CATEGORY_LABEL: Record<string, string> = {
   celular: 'Celular',
@@ -39,6 +40,11 @@ const ProductDetail: React.FC = () => {
   const { data: isWishlisted } = useWishlistCheck(id);
   const addWishlist = useAddToWishlist();
   const removeWishlist = useRemoveFromWishlist();
+
+  const isComparing = useCompareStore((s) => (id ? s.productIds.includes(id) : false));
+  const compareCount = useCompareStore((s) => s.productIds.length);
+  const toggleCompare = useCompareStore((s) => s.toggleProduct);
+  const compareDisabled = !isComparing && compareCount >= MAX_COMPARE_ITEMS;
 
   const [activeImg, setActiveImg] = useState(0);
   const [added, setAdded] = useState(false);
@@ -402,6 +408,29 @@ const ProductDetail: React.FC = () => {
                   {isWishlisted ? 'En mi lista de deseos' : 'Agregar a mi lista'}
                 </button>
               )}
+
+              <button
+                type="button"
+                onClick={() => id && toggleCompare(id)}
+                disabled={compareDisabled}
+                className="btn-outline"
+                style={{
+                  width: '100%',
+                  padding: '13px 24px',
+                  fontSize: '0.875rem',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 8,
+                  cursor: compareDisabled ? 'not-allowed' : 'pointer',
+                  opacity: compareDisabled ? 0.5 : 1,
+                }}
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M9 3v18M15 3v18M4 8h5m6 0h5M4 16h5m6 0h5" />
+                </svg>
+                {isComparing ? 'Quitar de comparación' : 'Comparar'}
+              </button>
 
               <Link
                 to="/home"

--- a/frontend/src/services/products.service.ts
+++ b/frontend/src/services/products.service.ts
@@ -141,6 +141,16 @@ export const productsService = {
     return (result?.data ?? result) as Product;
   },
 
+  async compare(ids: string[]): Promise<Product[]> {
+    const response = await fetch(`${API_URL}/products/compare?ids=${ids.map(encodeURIComponent).join(',')}`);
+    if (!response.ok) {
+      const result = await response.json().catch(() => ({}));
+      throw new Error(result?.message || result?.errors?.[0]?.message || 'Failed to fetch products for comparison');
+    }
+    const result = await response.json();
+    return result.data || [];
+  },
+
   async getBestSellers(limit = 4): Promise<BestSellerProduct[]> {
     const response = await fetch(`${API_URL}/products/best-sellers?limit=${limit}`);
     if (!response.ok) {

--- a/frontend/src/store/compare.store.ts
+++ b/frontend/src/store/compare.store.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export const MAX_COMPARE_ITEMS = 4;
+
+interface CompareState {
+  productIds: string[];
+  toggleProduct: (productId: string) => void;
+  removeProduct: (productId: string) => void;
+  clearCompare: () => void;
+}
+
+export const useCompareStore = create<CompareState>()(
+  persist(
+    (set) => ({
+      productIds: [],
+
+      toggleProduct: (productId: string) => set((state) => {
+        if (state.productIds.includes(productId)) {
+          return { productIds: state.productIds.filter((id) => id !== productId) };
+        }
+        if (state.productIds.length >= MAX_COMPARE_ITEMS) return state;
+        return { productIds: [...state.productIds, productId] };
+      }),
+
+      removeProduct: (productId: string) => set((state) => ({
+        productIds: state.productIds.filter((id) => id !== productId),
+      })),
+
+      clearCompare: () => set({ productIds: [] }),
+    }),
+    {
+      name: 'safetech-compare-storage',
+    }
+  )
+);


### PR DESCRIPTION
## Resumen
- Nuevo endpoint `GET /api/products/compare?ids=a,b,c` que devuelve los productos indicados (2 a 4, validado con Zod).
- Store de comparación en frontend (`compare.store.ts`, persistido en localStorage, máx. 4 productos), checkbox "Comparar" en las tarjetas del catálogo y botón en el detalle de producto.
- Página `/compare` con tabla lado a lado (precio, condición, categoría, stock, descripción) y opción de quitar productos individualmente sin perder la selección restante.
- Ícono de acceso rápido en el header con contador, siguiendo el mismo patrón que la lista de deseos.
- Tests de controller y validator (`bun test`), `tsc -b` sin errores.

Closes #152

## Test plan
- [x] `bun test` (backend, 172 tests, todos pasan)
- [x] `npx tsc -b` sin errores
- [ ] Verificación manual en navegador (pendiente de levantar servicios)