### PR TITLE
feat: auditoria de acciones administrativas para HU-68

### DIFF
--- a/backend/src/controllers/audit.controller.test.ts
+++ b/backend/src/controllers/audit.controller.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { getAuditLogs } from './audit.controller';
+import { AuditLog } from '../models/AuditLog';
+
+function createContext() {
+  let statusCode = 200;
+  let payload: unknown;
+
+  const context = {
+    json: (value: unknown, status?: number) => {
+      payload = value;
+      statusCode = status ?? 200;
+      return { payload: value, status: statusCode };
+    },
+  };
+
+  return {
+    context,
+    get statusCode() {
+      return statusCode;
+    },
+    get payload() {
+      return payload;
+    },
+  };
+}
+
+function createSortLimitQuery(result: unknown) {
+  const limitSpy = mock(() => Promise.resolve(result));
+  const sortSpy = mock(() => ({ limit: limitSpy }));
+  return { sortSpy, limitSpy, query: { sort: sortSpy } };
+}
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe('getAuditLogs controller', () => {
+  test('returns logs sorted by most recent first, capped at 200', async () => {
+    const logs = [{ _id: 'log_2' }, { _id: 'log_1' }];
+    const { sortSpy, limitSpy, query } = createSortLimitQuery(logs);
+    AuditLog.find = mock(() => query) as unknown as typeof AuditLog.find;
+
+    const harness = createContext();
+
+    await getAuditLogs(harness.context as never);
+
+    expect(sortSpy).toHaveBeenCalledWith({ createdAt: -1 });
+    expect(limitSpy).toHaveBeenCalledWith(200);
+    expect(harness.statusCode).toBe(200);
+    expect(harness.payload).toEqual(logs);
+  });
+
+  test('returns a 500 when the lookup fails', async () => {
+    AuditLog.find = mock(() => {
+      throw new Error('db down');
+    }) as unknown as typeof AuditLog.find;
+
+    const harness = createContext();
+
+    await getAuditLogs(harness.context as never);
+
+    expect(harness.statusCode).toBe(500);
+    expect(harness.payload).toEqual({ error: 'db down' });
+  });
+});

--- a/backend/src/controllers/audit.controller.ts
+++ b/backend/src/controllers/audit.controller.ts
@@ -1,0 +1,13 @@
+import { Context } from 'hono';
+import { AuditLog } from '../models/AuditLog';
+
+const MAX_AUDIT_LOGS = 200;
+
+export const getAuditLogs = async (c: Context) => {
+  try {
+    const logs = await AuditLog.find().sort({ createdAt: -1 }).limit(MAX_AUDIT_LOGS);
+    return c.json(logs);
+  } catch (error: any) {
+    return c.json({ error: error.message }, 500);
+  }
+};

--- a/backend/src/controllers/order.controller.ts
+++ b/backend/src/controllers/order.controller.ts
@@ -6,6 +6,7 @@ import { User } from '../models/User';
 import { finalizePaidOrder, notifyPurchaseConfirmed } from '../services/order.service';
 import { isE2EPaymentIntent, isE2ETestMode } from '../lib/e2e';
 import { sendOrderStatusChangedEmail } from '../services/email.service';
