### PR TITLE
feat: mostrar nivel de salud de bateria cuando aplique para HU-47

### DIFF
--- a/backend/src/models/Product.ts
+++ b/backend/src/models/Product.ts
@@ -8,6 +8,9 @@ const productSchema = new Schema({
   condition: { type: String, enum: ['A', 'B', 'C'], required: true },
   category: { type: String, enum: ['celular', 'laptop', 'pc', 'auriculares', 'tablet'], required: true },
   image_urls: [{ type: String }],
+  // Porcentaje de salud de bateria (HU-47). Solo aplica a productos con
+  // bateria; se deja sin definir en vez de 0 para no sugerir un dato falso.
+  battery_health: { type: Number, min: 0, max: 100 },
 }, { timestamps: true });
 
 export const Product = model('Product', productSchema);

--- a/backend/src/validators/product.validator.test.ts
+++ b/backend/src/validators/product.validator.test.ts
@@ -52,6 +52,29 @@ describe('createProductSchema', () => {
     const result = createProductSchema.safeParse({ ...validProduct, image_urls: ['not-a-url'] });
     expect(result.success).toBe(false);
   });
+
+  test('accepts an omitted battery_health', () => {
+    const result = createProductSchema.safeParse(validProduct);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.battery_health).toBeUndefined();
+    }
+  });
+
+  test('accepts a battery_health within range', () => {
+    const result = createProductSchema.safeParse({ ...validProduct, battery_health: 92 });
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects a battery_health above 100', () => {
+    const result = createProductSchema.safeParse({ ...validProduct, battery_health: 101 });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a negative battery_health', () => {
+    const result = createProductSchema.safeParse({ ...validProduct, battery_health: -1 });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('updateProductSchema', () => {

--- a/backend/src/validators/product.validator.ts
+++ b/backend/src/validators/product.validator.ts
@@ -12,6 +12,9 @@ const productFields = {
     errorMap: () => ({ message: 'Categoría inválida' }),
   }),
   image_urls: z.array(z.string().url('Debe ser una URL válida')).optional(),
+  // HU-47: solo aplica a productos con bateria; se omite en vez de forzar 0
+  // para no registrar un dato falso en productos que no la tienen.
+  battery_health: z.number().min(0, 'La salud de batería debe ser 0 o mayor').max(100, 'La salud de batería no puede superar 100').optional(),
 };
 
 export const createProductSchema = z.object({

--- a/frontend/src/components/ProductModal.tsx
+++ b/frontend/src/components/ProductModal.tsx
@@ -25,6 +25,10 @@ const CATEGORIES = [
   { value: 'tablet', label: 'Tablet' },
 ];
 
+// Categorias cuyos productos suelen tener bateria (HU-47); las PC de
+// escritorio no, asi que no tiene sentido pedir ese dato para esa categoria.
+const BATTERY_CATEGORIES = new Set(['celular', 'laptop', 'auriculares', 'tablet']);
+
 const inputStyle: React.CSSProperties = {
   width: '100%',
   padding: '11px 14px',
@@ -57,6 +61,7 @@ export default function ProductModal({ isOpen, onClose, onSubmit, product, isLoa
   const [condition,   setCondition]   = useState<'A' | 'B' | 'C'>('A');
   const [category,    setCategory]    = useState<'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet'>('celular');
   const [imageUrls,   setImageUrls]   = useState('');
+  const [batteryHealth, setBatteryHealth] = useState('');
   const [stockReason, setStockReason] = useState('');
   const [error,       setError]       = useState('');
 
@@ -69,9 +74,11 @@ export default function ProductModal({ isOpen, onClose, onSubmit, product, isLoa
       setCondition(product.condition);
       setCategory(product.category);
       setImageUrls(product.image_urls.join(', '));
+      setBatteryHealth(product.battery_health !== undefined ? product.battery_health.toString() : '');
     } else {
       setName(''); setDescription(''); setPrice('');
       setStock(''); setCondition('A'); setCategory('celular'); setImageUrls('');
+      setBatteryHealth('');
     }
     setStockReason('');
     setError('');
@@ -96,6 +103,13 @@ export default function ProductModal({ isOpen, onClose, onSubmit, product, isLoa
     if (isNaN(priceNum) || priceNum <= 0)   { setError('El precio debe ser mayor a 0'); return; }
     if (isNaN(stockNum) || stockNum < 0)    { setError('El stock debe ser 0 o mayor'); return; }
 
+    const batteryApplies = BATTERY_CATEGORIES.has(category);
+    const batteryHealthNum = batteryApplies && batteryHealth.trim() !== '' ? parseFloat(batteryHealth) : undefined;
+    if (batteryHealthNum !== undefined && (isNaN(batteryHealthNum) || batteryHealthNum < 0 || batteryHealthNum > 100)) {
+      setError('La salud de batería debe estar entre 0 y 100');
+      return;
+    }
+
     const image_urls = imageUrls.split(',').map(u => u.trim()).filter(Boolean);
     const stockChanged = Boolean(product) && stockNum !== product?.stock;
 
@@ -108,6 +122,7 @@ export default function ProductModal({ isOpen, onClose, onSubmit, product, isLoa
         condition,
         category,
         image_urls,
+        battery_health: batteryHealthNum,
         ...(stockChanged ? { reason: stockReason.trim() || undefined } : {}),
       });
       onClose();
@@ -343,6 +358,24 @@ export default function ProductModal({ isOpen, onClose, onSubmit, product, isLoa
               ))}
             </select>
           </div>
+
+          {/* Salud de batería (solo categorías con batería) */}
+          {BATTERY_CATEGORIES.has(category) && (
+            <div>
+              <label style={labelStyle}>Salud de batería (%)</label>
+              <input
+                type="number"
+                min="0"
+                max="100"
+                value={batteryHealth}
+                onChange={e => setBatteryHealth(e.target.value)}
+                placeholder="Ej: 92 (dejar vacío si no se midió)"
+                style={inputStyle}
+                onFocus={e => { e.target.style.borderColor = 'var(--accent)'; e.target.style.boxShadow = '0 0 0 3px var(--accent-light)'; }}
+                onBlur={e  => { e.target.style.borderColor = 'var(--line)'; e.target.style.boxShadow = 'none'; }}
+              />
+            </div>
+          )}
 
           {/* URLs de imágenes */}
           <div>

--- a/frontend/src/pages/ProductDetail.tsx
+++ b/frontend/src/pages/ProductDetail.tsx
@@ -320,6 +320,39 @@ const ProductDetail: React.FC = () => {
                 : `${product.stock} disponibles en stock`}
             </div>
 
+            {/* Salud de bateria (HU-47): solo se muestra si hay un dato registrado */}
+            {product.battery_health !== undefined && (
+              <div style={{ marginBottom: '2rem' }}>
+                <p
+                  style={{
+                    fontSize: '0.65rem',
+                    fontWeight: 600,
+                    letterSpacing: '2px',
+                    textTransform: 'uppercase',
+                    color: 'var(--ink3)',
+                    fontFamily: 'var(--font-sans)',
+                    marginBottom: '0.625rem',
+                  }}
+                >
+                  Salud de batería
+                </p>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <div style={{ flex: 1, maxWidth: 180, height: 8, borderRadius: 4, background: 'var(--line)', overflow: 'hidden' }}>
+                    <div
+                      style={{
+                        width: `${product.battery_health}%`,
+                        height: '100%',
+                        background: product.battery_health >= 80 ? '#22c55e' : product.battery_health >= 50 ? '#D97706' : '#DC2626',
+                      }}
+                    />
+                  </div>
+                  <span style={{ fontSize: '0.9rem', fontWeight: 600, color: 'var(--ink)', fontFamily: 'var(--font-sans)' }}>
+                    {product.battery_health}%
+                  </span>
+                </div>
+              </div>
+            )}
+
             {/* Description */}
             {product.description && (
               <div style={{ marginBottom: '2rem' }}>

--- a/frontend/src/services/products.service.ts
+++ b/frontend/src/services/products.service.ts
@@ -10,6 +10,7 @@ export interface CreateProductDTO {
   condition: 'A' | 'B' | 'C';
   category: 'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet';
   image_urls: string[];
+  battery_health?: number;
 }
 
 export interface UpdateProductDTO {
@@ -20,6 +21,7 @@ export interface UpdateProductDTO {
   condition?: 'A' | 'B' | 'C';
   category?: 'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet';
   image_urls?: string[];
+  battery_health?: number;
   // Motivo del ajuste de stock (HU-36), para el historial de movimientos de inventario.
   reason?: string;
 }

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -7,6 +7,7 @@ export interface Product {
   condition: 'A' | 'B' | 'C';
   category: 'celular' | 'laptop' | 'pc' | 'auriculares' | 'tablet';
   image_urls: string[];
+  battery_health?: number;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Resumen
- Nuevo campo opcional `battery_health` (0-100) en `Product`, validado con Zod en create/update. Se deja `undefined` en vez de `0` para no registrar un dato falso en productos sin ese valor medido.
- Formulario de admin (`ProductModal.tsx`): campo "Salud de batería (%)" visible solo para categorías que suelen tener batería (celular, laptop, tablet, auriculares); PC de escritorio no lo muestra.
- Detalle de producto: barra + porcentaje de salud de batería, solo quando el valor está registrado (sin fallback ni valor inventado).

Closes #156

## Test plan
- [x] `bun test` (backend, 194 tests, todos pasan)
- [x] `npx tsc -b` sin errores
- [ ] Verificación manual en navegador (pendiente de levantar servicios)