### PR TITLE
feat: permitir limpiar el historial de productos vistos para HU-49

### DIFF
--- a/frontend/src/components/RecentlyViewedSection.tsx
+++ b/frontend/src/components/RecentlyViewedSection.tsx
@@ -43,15 +43,26 @@ const RecentlyViewedCard: React.FC<{ productId: string }> = ({ productId }) => {
 
 export const RecentlyViewedSection: React.FC = () => {
   const productIds = useRecentlyViewedStore((s) => s.productIds);
+  const clearRecentlyViewed = useRecentlyViewedStore((s) => s.clearRecentlyViewed);
 
   if (productIds.length === 0) return null;
 
   return (
     <section style={{ padding: '3rem 0 0', background: 'var(--white)' }}>
       <div className="page-container">
-        <h2 style={{ fontSize: 'clamp(1.25rem, 3vw, 1.75rem)', fontWeight: 600, color: 'var(--ink)', fontFamily: 'var(--font-display)', marginBottom: '1.5rem' }}>
-          Vistos recientemente
-        </h2>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem', marginBottom: '1.5rem', flexWrap: 'wrap' }}>
+          <h2 style={{ fontSize: 'clamp(1.25rem, 3vw, 1.75rem)', fontWeight: 600, color: 'var(--ink)', fontFamily: 'var(--font-display)' }}>
+            Vistos recientemente
+          </h2>
+          <button
+            type="button"
+            onClick={clearRecentlyViewed}
+            className="btn-outline"
+            style={{ fontSize: '0.78rem', padding: '8px 16px' }}
+          >
+            Limpiar historial
+          </button>
+        </div>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '1rem' }}>
           {productIds.map((productId) => (
             <RecentlyViewedCard key={productId} productId={productId} />

--- a/frontend/src/store/recentlyViewed.store.ts
+++ b/frontend/src/store/recentlyViewed.store.ts
@@ -6,6 +6,7 @@ export const MAX_RECENTLY_VIEWED = 12;
 interface RecentlyViewedState {
   productIds: string[];
   recordView: (productId: string) => void;
+  clearRecentlyViewed: () => void;
 }
 
 export const useRecentlyViewedStore = create<RecentlyViewedState>()(
@@ -18,6 +19,8 @@ export const useRecentlyViewedStore = create<RecentlyViewedState>()(
       recordView: (productId: string) => set((state) => ({
         productIds: [productId, ...state.productIds.filter((id) => id !== productId)].slice(0, MAX_RECENTLY_VIEWED),
       })),
+
+      clearRecentlyViewed: () => set({ productIds: [] }),
     }),
     {
       name: 'safetech-recently-viewed-storage',


### PR DESCRIPTION
## Resumen
- Nueva acción `clearRecentlyViewed` en el store de vistos recientemente (HU-48).
- Botón "Limpiar historial" en la sección "Vistos recientemente": vacía la lista (y el localStorage) al instante; al no quedar productos, la sección desaparece de inmediato y no reaparecen productos antiguos.

Closes #158

## Test plan
- [x] `npx tsc -b` sin errores
- [x] `bun test` (backend sin cambios en este PR, 194 tests siguen pasando)
- [ ] Verificación manual en navegador (pendiente de levantar servicios)