### PR TITLE
feat: ficha de inspeccion tecnica por producto para HU-46

### DIFF
--- a/backend/src/controllers/inspection.controller.test.ts
+++ b/backend/src/controllers/inspection.controller.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { getProductInspection, upsertProductInspection } from './inspection.controller';
+import { InspectionReport } from '../models/InspectionReport';
+import { Product } from '../models/Product';
+import { Technician } from '../models/Technician';
+
+const validId = '507f1f77bcf86cd799439011';
+
+function createContext(options: { param?: string; json?: Record<string, unknown>; technicianDocId?: string } = {}) {
+  let statusCode = 200;
+  let payload: unknown;
+
+  const context = {
+    req: {
+      param: () => options.param,
+      valid: (_key: string) => options.json ?? {},
+    },
+    get: (key: string) => (key === 'technicianDocId' ? options.technicianDocId : undefined),
+    json: (value: unknown, status?: number) => {
+      payload = value;
+      statusCode = status ?? 200;
+      return { payload: value, status: statusCode };
+    },
+  };
+
+  return {
+    context,
+    get statusCode() {
+      return statusCode;
+    },
+    get payload() {
+      return payload;
+    },
+  };
+}
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe('getProductInspection controller', () => {
+  test('returns a 400 for an invalid product id', async () => {
+    const harness = createContext({ param: 'not-an-id' });
+
+    await getProductInspection(harness.context as never);
+
+    expect(harness.statusCode).toBe(400);
+    expect(harness.payload).toEqual({ success: false, message: 'ID de producto invalido' });
+  });
+
+  test('returns data: null when no report exists, not an error', async () => {
+    InspectionReport.findOne = mock(() => Promise.resolve(null)) as typeof InspectionReport.findOne;
+
+    const harness = createContext({ param: validId });
+
+    await getProductInspection(harness.context as never);
+
+    expect(harness.statusCode).toBe(200);
+    expect(harness.payload).toEqual({ success: true, data: null });
+  });
+
+  test('returns the existing report', async () => {
+    const report = { product: validId, checklist: [{ aspect: 'Pantalla', result: 'Sin rayones', passed: true }] };
+    InspectionReport.findOne = mock(() => Promise.resolve(report)) as typeof InspectionReport.findOne;
+
+    const harness = createContext({ param: validId });
+
+    await getProductInspection(harness.context as never);
+
+    expect(harness.statusCode).toBe(200);
+    expect(harness.payload).toEqual({ success: true, data: report });
+  });
+});
+
+describe('upsertProductInspection controller', () => {
+  test('returns a 400 for an invalid product id', async () => {
+    const harness = createContext({ param: 'not-an-id' });
+
+    await upsertProductInspection(harness.context as never);
+
+    expect(harness.statusCode).toBe(400);
+    expect(harness.payload).toEqual({ success: false, message: 'ID de producto invalido' });
+  });
+
+  test('returns a 404 when the product does not exist', async () => {
+    Product.findById = mock(() => Promise.resolve(null)) as typeof Product.findById;
+
+    const harness = createContext({ param: validId });
+
+    await upsertProductInspection(harness.context as never);
+
+    expect(harness.statusCode).toBe(404);
+    expect(harness.payload).toEqual({ success: false, message: 'Producto no encontrado' });
+  });
+
+  test('upserts the report tagging the acting technician', async () => {
+    Product.findById = mock(() => Promise.resolve({ _id: validId })) as typeof Product.findById;
+    Technician.findById = mock(() => Promise.resolve({ _id: 'tech_1', name: 'Ana Pérez' })) as typeof Technician.findById;
+
+    const checklist = [{ aspect: 'Batería', result: '92% de salud', passed: true }];
+    const updatedReport = { product: validId, checklist, technicianId: 'tech_1', technicianName: 'Ana Pérez' };
+    const findOneAndUpdate = mock(() => Promise.resolve(updatedReport));
+    InspectionReport.findOneAndUpdate = findOneAndUpdate as typeof InspectionReport.findOneAndUpdate;
+
+    const harness = createContext({ param: validId, json: { checklist }, technicianDocId: 'tech_1' });
+
+    await upsertProductInspection(harness.context as never);
+
+    expect(findOneAndUpdate).toHaveBeenCalledWith(
+      { product: validId },
+      expect.objectContaining({ checklist, technicianId: 'tech_1', technicianName: 'Ana Pérez' }),
+      { new: true, upsert: true, setDefaultsOnInsert: true }
+    );
+    expect(harness.statusCode).toBe(200);
+    expect(harness.payload).toEqual({ success: true, data: updatedReport });
+  });
+});