+import { recordAuditLog } from '../services/audit.service';
 
 const getStripeClient = () => {
   const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
@@ -345,6 +346,14 @@ export const refundOrder = async (c: Context) => {
     if (owner?.email) {
       await sendOrderStatusChangedEmail(owner.email, order);
     }
+
+    await recordAuditLog({
+      userId: adminUserId ?? 'system',
+      action: 'order.refund',
+      resourceType: 'Order',
+      resourceId: id,
+      metadata: { refundId, refundedAmount: order.refunded_amount },
+    });
 
     return c.json(order);
   } catch (error: any) {

--- a/backend/src/controllers/product.controller.test.ts
+++ b/backend/src/controllers/product.controller.test.ts
@@ -1,8 +1,22 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
-import { deleteProduct, getProductsForComparison, getRecentProducts, getRelatedProducts } from './product.controller';
+import {
+  createProduct,
+  deleteProduct,
+  getProductsForComparison,
+  getRecentProducts,
+  getRelatedProducts,
+  updateProduct,
+} from './product.controller';
 import { Product } from '../models/Product';
+import { AuditLog } from '../models/AuditLog';
 
-function createContext(id = 'prod_1') {
+function mockAuditLog() {
+  const create = mock(() => Promise.resolve({ _id: 'log_1' }));
+  AuditLog.create = create as unknown as typeof AuditLog.create;
+  return create;
+}
+
+function createContext(id = 'prod_1', userId?: string) {
   let statusCode = 200;
   let payload: unknown;
 
@@ -10,6 +24,7 @@ function createContext(id = 'prod_1') {
     req: {
       param: () => id,
     },
+    get: (key: string) => (key === 'userId' ? userId : undefined),
     json: (value: unknown, status?: number) => {
       payload = value;
       statusCode = status ?? 200;
@@ -54,7 +69,7 @@ function createQueryContext(query: Record<string, unknown>) {
   };
 }
 
-function createParamAndQueryContext(id: string, query: Record<string, unknown>) {
+function createParamAndQueryContext(id: string, query: Record<string, unknown>, userId?: string) {
   let statusCode = 200;
   let payload: unknown;
 
@@ -63,6 +78,34 @@ function createParamAndQueryContext(id: string, query: Record<string, unknown>) 
       param: () => id,
       valid: (_key: string) => query,
     },
+    get: (key: string) => (key === 'userId' ? userId : undefined),
+    json: (value: unknown, status?: number) => {
+      payload = value;
+      statusCode = status ?? 200;
+      return { payload: value, status: statusCode };
+    },
+  };
+
+  return {
+    context,
+    get statusCode() {
+      return statusCode;
+    },
+    get payload() {
+      return payload;
+    },
+  };
+}
+
+function createJsonContext(json: Record<string, unknown>, userId?: string) {
+  let statusCode = 200;
+  let payload: unknown;
+
+  const context = {
+    req: {
+      valid: (_key: string) => json,
+    },
+    get: (key: string) => (key === 'userId' ? userId : undefined),
     json: (value: unknown, status?: number) => {
       payload = value;
       statusCode = status ?? 200;
@@ -86,7 +129,7 @@ afterEach(() => {
 });
 
 describe('deleteProduct controller', () => {
-  test('returns deleted product data when the product exists', async () => {
+  test('returns deleted product data and records an audit log when the product exists', async () => {
     const deletedProduct = {
       _id: 'prod_1',
       name: 'iPhone 13 Reacondicionado',
@@ -100,12 +143,19 @@ describe('deleteProduct controller', () => {
 
     const deleteById = mock(() => Promise.resolve(deletedProduct));
     Product.findByIdAndDelete = deleteById as typeof Product.findByIdAndDelete;
+    const auditCreate = mockAuditLog();
 
-    const harness = createContext('prod_1');
+    const harness = createContext('prod_1', 'admin_1');
 
     await deleteProduct(harness.context as never);
 
     expect(deleteById).toHaveBeenCalledWith('prod_1');
+    expect(auditCreate).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'admin_1',
+      action: 'product.delete',
+      resourceType: 'Product',
+      resourceId: 'prod_1',
+    }));
     expect(harness.statusCode).toBe(200);
     expect(harness.payload).toEqual({
       success: true,
@@ -269,5 +319,51 @@ describe('getRecentProducts controller', () => {
 
     expect(harness.statusCode).toBe(500);
     expect(harness.payload).toEqual({ success: false, message: 'db down' });
+  });
+});
+
+describe('createProduct controller', () => {
+  test('creates the product and records an audit log, skipping stock movement when stock is 0', async () => {
+    const created = { _id: 'prod_new', name: 'iPad Air', stock: 0 };
+    Product.create = mock(() => Promise.resolve(created)) as unknown as typeof Product.create;
+    const auditCreate = mockAuditLog();
+
+    const harness = createJsonContext({ name: 'iPad Air', stock: 0 }, 'admin_1');
+
+    await createProduct(harness.context as never);
+
+    expect(auditCreate).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'admin_1',
+      action: 'product.create',
+      resourceType: 'Product',
+      resourceId: 'prod_new',
+    }));
+    expect(harness.statusCode).toBe(201);
+    expect(harness.payload).toEqual({ success: true, data: created });
+  });
+});
+
+describe('updateProduct controller', () => {
+  test('updates the product and records an audit log', async () => {
+    const previousProduct = { _id: 'prod_1', price: 500, stock: 4 };
+    const updatedProduct = { _id: 'prod_1', name: 'Nuevo nombre', price: 500, stock: 4 };
+
+    Product.findById = mock(() => Promise.resolve(previousProduct)) as typeof Product.findById;
+    Product.findByIdAndUpdate = mock(() => Promise.resolve(updatedProduct)) as typeof Product.findByIdAndUpdate;
+    const auditCreate = mockAuditLog();
+
+    const harness = createParamAndQueryContext('prod_1', { name: 'Nuevo nombre' }, 'admin_1');
+
+    await updateProduct(harness.context as never);
+
+    expect(auditCreate).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'admin_1',
+      action: 'product.update',
+      resourceType: 'Product',
+      resourceId: 'prod_1',
+      metadata: { changes: { name: 'Nuevo nombre' } },
+    }));
+    expect(harness.statusCode).toBe(200);
+    expect(harness.payload).toEqual({ success: true, data: updatedProduct });
   });
 });

--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -5,6 +5,7 @@ import { Order } from '../models/Order';
 import { InventoryMovement } from '../models/InventoryMovement';
 import { recordInventoryMovement } from '../services/inventory.service';
 import { notifyPriceDrop } from '../services/priceAlert.service';
+import { recordAuditLog } from '../services/audit.service';
 
 export const getProducts = async (c: Context) => {
   try {
@@ -111,6 +112,14 @@ export const createProduct = async (c: Context) => {
       });
     }
 
+    await recordAuditLog({
+      userId: userId ?? 'system',
+      action: 'product.create',
+      resourceType: 'Product',
+      resourceId: String(newProduct._id),
+      metadata: { name: (data as { name?: string }).name },
+    });
+
     return c.json({ success: true, data: newProduct }, 201);
   } catch (error: any) {
     return c.json({ success: false, message: error.message }, 500);
@@ -154,6 +163,14 @@ export const updateProduct = async (c: Context) => {
     if (data.price !== undefined && data.price < previousProduct.price) {
       await notifyPriceDrop(updatedProduct._id, updatedProduct.name, updatedProduct.price);
     }
+
+    await recordAuditLog({
+      userId: userId ?? 'system',
+      action: 'product.update',
+      resourceType: 'Product',
+      resourceId: String(updatedProduct._id),
+      metadata: { changes: updateData },
+    });
 
     return c.json({ success: true, data: updatedProduct });
   } catch (error: any) {
@@ -290,12 +307,21 @@ export const getRecentProducts = async (c: Context) => {
 export const deleteProduct = async (c: Context) => {
   try {
     const id = c.req.param('id');
+    const userId = c.get('userId');
     const deletedProduct = await Product.findByIdAndDelete(id);
-    
+
     if (!deletedProduct) {
       return c.json({ success: false, message: 'Producto no encontrado' }, 404);
     }
-    
+
+    await recordAuditLog({
+      userId: userId ?? 'system',
+      action: 'product.delete',
+      resourceType: 'Product',
+      resourceId: id,
+      metadata: { name: (deletedProduct as { name?: string }).name },
+    });
+
     return c.json({
       success: true,
       message: 'Producto eliminado correctamente',

--- a/backend/src/controllers/warranty.controller.test.ts
+++ b/backend/src/controllers/warranty.controller.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
-import { assignTechnician } from './warranty.controller';
+import { assignTechnician, updateWarrantyStatus } from './warranty.controller';
 import { Technician } from '../models/Technician';
 import { WarrantyReport } from '../models/WarrantyReport';
+import { AuditLog } from '../models/AuditLog';
 
-function createContext(body: Record<string, unknown>, id = 'wr_1') {
+function createContext(body: Record<string, unknown>, id = 'wr_1', userId?: string) {
   let statusCode = 200;
   let payload: unknown;
 
@@ -12,6 +13,7 @@ function createContext(body: Record<string, unknown>, id = 'wr_1') {
       param: () => ({ id }),
       json: async () => body,
     },
+    get: (key: string) => (key === 'userId' ? userId : undefined),
     json: (value: unknown, status?: number) => {
       payload = value;
       statusCode = status ?? 200;
@@ -88,5 +90,46 @@ describe('assignTechnician controller', () => {
 
     expect(harness.statusCode).toBe(409);
     expect(harness.payload).toEqual({ error: 'Technician is inactive' });
+  });
+});
+
+describe('updateWarrantyStatus controller', () => {
+  test('records an audit log for the admin performing the update', async () => {
+    const report = {
+      _id: 'wr_1',
+      userId: 'user_1',
+      status: 'review',
+      resolvedAt: undefined as Date | undefined,
+      repairNotes: undefined as string | undefined,
+      save: mock(() => Promise.resolve()),
+    };
+    WarrantyReport.findById = mock(() => Promise.resolve(report)) as typeof WarrantyReport.findById;
+    const auditCreate = mock(() => Promise.resolve({ _id: 'log_1' }));
+    AuditLog.create = auditCreate as unknown as typeof AuditLog.create;
+
+    // Mismo status que el actual: evita el envio de email (rama no cubierta
+    // aqui) mientras se verifica que la auditoria se registra igual.
+    const harness = createContext({ status: 'review' }, 'wr_1', 'admin_1');
+
+    await updateWarrantyStatus(harness.context as never);
+
+    expect(report.save).toHaveBeenCalled();
+    expect(auditCreate).toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'admin_1',
+      action: 'warranty.status_change',
+      resourceType: 'WarrantyReport',
+      resourceId: 'wr_1',
+    }));
+    expect(harness.statusCode).toBe(200);
+  });
+
+  test('returns 404 when the report does not exist', async () => {
+    WarrantyReport.findById = mock(() => Promise.resolve(null)) as typeof WarrantyReport.findById;
+
+    const harness = createContext({ status: 'resolved' }, 'missing');
+
+    await updateWarrantyStatus(harness.context as never);
+
+    expect(harness.statusCode).toBe(404);
   });
 });

--- a/backend/src/controllers/warranty.controller.ts
+++ b/backend/src/controllers/warranty.controller.ts
@@ -4,6 +4,7 @@ import { Order } from '../models/Order';
 import { User } from '../models/User';
 import { Technician } from '../models/Technician';
 import { sendWarrantyCreatedEmail, sendWarrantyStatusChangedEmail } from '../services/email.service';
+import { recordAuditLog } from '../services/audit.service';
 
 export const createWarrantyReport = async (c: Context) => {
   try {
@@ -98,6 +99,7 @@ export const updateWarrantyStatus = async (c: Context) => {
   try {
     const { id } = c.req.param();
     const body = await c.req.json();
+    const adminUserId = c.get('userId');
 
     const report = await WarrantyReport.findById(id);
 
@@ -127,6 +129,14 @@ export const updateWarrantyStatus = async (c: Context) => {
         await sendWarrantyStatusChangedEmail(owner.email, report);
       }
     }
+
+    await recordAuditLog({
+      userId: adminUserId ?? 'system',
+      action: 'warranty.status_change',
+      resourceType: 'WarrantyReport',
+      resourceId: id,
+      metadata: { status: report.status, repairNotes: body.repairNotes },
+    });
 
     return c.json(report);
   } catch (error: any) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -22,6 +22,7 @@ import e2eRoutes from './routes/e2e.routes';
 import reportRoutes from './routes/report.routes';
 import supportRoutes from './routes/support.routes';
 import couponRoutes from './routes/coupon.routes';
+import auditRoutes from './routes/audit.routes';
 import { isE2ETestMode } from './lib/e2e';
 
 const app = new Hono();
@@ -59,6 +60,7 @@ app.route('/api/price-alerts', priceAlertRoutes);
 app.route('/api/reports', reportRoutes);
 app.route('/api/support-tickets', supportRoutes);
 app.route('/api/coupons', couponRoutes);
+app.route('/api/audit-logs', auditRoutes);
 if (isE2ETestMode) {
   app.route('/api/e2e', e2eRoutes);
 }

--- a/backend/src/models/AuditLog.ts
+++ b/backend/src/models/AuditLog.ts
@@ -1,0 +1,16 @@
+import { Schema, model } from 'mongoose';
+
+const auditLogSchema = new Schema(
+  {
+    userId: { type: String, required: true },
+    action: { type: String, required: true },
+    resourceType: { type: String, required: true },
+    resourceId: { type: String, required: true },
+    metadata: { type: Schema.Types.Mixed },
+  },
+  // Un log de auditoria es un hecho puntual; solo interesa cuando ocurrio,
+  // no una fecha de "actualizacion" (los registros nunca se editan).
+  { timestamps: { createdAt: true, updatedAt: false } }
+);
+
+export const AuditLog = model('AuditLog', auditLogSchema);

--- a/backend/src/routes/audit.routes.ts
+++ b/backend/src/routes/audit.routes.ts
@@ -1,0 +1,9 @@
+import { Hono } from 'hono';
+import { getAuditLogs } from '../controllers/audit.controller';
+import { adminAuthMiddleware } from '../middlewares/auth.middleware';
+
+const auditRoutes = new Hono();
+
+auditRoutes.get('/', adminAuthMiddleware, getAuditLogs);
+
+export default auditRoutes;

--- a/backend/src/services/audit.service.test.ts
+++ b/backend/src/services/audit.service.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { recordAuditLog } from './audit.service';
+import { AuditLog } from '../models/AuditLog';
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe('recordAuditLog', () => {
+  test('creates an audit log entry with the given fields', async () => {
+    const created = { _id: 'log_1' };
+    const create = mock(() => Promise.resolve(created));
+    AuditLog.create = create as unknown as typeof AuditLog.create;
+
+    const result = await recordAuditLog({
+      userId: 'admin_1',
+      action: 'product.create',
+      resourceType: 'Product',
+      resourceId: 'prod_1',
+      metadata: { name: 'iPhone 13' },
+    });
+
+    expect(create).toHaveBeenCalledWith({
+      userId: 'admin_1',
+      action: 'product.create',
+      resourceType: 'Product',
+      resourceId: 'prod_1',
+      metadata: { name: 'iPhone 13' },
+    });
+    expect(result).toBe(created);
+  });
+
+  test('allows omitting metadata', async () => {
+    const create = mock(() => Promise.resolve({ _id: 'log_2' }));
+    AuditLog.create = create as unknown as typeof AuditLog.create;
+
+    await recordAuditLog({
+      userId: 'admin_1',
+      action: 'order.refund',
+      resourceType: 'Order',
+      resourceId: 'order_1',
+    });
+
+    expect(create).toHaveBeenCalledWith({
+      userId: 'admin_1',
+      action: 'order.refund',
+      resourceType: 'Order',
+      resourceId: 'order_1',
+      metadata: undefined,
+    });
+  });
+});

--- a/backend/src/services/audit.service.ts
+++ b/backend/src/services/audit.service.ts
@@ -1,0 +1,15 @@
+import { AuditLog } from '../models/AuditLog';
+
+export interface RecordAuditLogParams {
+  userId: string;
+  action: string;
+  resourceType: string;
+  resourceId: string;
+  metadata?: Record<string, unknown>;
+}
+
+export async function recordAuditLog(params: RecordAuditLogParams) {
+  const { userId, action, resourceType, resourceId, metadata } = params;
+
+  return AuditLog.create({ userId, action, resourceType, resourceId, metadata });
+}

--- a/frontend/src/components/AdminSidebar.tsx
+++ b/frontend/src/components/AdminSidebar.tsx
@@ -42,6 +42,11 @@ const SupportIcon = () => (
     <path strokeLinecap="round" strokeLinejoin="round" d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm7.5 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z" />
   </svg>
 );
+const AuditIcon = () => (
+  <svg fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75M3.75 21h9.9a2.25 2.25 0 002.25-2.25V12.75a2.25 2.25 0 00-2.25-2.25H3.75A2.25 2.25 0 001.5 12.75v6a2.25 2.25 0 002.25 2.25zM3.75 10.5V4.5A2.25 2.25 0 016 2.25h6.879a1.125 1.125 0 01.795.33l3.546 3.546a1.125 1.125 0 01.33.795V10.5" />
+  </svg>
+);
 const BackIcon = () => (
   <svg fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor">
     <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
@@ -64,6 +69,12 @@ const navSections = [
       { id: 'technicians',  label: 'Técnicos',   icon: <TechnicianIcon /> },
       { id: 'coupons',      label: 'Cupones',    icon: <CouponIcon /> },
       { id: 'support',      label: 'Soporte',    icon: <SupportIcon /> },
+    ],
+  },
+  {
+    label: 'Seguridad',
+    items: [
+      { id: 'audit',        label: 'Auditoría',  icon: <AuditIcon /> },
     ],
   },
 ];

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -6,11 +6,13 @@ import { ordersService } from '../services/orders.service';
 import { technicianService } from '../services/technician.service';
 import { couponService } from '../services/coupon.service';
 import { supportTicketService } from '../services/supportTicket.service';
+import { auditLogService } from '../services/auditLog.service';
 import type { IWarranty } from '../types/warranty';
 import type { Order } from '../types/order';
 import type { Technician } from '../types/technician';
 import type { Coupon } from '../types/coupon';
 import type { SupportTicket } from '../types/supportTicket';
+import type { AuditLog } from '../types/auditLog';
 import { useState } from 'react';
 import AdminSidebar from '../components/AdminSidebar';
 import StatsCards from '../components/StatsCards';
@@ -19,7 +21,7 @@ import ProductTable from '../components/ProductTable';
 import { Badge } from '../components/ui/Badge';
 import { SkeletonTableRow } from '../components/ui/Skeleton';
 
-type SectionType = 'dashboard' | 'orders' | 'warranties' | 'products' | 'technicians' | 'coupons' | 'support';
+type SectionType = 'dashboard' | 'orders' | 'warranties' | 'products' | 'technicians' | 'coupons' | 'support' | 'audit';
 
 const PAGE_SIZE = 10;
 
@@ -354,6 +356,7 @@ export default function AdminDashboard() {
   const [techniciansPage, setTechniciansPage] = useState(1);
   const [couponsPage, setCouponsPage] = useState(1);
   const [supportPage, setSupportPage] = useState(1);
+  const [auditPage, setAuditPage] = useState(1);
   const queryClient = useQueryClient();
 
   const { data: orders, isLoading: ordersLoading } = useQuery<Order[]>({
@@ -468,6 +471,16 @@ export default function AdminDashboard() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['admin-support-tickets'] }),
   });
 
+  const { data: auditLogs, isLoading: auditLogsLoading } = useQuery<AuditLog[]>({
+    queryKey: ['admin-audit-logs'],
+    queryFn: async () => {
+      const token = await getToken();
+      if (!token) throw new Error('No token');
+      return auditLogService.getAll(token);
+    },
+    enabled: isLoaded,
+  });
+
   const updateShippingMutation = useMutation({
     mutationFn: async ({ orderId, data }: { orderId: string; data: { status?: 'processing' | 'shipped' | 'delivered'; carrier?: string; trackingNumber?: string } }) => {
       const token = await getToken();
@@ -496,6 +509,7 @@ export default function AdminDashboard() {
     setTechniciansPage(1);
     setCouponsPage(1);
     setSupportPage(1);
+    setAuditPage(1);
     setSidebarOpen(false);
   };
 
@@ -504,6 +518,7 @@ export default function AdminDashboard() {
   const pagedTechnicians    = (technicians    ?? []).slice((techniciansPage - 1)    * PAGE_SIZE, techniciansPage    * PAGE_SIZE);
   const pagedCoupons        = (coupons        ?? []).slice((couponsPage - 1)        * PAGE_SIZE, couponsPage        * PAGE_SIZE);
   const pagedSupportTickets = (supportTickets ?? []).slice((supportPage - 1)        * PAGE_SIZE, supportPage        * PAGE_SIZE);
+  const pagedAuditLogs      = (auditLogs      ?? []).slice((auditPage - 1)          * PAGE_SIZE, auditPage          * PAGE_SIZE);
 
   return (
     <div style={{ display: 'flex', minHeight: '100vh', background: 'var(--cream)' }}>
@@ -1020,6 +1035,54 @@ export default function AdminDashboard() {
                   </tbody>
                 </table>
                 <Pagination total={supportTickets?.length ?? 0} page={supportPage} onPage={setSupportPage} />
+              </div>
+            </div>
+          )}
+
+          {/* ══ AUDITORÍA ══ */}
+          {activeSection === 'audit' && (
+            <div style={{ animation: 'fadeIn 0.3s ease both' }}>
+              <SectionHeader title="Auditoría de acciones administrativas" count={auditLogs?.length} />
+              <div className="admin-table-wrapper">
+                <table className="admin-table">
+                  <thead>
+                    <tr>
+                      <th>Fecha</th>
+                      <th>Usuario</th>
+                      <th>Acción</th>
+                      <th>Recurso</th>
+                      <th>Detalle</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {auditLogsLoading
+                      ? Array.from({ length: 6 }).map((_, i) => <SkeletonTableRow key={i} cols={5} />)
+                      : pagedAuditLogs.length === 0
+                        ? (
+                          <tr>
+                            <td colSpan={5} style={{ padding: '3rem', textAlign: 'center', color: 'var(--ink3)', fontSize: '0.9rem' }}>
+                              No hay acciones auditadas todavía.
+                            </td>
+                          </tr>
+                        )
+                        : pagedAuditLogs.map((log) => (
+                          <tr key={log._id}>
+                            <td style={{ fontWeight: 500 }}>{formatDate(log.createdAt)}</td>
+                            <td style={{ color: 'var(--ink2)', fontSize: '0.85rem' }}>{log.userId}</td>
+                            <td style={{ color: 'var(--ink2)', fontSize: '0.85rem' }}>{log.action}</td>
+                            <td style={{ color: 'var(--ink2)', fontSize: '0.85rem' }}>{log.resourceType} · {log.resourceId}</td>
+                            <td
+                              style={{ maxWidth: 260, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--ink3)', fontSize: '0.8rem' }}
+                              title={log.metadata ? JSON.stringify(log.metadata) : undefined}
+                            >
+                              {log.metadata ? JSON.stringify(log.metadata) : '—'}
+                            </td>
+                          </tr>
+                        ))
+                    }
+                  </tbody>
+                </table>
+                <Pagination total={auditLogs?.length ?? 0} page={auditPage} onPage={setAuditPage} />
               </div>
             </div>
           )}

--- a/frontend/src/services/auditLog.service.ts
+++ b/frontend/src/services/auditLog.service.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+import type { AuditLog } from '../types/auditLog';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api';
+
+export const auditLogService = {
+  getAll: async (token: string): Promise<AuditLog[]> => {
+    const response = await axios.get(`${API_URL}/audit-logs`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.data;
+  },
+};

--- a/frontend/src/types/auditLog.ts
+++ b/frontend/src/types/auditLog.ts
@@ -1,0 +1,9 @@
+export interface AuditLog {
+  _id: string;
+  userId: string;
+  action: string;
+  resourceType: string;
+  resourceId: string;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+}


### PR DESCRIPTION
## Resumen
- Nuevo modelo `AuditLog` (userId, action, resourceType, resourceId, metadata, fecha) y servicio `recordAuditLog` reutilizable.
- `GET /api/audit-logs` (solo administradores, `adminAuthMiddleware`): últimos 200 registros, ordenados por fecha descendente.
- Se audita en las acciones administrativas sensibles pedidas explícitamente por la HU:
  - **Crear producto** → `product.create`
  - **Reembolsar** una orden → `order.refund`
  - **Cambiar estados**: actualizar producto (`product.update`), eliminar producto (`product.delete`), cambiar estado de una garantía (`warranty.status_change`)
- Frontend: nueva sección "Auditoría" en el panel de admin (`AdminDashboard.tsx` + `AdminSidebar.tsx`), con tabla paginada (fecha, usuario, acción, recurso, detalle) — solo accesible para administradores autorizados vía `ProtectedAdminRoute`.
- Tests de service/controller para el módulo de auditoría, y tests actualizados/nuevos en `product.controller.test.ts` y `warranty.controller.test.ts` verificando que cada acción registra su log correspondiente.

Closes #177

## Test plan
- [x] `bun test` (backend, 208 tests, todos pasan)
- [x] `npx tsc -b` sin errores
- [ ] Verificación manual en navegador (pendiente de levantar servicios)