### PR TITLE
feat: mostrar productos vistos recientemente para HU-48

### DIFF
--- a/frontend/src/components/RecentlyViewedSection.tsx
+++ b/frontend/src/components/RecentlyViewedSection.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useRecentlyViewedStore } from '../store/recentlyViewed.store';
+import { useProduct } from '../hooks/useProducts';
+
+const RecentlyViewedCard: React.FC<{ productId: string }> = ({ productId }) => {
+  const { data: product } = useProduct(productId);
+  if (!product) return null;
+
+  return (
+    <Link
+      to={`/product/${product._id}`}
+      style={{ display: 'block', color: 'inherit', textDecoration: 'none' }}
+      aria-label={`Ver detalles de ${product.name}`}
+    >
+      <article
+        style={{
+          border: '1px solid var(--line)',
+          borderRadius: 'var(--radius-md)',
+          overflow: 'hidden',
+          background: 'var(--white)',
+        }}
+      >
+        <div style={{ aspectRatio: '4/3', background: 'var(--cream)', overflow: 'hidden' }}>
+          <img
+            src={product.image_urls?.[0] || `https://picsum.photos/seed/${product._id}/400/300`}
+            alt={product.name}
+            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+          />
+        </div>
+        <div style={{ padding: '0.9rem 1rem' }}>
+          <h3 style={{ fontSize: '0.9rem', fontWeight: 500, color: 'var(--ink)', marginBottom: '0.4rem', fontFamily: 'var(--font-display)', lineHeight: 1.3 }}>
+            {product.name}
+          </h3>
+          <p style={{ fontSize: '1rem', fontWeight: 300, color: 'var(--ink)', fontFamily: 'var(--font-display)' }}>
+            ${product.price.toFixed(2)}
+          </p>
+        </div>
+      </article>
+    </Link>
+  );
+};
+
+export const RecentlyViewedSection: React.FC = () => {
+  const productIds = useRecentlyViewedStore((s) => s.productIds);
+
+  if (productIds.length === 0) return null;
+
+  return (
+    <section style={{ padding: '3rem 0 0', background: 'var(--white)' }}>
+      <div className="page-container">
+        <h2 style={{ fontSize: 'clamp(1.25rem, 3vw, 1.75rem)', fontWeight: 600, color: 'var(--ink)', fontFamily: 'var(--font-display)', marginBottom: '1.5rem' }}>
+          Vistos recientemente
+        </h2>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '1rem' }}>
+          {productIds.map((productId) => (
+            <RecentlyViewedCard key={productId} productId={productId} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import { ProductList } from '../components/ProductList';
 import { BestSellersSection } from '../components/BestSellersSection';
+import { RecentlyViewedSection } from '../components/RecentlyViewedSection';
 
 export default function Home() {
   return (
@@ -40,6 +41,8 @@ export default function Home() {
       </section>
 
       <BestSellersSection />
+
+      <RecentlyViewedSection />
 
       {/* Productos */}
       <section style={{ padding: '3rem 0 5rem', background: 'var(--white)' }}>

--- a/frontend/src/pages/ProductDetail.tsx
+++ b/frontend/src/pages/ProductDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useProduct, useRelatedProducts } from '../hooks/useProducts';
 import { useProductInspection } from '../hooks/useInspection';
@@ -8,6 +8,7 @@ import { EmptyState } from '../components/ui/EmptyState';
 import { useWishlistCheck, useAddToWishlist, useRemoveFromWishlist } from '../hooks/useWishlist';
 import { useAuth } from '../lib/auth';
 import { useCompareStore, MAX_COMPARE_ITEMS } from '../store/compare.store';
+import { useRecentlyViewedStore } from '../store/recentlyViewed.store';
 
 const CATEGORY_LABEL: Record<string, string> = {
   celular: 'Celular',
@@ -52,6 +53,11 @@ const ProductDetail: React.FC = () => {
   const [activeImg, setActiveImg] = useState(0);
   const [added, setAdded] = useState(false);
   const [copied, setCopied] = useState(false);
+
+  const recordView = useRecentlyViewedStore((s) => s.recordView);
+  useEffect(() => {
+    if (product) recordView(product._id);
+  }, [product, recordView]);
 
   if (isLoading) {
     return (

--- a/frontend/src/store/recentlyViewed.store.ts
+++ b/frontend/src/store/recentlyViewed.store.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export const MAX_RECENTLY_VIEWED = 12;
+
+interface RecentlyViewedState {
+  productIds: string[];
+  recordView: (productId: string) => void;
+}
+
+export const useRecentlyViewedStore = create<RecentlyViewedState>()(
+  persist(
+    (set) => ({
+      productIds: [],
+
+      // Mas reciente primero; si ya estaba en la lista se mueve al frente en
+      // vez de duplicarse.
+      recordView: (productId: string) => set((state) => ({
+        productIds: [productId, ...state.productIds.filter((id) => id !== productId)].slice(0, MAX_RECENTLY_VIEWED),
+      })),
+    }),
+    {
+      name: 'safetech-recently-viewed-storage',
+    }
+  )
+);


### PR DESCRIPTION
## Resumen
- Nuevo store cliente (`recentlyViewed.store.ts`, Zustand + localStorage) que registra los productos vistos, más reciente primero, deduplicando y con tope de 12.
- `ProductDetail.tsx` registra la vista al cargar un producto.
- Nueva sección "Vistos recientemente" (`RecentlyViewedSection.tsx`) en el catálogo (`Home.tsx`), en orden cronológico inverso, con enlace al detalle de cada producto. No se muestra si no hay historial.
- Es un registro puramente local (localStorage), sin endpoint de backend nuevo, acorde al criterio "el sistema debe registrar **localmente**".

Closes #157

## Test plan
- [x] `npx tsc -b` sin errores
- [x] `bun test` (backend, 194 tests, todos pasan — sin cambios de backend en este PR)
- [ ] Verificación manual en navegador (pendiente de levantar servicios)