--- a/backend/src/controllers/inspection.controller.ts
+++ b/backend/src/controllers/inspection.controller.ts
@@ -1,0 +1,58 @@
+import { Context } from 'hono';
+import mongoose from 'mongoose';
+import { InspectionReport } from '../models/InspectionReport';
+import { Product } from '../models/Product';
+import { Technician } from '../models/Technician';
+
+export const getProductInspection = async (c: Context) => {
+  try {
+    const productId = c.req.param('id');
+    if (!mongoose.Types.ObjectId.isValid(productId)) {
+      return c.json({ success: false, message: 'ID de producto invalido' }, 400);
+    }
+
+    // Sin ficha registrada: se responde 200 con data: null, no un error, para
+    // que el frontend muestre un estado informativo (criterio de HU-46).
+    const report = await InspectionReport.findOne({ product: productId });
+
+    return c.json({ success: true, data: report });
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};
+
+export const upsertProductInspection = async (c: Context) => {
+  try {
+    const productId = c.req.param('id');
+    if (!mongoose.Types.ObjectId.isValid(productId)) {
+      return c.json({ success: false, message: 'ID de producto invalido' }, 400);
+    }
+
+    const product = await Product.findById(productId);
+    if (!product) {
+      return c.json({ success: false, message: 'Producto no encontrado' }, 404);
+    }
+
+    const { checklist } = c.req.valid('json' as any) as {
+      checklist: { aspect: string; result: string; passed: boolean }[];
+    };
+
+    const technicianDocId = c.get('technicianDocId');
+    const technician = technicianDocId ? await Technician.findById(technicianDocId) : null;
+
+    const report = await InspectionReport.findOneAndUpdate(
+      { product: productId },
+      {
+        checklist,
+        technicianId: technicianDocId,
+        technicianName: technician?.name,
+        inspectedAt: new Date(),
+      },
+      { new: true, upsert: true, setDefaultsOnInsert: true }
+    );
+
+    return c.json({ success: true, data: report });
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};

--- a/backend/src/models/InspectionReport.ts
+++ b/backend/src/models/InspectionReport.ts
@@ -1,0 +1,46 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface IInspectionChecklistItem {
+  aspect: string;
+  result: string;
+  passed: boolean;
+}
+
+export interface IInspectionReport extends Document {
+  product: Types.ObjectId;
+  technicianId?: string;
+  technicianName?: string;
+  checklist: IInspectionChecklistItem[];
+  inspectedAt: Date;
+}
+
+const checklistItemSchema = new Schema<IInspectionChecklistItem>(
+  {
+    aspect: { type: String, required: true },
+    result: { type: String, required: true },
+    passed: { type: Boolean, required: true, default: true },
+  },
+  { _id: false }
+);
+
+const inspectionReportSchema = new Schema<IInspectionReport>(
+  {
+    // Un producto tiene a lo sumo una ficha vigente (HU-46); se actualiza in
+    // situ (upsert) en vez de acumular historial de fichas.
+    product: { type: Schema.Types.ObjectId, ref: 'Product', required: true, unique: true },
+    technicianId: { type: String },
+    technicianName: { type: String },
+    checklist: {
+      type: [checklistItemSchema],
+      required: true,
+      validate: {
+        validator: (items: IInspectionChecklistItem[]) => items.length > 0,
+        message: 'La ficha debe incluir al menos un aspecto revisado',
+      },
+    },
+    inspectedAt: { type: Date, default: Date.now },
+  },
+  { timestamps: true }
+);
+
+export const InspectionReport = model<IInspectionReport>('InspectionReport', inspectionReportSchema);

--- a/backend/src/routes/product.routes.ts
+++ b/backend/src/routes/product.routes.ts
@@ -12,6 +12,7 @@ import {
   getRelatedProducts,
   updateProduct,
 } from '../controllers/product.controller';
+import { getProductInspection, upsertProductInspection } from '../controllers/inspection.controller';
 import {
   createProductSchema,
   bestSellersQuerySchema,
@@ -21,7 +22,8 @@ import {
   relatedProductsQuerySchema,
   updateProductSchema,
 } from '../validators/product.validator';
-import { adminAuthMiddleware } from '../middlewares/auth.middleware';
+import { upsertInspectionSchema } from '../validators/inspection.validator';
+import { adminAuthMiddleware, technicianAuthMiddleware } from '../middlewares/auth.middleware';
 
 const productRoutes = new Hono();
 
@@ -87,6 +89,20 @@ productRoutes.get(
     }
   }),
   getRelatedProducts
+);
+
+// Ficha de inspeccion tecnica de un producto (HU-46). Lectura publica;
+// solo un tecnico autenticado puede registrarla/actualizarla.
+productRoutes.get('/:id/inspection', getProductInspection);
+productRoutes.put(
+  '/:id/inspection',
+  technicianAuthMiddleware,
+  zValidator('json', upsertInspectionSchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  upsertProductInspection
 );
 
 // Crear un producto con validación de Zod (solo admin)

--- a/backend/src/validators/inspection.validator.test.ts
+++ b/backend/src/validators/inspection.validator.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { upsertInspectionSchema } from './inspection.validator';
+
+describe('upsertInspectionSchema', () => {
+  test('accepts a checklist with at least one item', () => {
+    const result = upsertInspectionSchema.safeParse({
+      checklist: [{ aspect: 'Pantalla', result: 'Sin rayones', passed: true }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test('defaults passed to true when omitted', () => {
+    const result = upsertInspectionSchema.safeParse({
+      checklist: [{ aspect: 'Pantalla', result: 'Sin rayones' }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.checklist[0].passed).toBe(true);
+    }
+  });
+
+  test('rejects an empty checklist', () => {
+    const result = upsertInspectionSchema.safeParse({ checklist: [] });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects an item missing the result', () => {
+    const result = upsertInspectionSchema.safeParse({
+      checklist: [{ aspect: 'Pantalla', result: '' }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a missing checklist', () => {
+    const result = upsertInspectionSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/src/validators/inspection.validator.ts
+++ b/backend/src/validators/inspection.validator.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const upsertInspectionSchema = z.object({
+  checklist: z
+    .array(
+      z.object({
+        aspect: z.string().min(1, 'El aspecto revisado es requerido'),
+        result: z.string().min(1, 'El resultado es requerido'),
+        passed: z.boolean().default(true),
+      })
+    )
+    .min(1, 'La ficha debe incluir al menos un aspecto revisado'),
+});

--- a/frontend/src/hooks/useInspection.ts
+++ b/frontend/src/hooks/useInspection.ts
@@ -1,0 +1,27 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '../lib/auth';
+import { inspectionService } from '../services/inspection.service';
+import type { InspectionChecklistItem, InspectionReport } from '../types/inspection';
+
+export const useProductInspection = (productId: string | undefined) => {
+  return useQuery<InspectionReport | null, Error>({
+    queryKey: ['product', productId, 'inspection'],
+    queryFn: () => inspectionService.getByProduct(productId as string),
+    enabled: Boolean(productId),
+  });
+};
+
+export const useUpsertInspection = () => {
+  const { getToken } = useAuth();
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ productId, checklist }: { productId: string; checklist: InspectionChecklistItem[] }) => {
+      const token = await getToken();
+      if (!token) throw new Error('No token');
+      return inspectionService.upsert(productId, checklist, token);
+    },
+    onSuccess: (_data, variables) => {
+      qc.invalidateQueries({ queryKey: ['product', variables.productId, 'inspection'] });
+    },
+  });
+};

--- a/frontend/src/pages/ProductDetail.tsx
+++ b/frontend/src/pages/ProductDetail.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useProduct, useRelatedProducts } from '../hooks/useProducts';
+import { useProductInspection } from '../hooks/useInspection';
 import { useCartStore } from '../store/cart.store';
 import { SkeletonCard } from '../components/ui/Skeleton';
 import { EmptyState } from '../components/ui/EmptyState';
@@ -33,6 +34,7 @@ const ProductDetail: React.FC = () => {
   const navigate = useNavigate();
   const { data: product, isLoading, isError, error } = useProduct(id);
   const { data: relatedProducts } = useRelatedProducts(id);
+  const { data: inspectionReport, isLoading: isInspectionLoading } = useProductInspection(id);
 
   const addItem = useCartStore((s) => s.addItem);
   const toggleDrawer = useCartStore((s) => s.toggleDrawer);
@@ -498,6 +500,67 @@ const ProductDetail: React.FC = () => {
           </div>
         </div>
       </div>
+
+      {/* Ficha de inspeccion tecnica (HU-46) */}
+      {!isInspectionLoading && (
+        <div className="page-container" style={{ padding: '2rem 2.5rem 0' }}>
+          <h2
+            style={{
+              fontSize: '1.15rem',
+              fontWeight: 500,
+              color: 'var(--ink)',
+              fontFamily: 'var(--font-display)',
+              letterSpacing: '-0.01em',
+              marginBottom: '1.25rem',
+              paddingTop: '2rem',
+              borderTop: '1px solid var(--line)',
+            }}
+          >
+            Ficha de inspección técnica
+          </h2>
+          {inspectionReport ? (
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: '0.75rem' }}>
+              {inspectionReport.checklist.map((item, i) => (
+                <div
+                  key={i}
+                  style={{
+                    padding: '0.9rem 1rem',
+                    background: 'var(--white)',
+                    border: '1px solid var(--line)',
+                    borderRadius: 'var(--radius-sm)',
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: 10,
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 18, height: 18, borderRadius: '50%', flexShrink: 0, marginTop: 2,
+                      display: 'flex', alignItems: 'center', justifyContent: 'center',
+                      background: item.passed ? '#22c55e' : '#DC2626', color: '#fff', fontSize: '0.65rem',
+                    }}
+                    aria-hidden="true"
+                  >
+                    {item.passed ? '✓' : '✕'}
+                  </span>
+                  <div>
+                    <p style={{ fontSize: '0.82rem', fontWeight: 600, color: 'var(--ink)', fontFamily: 'var(--font-sans)', marginBottom: 2 }}>
+                      {item.aspect}
+                    </p>
+                    <p style={{ fontSize: '0.78rem', color: 'var(--ink2)', fontFamily: 'var(--font-sans)' }}>
+                      {item.result}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p style={{ fontSize: '0.85rem', color: 'var(--ink3)', fontFamily: 'var(--font-sans)' }}>
+              Este producto todavía no tiene una ficha de inspección técnica registrada.
+            </p>
+          )}
+        </div>
+      )}
 
       {/* Productos relacionados (HU-44) */}
       {relatedProducts && relatedProducts.length > 0 && (

--- a/frontend/src/pages/TechnicianDashboard.tsx
+++ b/frontend/src/pages/TechnicianDashboard.tsx
@@ -4,6 +4,9 @@ import { useAuth } from '../lib/auth';
 import { warrantyService } from '../services/warranty.service';
 import type { IWarranty } from '../types/warranty';
 import { Badge } from '../components/ui/Badge';
+import { useProducts } from '../hooks/useProducts';
+import { useProductInspection, useUpsertInspection } from '../hooks/useInspection';
+import type { InspectionChecklistItem } from '../types/inspection';
 
 const statusVariant: Record<string, 'success' | 'warning' | 'error' | 'neutral'> = {
   review:    'neutral',
@@ -161,6 +164,164 @@ function TicketCard({ warranty }: { warranty: IWarranty }) {
   );
 }
 
+const EMPTY_ITEM: InspectionChecklistItem = { aspect: '', result: '', passed: true };
+
+function InspectionForm() {
+  const { data: products } = useProducts();
+  const [productId, setProductId] = useState('');
+  const { data: existingReport } = useProductInspection(productId || undefined);
+  const [checklist, setChecklist] = useState<InspectionChecklistItem[] | null>(null);
+  const [saved, setSaved] = useState(false);
+  const mutation = useUpsertInspection();
+
+  const startEditing = () => {
+    setChecklist(existingReport?.checklist?.length ? existingReport.checklist : [EMPTY_ITEM]);
+  };
+
+  const updateItem = (index: number, patch: Partial<InspectionChecklistItem>) => {
+    setChecklist((prev) => (prev ? prev.map((item, i) => (i === index ? { ...item, ...patch } : item)) : prev));
+  };
+
+  const removeItem = (index: number) => {
+    setChecklist((prev) => (prev ? prev.filter((_, i) => i !== index) : prev));
+  };
+
+  const handleSelectProduct = (newProductId: string) => {
+    setProductId(newProductId);
+    setChecklist(null);
+    setSaved(false);
+  };
+
+  const handleSubmit = () => {
+    if (!productId || !checklist) return;
+    const validItems = checklist.filter((item) => item.aspect.trim() && item.result.trim());
+    if (validItems.length === 0) return;
+    mutation.mutate(
+      { productId, checklist: validItems },
+      {
+        onSuccess: () => {
+          setSaved(true);
+          setChecklist(null);
+          setTimeout(() => setSaved(false), 2000);
+        },
+      }
+    );
+  };
+
+  return (
+    <div style={{
+      background: 'var(--white)',
+      border: '1.5px solid var(--line)',
+      borderRadius: 'var(--radius-card)',
+      padding: '1.5rem',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '1rem',
+    }}>
+      <div>
+        <label style={{ display: 'block', fontSize: '0.7rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '1px', color: 'var(--ink3)', marginBottom: 4 }}>
+          Producto
+        </label>
+        <select
+          className="admin-select"
+          value={productId}
+          onChange={(e) => handleSelectProduct(e.target.value)}
+          style={{ width: '100%' }}
+        >
+          <option value="">Selecciona un producto…</option>
+          {(products ?? []).map((p) => (
+            <option key={p._id} value={p._id}>{p.name}</option>
+          ))}
+        </select>
+      </div>
+
+      {productId && !checklist && (
+        <div>
+          {existingReport ? (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: '0.75rem' }}>
+              {existingReport.checklist.map((item, i) => (
+                <p key={i} style={{ fontSize: '0.82rem', color: 'var(--ink2)', fontFamily: 'var(--font-sans)' }}>
+                  {item.passed ? '✓' : '✕'} <strong>{item.aspect}:</strong> {item.result}
+                </p>
+              ))}
+            </div>
+          ) : (
+            <p style={{ fontSize: '0.82rem', color: 'var(--ink3)', fontFamily: 'var(--font-sans)', marginBottom: '0.75rem' }}>
+              Este producto no tiene ficha registrada todavía.
+            </p>
+          )}
+          <button onClick={startEditing} className="btn-outline" style={{ padding: '0 1.25rem', height: 36, fontSize: '0.8rem' }}>
+            {existingReport ? 'Editar ficha' : 'Crear ficha'}
+          </button>
+        </div>
+      )}
+
+      {checklist && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+          {checklist.map((item, i) => (
+            <div key={i} style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+              <input
+                className="input"
+                placeholder="Aspecto (ej. Pantalla)"
+                value={item.aspect}
+                onChange={(e) => updateItem(i, { aspect: e.target.value })}
+                style={{ flex: 1, minWidth: 140 }}
+              />
+              <input
+                className="input"
+                placeholder="Resultado (ej. Sin rayones)"
+                value={item.result}
+                onChange={(e) => updateItem(i, { result: e.target.value })}
+                style={{ flex: 1, minWidth: 140 }}
+              />
+              <label style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: '0.78rem', color: 'var(--ink2)', fontFamily: 'var(--font-sans)' }}>
+                <input type="checkbox" checked={item.passed} onChange={(e) => updateItem(i, { passed: e.target.checked })} />
+                OK
+              </label>
+              <button
+                type="button"
+                onClick={() => removeItem(i)}
+                aria-label="Quitar aspecto"
+                style={{ border: 'none', background: 'transparent', color: 'var(--gray)', cursor: 'pointer', fontSize: '1rem' }}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+
+          <button
+            type="button"
+            onClick={() => setChecklist((prev) => [...(prev ?? []), { ...EMPTY_ITEM }])}
+            className="btn-outline"
+            style={{ alignSelf: 'flex-start', padding: '0 1rem', height: 32, fontSize: '0.78rem' }}
+          >
+            + Agregar aspecto
+          </button>
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+            <button
+              onClick={handleSubmit}
+              disabled={mutation.isPending}
+              className="btn-primary"
+              style={{ padding: '0 1.5rem', height: 40, fontSize: '0.85rem' }}
+            >
+              {mutation.isPending ? 'Guardando…' : 'Guardar ficha'}
+            </button>
+            <button onClick={() => setChecklist(null)} className="btn-outline" style={{ padding: '0 1.25rem', height: 40, fontSize: '0.85rem' }}>
+              Cancelar
+            </button>
+            {saved && (
+              <span style={{ fontSize: '0.8rem', color: '#2a7a4b', fontFamily: 'var(--font-sans)' }}>
+                ✓ Guardado
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function TechnicianDashboard() {
   const { getToken, isLoaded } = useAuth();
   const [filter, setFilter] = useState<'all' | 'open' | 'closed'>('open');
@@ -233,6 +394,14 @@ export default function TechnicianDashboard() {
             {filtered.map(w => <TicketCard key={w._id} warranty={w} />)}
           </div>
         )}
+
+        {/* Fichas de inspeccion tecnica (HU-46) */}
+        <div style={{ marginTop: '3rem', marginBottom: '1.5rem', paddingBottom: '1.5rem', borderBottom: '1px solid var(--line)' }}>
+          <h2 style={{ fontSize: 'clamp(1.25rem, 3vw, 1.75rem)', fontWeight: 300, letterSpacing: '-0.02em', color: 'var(--ink)', fontFamily: 'var(--font-display)' }}>
+            Fichas de inspección técnica
+          </h2>
+        </div>
+        <InspectionForm />
       </div>
     </div>
   );

--- a/frontend/src/services/inspection.service.ts
+++ b/frontend/src/services/inspection.service.ts
@@ -1,0 +1,32 @@
+import type { InspectionChecklistItem, InspectionReport } from '../types/inspection';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
+
+export const inspectionService = {
+  async getByProduct(productId: string): Promise<InspectionReport | null> {
+    const response = await fetch(`${API_URL}/products/${productId}/inspection`);
+    if (!response.ok) {
+      const result = await response.json().catch(() => ({}));
+      throw new Error(result?.message || result?.errors?.[0]?.message || 'Failed to fetch inspection report');
+    }
+    const result = await response.json();
+    return result.data ?? null;
+  },
+
+  async upsert(productId: string, checklist: InspectionChecklistItem[], token: string): Promise<InspectionReport> {
+    const response = await fetch(`${API_URL}/products/${productId}/inspection`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ checklist }),
+    });
+    if (!response.ok) {
+      const result = await response.json().catch(() => ({}));
+      throw new Error(result?.message || result?.errors?.[0]?.message || 'Failed to save inspection report');
+    }
+    const result = await response.json();
+    return result.data;
+  },
+};

--- a/frontend/src/types/inspection.ts
+++ b/frontend/src/types/inspection.ts
@@ -1,0 +1,14 @@
+export interface InspectionChecklistItem {
+  aspect: string;
+  result: string;
+  passed: boolean;
+}
+
+export interface InspectionReport {
+  _id: string;
+  product: string;
+  technicianId?: string;
+  technicianName?: string;
+  checklist: InspectionChecklistItem[];
+  inspectedAt: string;
+}


### PR DESCRIPTION
## Resumen
- Nuevo modelo `InspectionReport` (una ficha por producto, con checklist de aspectos revisados y su resultado).
- `GET /api/products/:id/inspection` (público): devuelve la ficha o `data: null` si no existe — nunca un error, según criterio de aceptación.
- `PUT /api/products/:id/inspection` (solo técnicos autenticados, `technicianAuthMiddleware`): crea/actualiza la ficha (upsert), validado con Zod.
- Frontend: sección "Ficha de inspección técnica" en el detalle de producto, con estado informativo cuando no hay ficha registrada.
- Portal técnico (`TechnicianDashboard.tsx`): formulario para seleccionar un producto y crear/editar su ficha (aspecto + resultado + OK/no OK), necesario para que la funcionalidad sea utilizable end-to-end.
- Tests de controller y validator (`bun test`), `tsc -b` sin errores.

Closes #155

## Test plan
- [x] `bun test` (backend, 190 tests, todos pasan)
- [x] `npx tsc -b` sin errores
- [ ] Verificación manual en navegador (pendiente de levantar servicios)