### PR TITLE
feat: mostrar productos relacionados de la misma categoria para HU-44

### DIFF
--- a/backend/src/controllers/product.controller.test.ts
+++ b/backend/src/controllers/product.controller.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
-import { deleteProduct, getProductsForComparison } from './product.controller';
+import { deleteProduct, getProductsForComparison, getRelatedProducts } from './product.controller';
 import { Product } from '../models/Product';
 
 function createContext(id = 'prod_1') {
@@ -34,6 +34,33 @@ function createQueryContext(query: Record<string, unknown>) {
 
   const context = {
     req: {
+      valid: (_key: string) => query,
+    },
+    json: (value: unknown, status?: number) => {
+      payload = value;
+      statusCode = status ?? 200;
+      return { payload: value, status: statusCode };
+    },
+  };
+
+  return {
+    context,
+    get statusCode() {
+      return statusCode;
+    },
+    get payload() {
+      return payload;
+    },
+  };
+}
+
+function createParamAndQueryContext(id: string, query: Record<string, unknown>) {
+  let statusCode = 200;
+  let payload: unknown;
+
+  const context = {
+    req: {
+      param: () => id,
       valid: (_key: string) => query,
     },
     json: (value: unknown, status?: number) => {
@@ -136,5 +163,64 @@ describe('getProductsForComparison controller', () => {
 
     expect(harness.statusCode).toBe(500);
     expect(harness.payload).toEqual({ success: false, message: 'db down' });
+  });
+});
+
+function createLimitQuery(result: unknown) {
+  return { limit: () => Promise.resolve(result) };
+}
+
+describe('getRelatedProducts controller', () => {
+  const validId = '507f1f77bcf86cd799439011';
+
+  test('returns a 400 for an invalid product id', async () => {
+    const harness = createParamAndQueryContext('not-an-id', {});
+
+    await getRelatedProducts(harness.context as never);
+
+    expect(harness.statusCode).toBe(400);
+    expect(harness.payload).toEqual({ success: false, message: 'ID de producto invalido' });
+  });
+
+  test('returns a 404 when the product does not exist', async () => {
+    Product.findById = mock(() => Promise.resolve(null)) as typeof Product.findById;
+
+    const harness = createParamAndQueryContext(validId, {});
+
+    await getRelatedProducts(harness.context as never);
+
+    expect(harness.statusCode).toBe(404);
+    expect(harness.payload).toEqual({ success: false, message: 'Producto no encontrado' });
+  });
+
+  test('queries same-category products excluding the current one, applying the default limit', async () => {
+    const product = { _id: validId, category: 'laptop' };
+    const related = [{ _id: '507f1f77bcf86cd799439012', category: 'laptop' }];
+
+    Product.findById = mock(() => Promise.resolve(product)) as typeof Product.findById;
+    const find = mock(() => createLimitQuery(related));
+    Product.find = find as unknown as typeof Product.find;
+
+    const harness = createParamAndQueryContext(validId, {});
+
+    await getRelatedProducts(harness.context as never);
+
+    expect(find).toHaveBeenCalledWith({ _id: { $ne: validId }, category: 'laptop' });
+    expect(harness.statusCode).toBe(200);
+    expect(harness.payload).toEqual({ success: true, data: related });
+  });
+
+  test('honors a custom limit', async () => {
+    const product = { _id: validId, category: 'laptop' };
+    Product.findById = mock(() => Promise.resolve(product)) as typeof Product.findById;
+
+    const limitSpy = mock(() => Promise.resolve([]));
+    Product.find = mock(() => ({ limit: limitSpy })) as unknown as typeof Product.find;
+
+    const harness = createParamAndQueryContext(validId, { limit: 8 });
+
+    await getRelatedProducts(harness.context as never);
+
+    expect(limitSpy).toHaveBeenCalledWith(8);
   });
 });

--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -161,6 +161,34 @@ export const updateProduct = async (c: Context) => {
   }
 };
 
+const DEFAULT_RELATED_LIMIT = 4;
+
+export const getRelatedProducts = async (c: Context) => {
+  try {
+    const id = c.req.param('id');
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return c.json({ success: false, message: 'ID de producto invalido' }, 400);
+    }
+
+    const product = await Product.findById(id);
+    if (!product) {
+      return c.json({ success: false, message: 'Producto no encontrado' }, 404);
+    }
+
+    const { limit } = c.req.valid('query' as any) as { limit?: number };
+    const effectiveLimit = limit ?? DEFAULT_RELATED_LIMIT;
+
+    const related = await Product.find({
+      _id: { $ne: product._id },
+      category: product.category,
+    }).limit(effectiveLimit);
+
+    return c.json({ success: true, data: related });
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};
+
 export const getProductInventoryMovements = async (c: Context) => {
   try {
     const id = c.req.param('id');

--- a/backend/src/routes/product.routes.ts
+++ b/backend/src/routes/product.routes.ts
@@ -9,6 +9,7 @@ import {
   getProductInventoryMovements,
   getProducts,
   getProductsForComparison,
+  getRelatedProducts,
   updateProduct,
 } from '../controllers/product.controller';
 import {
@@ -17,6 +18,7 @@ import {
   compareQuerySchema,
   lowStockQuerySchema,
   productFilterSchema,
+  relatedProductsQuerySchema,
   updateProductSchema,
 } from '../validators/product.validator';
 import { adminAuthMiddleware } from '../middlewares/auth.middleware';
@@ -75,6 +77,17 @@ productRoutes.get('/:id', getProductById);
 
 // Historial de movimientos de inventario de un producto (solo admin)
 productRoutes.get('/:id/inventory-movements', adminAuthMiddleware, getProductInventoryMovements);
+
+// Productos relacionados (misma categoria, excluyendo el actual) (HU-44)
+productRoutes.get(
+  '/:id/related',
+  zValidator('query', relatedProductsQuerySchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  getRelatedProducts
+);
 
 // Crear un producto con validación de Zod (solo admin)
 productRoutes.post(

--- a/backend/src/validators/product.validator.test.ts
+++ b/backend/src/validators/product.validator.test.ts
@@ -5,6 +5,7 @@ import {
   createProductSchema,
   lowStockQuerySchema,
   productFilterSchema,
+  relatedProductsQuerySchema,
   updateProductSchema,
 } from './product.validator';
 
@@ -149,6 +150,26 @@ describe('compareQuerySchema', () => {
 
   test('rejects a missing ids param', () => {
     const result = compareQuerySchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('relatedProductsQuerySchema', () => {
+  test('accepts a missing limit', () => {
+    const result = relatedProductsQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test('coerces a valid limit from a string', () => {
+    const result = relatedProductsQuerySchema.safeParse({ limit: '6' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(6);
+    }
+  });
+
+  test('rejects a limit above 12', () => {
+    const result = relatedProductsQuerySchema.safeParse({ limit: '13' });
     expect(result.success).toBe(false);
   });
 });

--- a/backend/src/validators/product.validator.ts
+++ b/backend/src/validators/product.validator.ts
@@ -52,6 +52,11 @@ export const bestSellersQuerySchema = z.object({
   limit: z.coerce.number().int().min(1, 'limit debe ser al menos 1').max(12, 'limit no puede superar 12').optional(),
 });
 
+// HU-44: cantidad de productos relacionados (misma categoria) a devolver.
+export const relatedProductsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1, 'limit debe ser al menos 1').max(12, 'limit no puede superar 12').optional(),
+});
+
 const objectIdRegex = /^[0-9a-fA-F]{24}$/;
 
 // HU-43: ids llega como query string separado por comas (?ids=a,b,c). Se

--- a/frontend/src/hooks/useProducts.ts
+++ b/frontend/src/hooks/useProducts.ts
@@ -33,3 +33,11 @@ export const useProductsCompare = (ids: string[]) => {
     enabled: ids.length >= 2,
   });
 };
+
+export const useRelatedProducts = (id: string | undefined) => {
+  return useQuery<Product[], Error>({
+    queryKey: ['product', id, 'related'],
+    queryFn: () => productsService.getRelated(id as string),
+    enabled: Boolean(id),
+  });
+};

--- a/frontend/src/pages/ProductDetail.tsx
+++ b/frontend/src/pages/ProductDetail.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
-import { useProduct } from '../hooks/useProducts';
+import { useProduct, useRelatedProducts } from '../hooks/useProducts';
 import { useCartStore } from '../store/cart.store';
 import { SkeletonCard } from '../components/ui/Skeleton';
 import { EmptyState } from '../components/ui/EmptyState';
@@ -32,6 +32,7 @@ const ProductDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { data: product, isLoading, isError, error } = useProduct(id);
+  const { data: relatedProducts } = useRelatedProducts(id);
 
   const addItem = useCartStore((s) => s.addItem);
   const toggleDrawer = useCartStore((s) => s.toggleDrawer);
@@ -497,6 +498,62 @@ const ProductDetail: React.FC = () => {
           </div>
         </div>
       </div>
+
+      {/* Productos relacionados (HU-44) */}
+      {relatedProducts && relatedProducts.length > 0 && (
+        <div className="page-container" style={{ padding: '0 2.5rem 3.5rem' }}>
+          <h2
+            style={{
+              fontSize: '1.15rem',
+              fontWeight: 500,
+              color: 'var(--ink)',
+              fontFamily: 'var(--font-display)',
+              letterSpacing: '-0.01em',
+              marginBottom: '1.25rem',
+              paddingTop: '2rem',
+              borderTop: '1px solid var(--line)',
+            }}
+          >
+            También te puede interesar
+          </h2>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '1rem' }}>
+            {relatedProducts.map((related) => (
+              <Link
+                key={related._id}
+                to={`/product/${related._id}`}
+                style={{ display: 'block', color: 'inherit', textDecoration: 'none' }}
+                aria-label={`Ver detalles de ${related.name}`}
+              >
+                <article
+                  style={{
+                    border: '1px solid var(--line)',
+                    borderRadius: 'var(--radius-md)',
+                    overflow: 'hidden',
+                    background: 'var(--white)',
+                    transition: 'box-shadow 180ms ease, transform 180ms ease',
+                  }}
+                >
+                  <div style={{ aspectRatio: '4/3', background: 'var(--cream)', overflow: 'hidden' }}>
+                    <img
+                      src={related.image_urls?.[0] || `https://picsum.photos/seed/${related._id}/400/300`}
+                      alt={related.name}
+                      style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                    />
+                  </div>
+                  <div style={{ padding: '0.9rem 1rem' }}>
+                    <h3 style={{ fontSize: '0.9rem', fontWeight: 500, color: 'var(--ink)', marginBottom: '0.4rem', fontFamily: 'var(--font-display)', lineHeight: 1.3 }}>
+                      {related.name}
+                    </h3>
+                    <p style={{ fontSize: '1rem', fontWeight: 300, color: 'var(--ink)', fontFamily: 'var(--font-display)' }}>
+                      ${related.price.toFixed(2)}
+                    </p>
+                  </div>
+                </article>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Responsive */}
       <style>{`

--- a/frontend/src/services/products.service.ts
+++ b/frontend/src/services/products.service.ts
@@ -151,6 +151,17 @@ export const productsService = {
     return result.data || [];
   },
 
+  async getRelated(id: string, limit?: number): Promise<Product[]> {
+    const qs = limit !== undefined ? `?limit=${limit}` : '';
+    const response = await fetch(`${API_URL}/products/${id}/related${qs}`);
+    if (!response.ok) {
+      const result = await response.json().catch(() => ({}));
+      throw new Error(result?.message || result?.errors?.[0]?.message || 'Failed to fetch related products');
+    }
+    const result = await response.json();
+    return result.data || [];
+  },
+
   async getBestSellers(limit = 4): Promise<BestSellerProduct[]> {
     const response = await fetch(`${API_URL}/products/best-sellers?limit=${limit}`);
     if (!response.ok) {


### PR DESCRIPTION
## Resumen
- Nuevo endpoint `GET /api/products/:id/related?limit=` que devuelve productos de la misma categoría que el producto indicado, excluyéndolo (límite configurable, default 4, máx 12, validado con Zod).
- Frontend: sección "También te puede interesar" en el detalle de producto (`ProductDetail.tsx`), cada tarjeta navega al detalle del producto sugerido.
- Tests de controller y validator (`bun test`), `tsc -b` sin errores.

Closes #153

## Test plan
- [x] `bun test` (backend, 179 tests, todos pasan)
- [x] `npx tsc -b` sin errores
- [ ] Verificación manual en navegador (pendiente de levantar servicios)