### PR TITLE
feat: mostrar los productos mas recientes del catalogo para HU-50

### DIFF
--- a/backend/src/controllers/product.controller.test.ts
+++ b/backend/src/controllers/product.controller.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
-import { deleteProduct, getProductsForComparison, getRelatedProducts } from './product.controller';
+import { deleteProduct, getProductsForComparison, getRecentProducts, getRelatedProducts } from './product.controller';
 import { Product } from '../models/Product';
 
 function createContext(id = 'prod_1') {
@@ -222,5 +222,52 @@ describe('getRelatedProducts controller', () => {
     await getRelatedProducts(harness.context as never);
 
     expect(limitSpy).toHaveBeenCalledWith(8);
+  });
+});
+
+function createSortLimitQuery(result: unknown) {
+  const limitSpy = mock(() => Promise.resolve(result));
+  const sortSpy = mock(() => ({ limit: limitSpy }));
+  return { sortSpy, limitSpy, query: { sort: sortSpy } };
+}
+
+describe('getRecentProducts controller', () => {
+  test('sorts by createdAt descending and applies the default limit', async () => {
+    const products = [{ _id: '1', createdAt: '2026-02-01' }, { _id: '2', createdAt: '2026-01-01' }];
+    const { sortSpy, limitSpy, query } = createSortLimitQuery(products);
+    Product.find = mock(() => query) as unknown as typeof Product.find;
+
+    const harness = createQueryContext({});
+
+    await getRecentProducts(harness.context as never);
+
+    expect(sortSpy).toHaveBeenCalledWith({ createdAt: -1 });
+    expect(limitSpy).toHaveBeenCalledWith(8);
+    expect(harness.statusCode).toBe(200);
+    expect(harness.payload).toEqual({ success: true, data: products });
+  });
+
+  test('honors a custom limit', async () => {
+    const { limitSpy, query } = createSortLimitQuery([]);
+    Product.find = mock(() => query) as unknown as typeof Product.find;
+
+    const harness = createQueryContext({ limit: 3 });
+
+    await getRecentProducts(harness.context as never);
+
+    expect(limitSpy).toHaveBeenCalledWith(3);
+  });
+
+  test('returns a 500 when the lookup fails', async () => {
+    Product.find = mock(() => {
+      throw new Error('db down');
+    }) as unknown as typeof Product.find;
+
+    const harness = createQueryContext({});
+
+    await getRecentProducts(harness.context as never);
+
+    expect(harness.statusCode).toBe(500);
+    expect(harness.payload).toEqual({ success: false, message: 'db down' });
   });
 });

--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -272,6 +272,21 @@ export const getBestSellingProducts = async (c: Context) => {
   }
 };
 
+const DEFAULT_RECENT_LIMIT = 8;
+
+export const getRecentProducts = async (c: Context) => {
+  try {
+    const { limit } = c.req.valid('query' as any) as { limit?: number };
+    const effectiveLimit = limit ?? DEFAULT_RECENT_LIMIT;
+
+    const products = await Product.find().sort({ createdAt: -1 }).limit(effectiveLimit);
+
+    return c.json({ success: true, data: products });
+  } catch (error: any) {
+    return c.json({ success: false, message: error.message }, 500);
+  }
+};
+
 export const deleteProduct = async (c: Context) => {
   try {
     const id = c.req.param('id');

--- a/backend/src/routes/product.routes.ts
+++ b/backend/src/routes/product.routes.ts
@@ -9,6 +9,7 @@ import {
   getProductInventoryMovements,
   getProducts,
   getProductsForComparison,
+  getRecentProducts,
   getRelatedProducts,
   updateProduct,
 } from '../controllers/product.controller';
@@ -19,6 +20,7 @@ import {
   compareQuerySchema,
   lowStockQuerySchema,
   productFilterSchema,
+  recentProductsQuerySchema,
   relatedProductsQuerySchema,
   updateProductSchema,
 } from '../validators/product.validator';
@@ -60,6 +62,17 @@ productRoutes.get(
     }
   }),
   getBestSellingProducts
+);
+
+// Productos mas recientes por fecha de registro (HU-50)
+productRoutes.get(
+  '/recent',
+  zValidator('query', recentProductsQuerySchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ success: false, errors: result.error.errors }, 400);
+    }
+  }),
+  getRecentProducts
 );
 
 // Productos a comparar lado a lado (HU-43). Registrada antes de '/:id' para

--- a/backend/src/validators/product.validator.test.ts
+++ b/backend/src/validators/product.validator.test.ts
@@ -5,6 +5,7 @@ import {
   createProductSchema,
   lowStockQuerySchema,
   productFilterSchema,
+  recentProductsQuerySchema,
   relatedProductsQuerySchema,
   updateProductSchema,
 } from './product.validator';
@@ -193,6 +194,26 @@ describe('relatedProductsQuerySchema', () => {
 
   test('rejects a limit above 12', () => {
     const result = relatedProductsQuerySchema.safeParse({ limit: '13' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('recentProductsQuerySchema', () => {
+  test('accepts a missing limit', () => {
+    const result = recentProductsQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test('coerces a valid limit from a string', () => {
+    const result = recentProductsQuerySchema.safeParse({ limit: '5' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(5);
+    }
+  });
+
+  test('rejects a limit above 12', () => {
+    const result = recentProductsQuerySchema.safeParse({ limit: '13' });
     expect(result.success).toBe(false);
   });
 });

--- a/backend/src/validators/product.validator.ts
+++ b/backend/src/validators/product.validator.ts
@@ -55,6 +55,11 @@ export const bestSellersQuerySchema = z.object({
   limit: z.coerce.number().int().min(1, 'limit debe ser al menos 1').max(12, 'limit no puede superar 12').optional(),
 });
 
+// HU-50: cantidad de productos mas recientes (por fecha de registro) a devolver.
+export const recentProductsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1, 'limit debe ser al menos 1').max(12, 'limit no puede superar 12').optional(),
+});
+
 // HU-44: cantidad de productos relacionados (misma categoria) a devolver.
 export const relatedProductsQuerySchema = z.object({
   limit: z.coerce.number().int().min(1, 'limit debe ser al menos 1').max(12, 'limit no puede superar 12').optional(),

--- a/frontend/src/components/RecentProductsSection.tsx
+++ b/frontend/src/components/RecentProductsSection.tsx
@@ -1,0 +1,71 @@
+import { Link } from 'react-router-dom';
+import { SkeletonCard } from './ui/Skeleton';
+import { useRecentProducts } from '../hooks/useRecentProducts';
+
+export const RecentProductsSection = () => {
+  const { data: products, isLoading, isError } = useRecentProducts(8);
+  const recent = products ?? [];
+
+  if (isError) return null;
+
+  return (
+    <section style={{ padding: '3rem 0 1.5rem', background: 'var(--white)' }}>
+      <div className="page-container">
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'end', gap: '1rem', marginBottom: '1.5rem', flexWrap: 'wrap' }}>
+          <div>
+            <p style={{ fontSize: '0.65rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '2.5px', color: 'var(--gray)', marginBottom: '0.75rem', fontFamily: 'var(--font-sans)' }}>
+              Recién llegados
+            </p>
+            <h2 style={{ fontSize: 'clamp(1.5rem, 3vw, 2.2rem)', fontWeight: 600, color: 'var(--ink)', lineHeight: 1.1, fontFamily: 'var(--font-display)' }}>
+              Novedades del catálogo
+            </h2>
+          </div>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '1rem' }}>
+          {isLoading
+            ? Array.from({ length: 4 }).map((_, i) => <SkeletonCard key={i} />)
+            : recent.length === 0
+              ? (
+                  <div style={{ gridColumn: '1 / -1', padding: '1rem 0', color: 'var(--ink2)', fontFamily: 'var(--font-sans)', fontSize: '0.9rem' }}>
+                    Todavía no hay productos registrados.
+                  </div>
+                )
+              : recent.map((product) => (
+                  <Link
+                    key={product._id}
+                    to={`/product/${product._id}`}
+                    style={{ display: 'block', color: 'inherit', textDecoration: 'none' }}
+                    aria-label={`Ver detalles de ${product.name}`}
+                  >
+                    <article
+                      style={{
+                        border: '1px solid var(--line)',
+                        borderRadius: 'var(--radius-md)',
+                        overflow: 'hidden',
+                        background: 'var(--white)',
+                      }}
+                    >
+                      <div style={{ aspectRatio: '4/3', background: 'var(--cream)', overflow: 'hidden' }}>
+                        <img
+                          src={product.image_urls?.[0] || `https://picsum.photos/seed/${product._id}/400/300`}
+                          alt={product.name}
+                          style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                        />
+                      </div>
+                      <div style={{ padding: '0.9rem 1rem' }}>
+                        <h3 style={{ fontSize: '0.9rem', fontWeight: 500, color: 'var(--ink)', marginBottom: '0.4rem', fontFamily: 'var(--font-display)', lineHeight: 1.3 }}>
+                          {product.name}
+                        </h3>
+                        <p style={{ fontSize: '1rem', fontWeight: 300, color: 'var(--ink)', fontFamily: 'var(--font-display)' }}>
+                          ${product.price.toFixed(2)}
+                        </p>
+                      </div>
+                    </article>
+                  </Link>
+                ))}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/frontend/src/hooks/useRecentProducts.ts
+++ b/frontend/src/hooks/useRecentProducts.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { productsService } from '../services/products.service';
+
+export const useRecentProducts = (limit = 8) => {
+  return useQuery({
+    queryKey: ['recent-products', limit],
+    queryFn: () => productsService.getRecent(limit),
+  });
+};

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import { ProductList } from '../components/ProductList';
 import { BestSellersSection } from '../components/BestSellersSection';
+import { RecentProductsSection } from '../components/RecentProductsSection';
 import { RecentlyViewedSection } from '../components/RecentlyViewedSection';
 
 export default function Home() {
@@ -41,6 +42,8 @@ export default function Home() {
       </section>
 
       <BestSellersSection />
+
+      <RecentProductsSection />
 
       <RecentlyViewedSection />
 

--- a/frontend/src/services/products.service.ts
+++ b/frontend/src/services/products.service.ts
@@ -174,6 +174,16 @@ export const productsService = {
     return result.data || [];
   },
 
+  async getRecent(limit = 8): Promise<Product[]> {
+    const response = await fetch(`${API_URL}/products/recent?limit=${limit}`);
+    if (!response.ok) {
+      const result = await response.json().catch(() => ({}));
+      throw new Error(result?.message || result?.errors?.[0]?.message || 'Failed to fetch recent products');
+    }
+    const result = await response.json();
+    return result.data || [];
+  },
+
   async create(data: CreateProductDTO, token: string): Promise<Product> {
     const response = await fetch(`${API_URL}/products`, {
       method: 'POST',


### PR DESCRIPTION
## Resumen
- Nuevo endpoint `GET /api/products/recent?limit=` que devuelve los productos ordenados por `createdAt` descendente (límite configurable, default 8, máx 12, validado con Zod).
- Sección "Novedades del catálogo" (`RecentProductsSection.tsx`) en `Home.tsx`, cada tarjeta navega al detalle del producto.
- Tests de controller y validator (`bun test`), `tsc -b` sin errores.

Closes #159

## Test plan
- [x] `bun test` (backend, 200 tests, todos pasan)
- [x] `npx tsc -b` sin errores
- [ ] Verificación manual en navegador (pendiente de levantar servicios)